### PR TITLE
introspection: Add function to execute introspection query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .*.swp
 .*.swo
 experimental/
+*~

--- a/example/main.go
+++ b/example/main.go
@@ -1,4 +1,4 @@
-package main
+package example
 
 import (
 	"context"
@@ -105,14 +105,18 @@ func (s *Server) registerMutation(schema *schemabuilder.Schema) {
 	})
 }
 
-func (s *Server) Schema() *graphql.Schema {
+func (s *Server) SchemaBuilderSchema() *schemabuilder.Schema {
 	schema := schemabuilder.NewSchema()
 
 	s.registerQuery(schema)
 	s.registerMutation(schema)
 	s.registerMessage(schema)
 
-	return schema.MustBuild()
+	return schema
+}
+
+func (s *Server) Schema() *graphql.Schema {
+	return s.SchemaBuilderSchema().MustBuild()
 }
 
 func main() {

--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -273,7 +273,7 @@ func (s *introspection) registerMutation(schema *schemabuilder.Schema) {
 	schema.Mutation()
 }
 
-func (s *introspection) Schema() *graphql.Schema {
+func (s *introspection) schema() *graphql.Schema {
 	schema := schemabuilder.NewSchema()
 
 	s.registerDirective(schema)
@@ -298,7 +298,7 @@ func AddIntrospectionToSchema(schema *graphql.Schema) {
 		query:    schema.Query,
 		mutation: schema.Mutation,
 	}
-	isSchema := is.Schema()
+	isSchema := is.schema()
 
 	query := schema.Query.(*graphql.Object)
 

--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -1,6 +1,9 @@
 package introspection
 
 import (
+	"strings"
+
+	"github.com/bradfitz/slice"
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/graphql/schemabuilder"
 )
@@ -140,6 +143,7 @@ func (s *introspection) registerType(schema *schemabuilder.Schema) {
 			}
 		}
 
+		slice.Sort(fields, func(i, j int) bool { return strings.Compare(fields[i].Name, fields[j].Name) < 0 })
 		return fields
 	})
 
@@ -158,6 +162,7 @@ func (s *introspection) registerType(schema *schemabuilder.Schema) {
 						Type: Type{Inner: a},
 					})
 				}
+				slice.Sort(args, func(i, j int) bool { return strings.Compare(args[i].Name, args[j].Name) < 0 })
 
 				fields = append(fields, field{
 					Name: name,
@@ -166,6 +171,7 @@ func (s *introspection) registerType(schema *schemabuilder.Schema) {
 				})
 			}
 		}
+		slice.Sort(fields, func(i, j int) bool { return strings.Compare(fields[i].Name, fields[j].Name) < 0 })
 
 		return fields
 	})
@@ -243,6 +249,7 @@ func (s *introspection) registerQuery(schema *schemabuilder.Schema) {
 		for _, typ := range s.types {
 			types = append(types, Type{Inner: typ})
 		}
+		slice.Sort(types, func(i, j int) bool { return strings.Compare(types[i].Inner.String(), types[j].Inner.String()) < 0 })
 
 		return &Schema{
 			Types:        types,

--- a/graphql/introspection/introspection.graphql
+++ b/graphql/introspection/introspection.graphql
@@ -1,0 +1,89 @@
+# Copied from https://github.com/graphql/graphiql/blob/master/src/utility/introspectionQueries.js
+
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+fragment InputValue on __InputValue {
+  name
+  description
+  type { ...TypeRef }
+  defaultValue
+}
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/graphql/introspection/introspection_test.go
+++ b/graphql/introspection/introspection_test.go
@@ -1,0 +1,34 @@
+package introspection_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	"github.com/samsarahq/thunder/example"
+	"github.com/samsarahq/thunder/graphql/introspection"
+)
+
+func TestComputeSchemaJSON(t *testing.T) {
+	server := example.Server{}
+	schemaBuilderSchema := server.SchemaBuilderSchema()
+
+	actualBytes, err := introspection.ComputeSchemaJSON(*schemaBuilderSchema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var actual map[string]interface{}
+	json.Unmarshal(actualBytes, &actual)
+
+	expectedBytes, err := ioutil.ReadFile("test-schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var expected map[string]interface{}
+	json.Unmarshal(expectedBytes, &expected)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("schema JSONs do not match:\n---expected---\n%+v\n---actual---\n%+v", expected, actual)
+	}
+}

--- a/graphql/introspection/test-schema.json
+++ b/graphql/introspection/test-schema.json
@@ -1,0 +1,256 @@
+{
+  "__schema": {
+    "directives": [],
+    "mutationType": {
+      "name": "Mutation"
+    },
+    "queryType": {
+      "name": "Query"
+    },
+    "types": [
+      {
+        "description": "A single message.",
+        "enumValues": [],
+        "fields": [
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "id",
+            "type": {
+              "kind": "SCALAR",
+              "name": "int64",
+              "ofType": null
+            }
+          },
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "reactions",
+            "type": {
+              "kind": "LIST",
+              "name": "",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Reaction",
+                "ofType": null
+              }
+            }
+          },
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "text",
+            "type": {
+              "kind": "SCALAR",
+              "name": "string",
+              "ofType": null
+            }
+          }
+        ],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "OBJECT",
+        "name": "Message",
+        "possibleTypes": []
+      },
+      {
+        "description": "",
+        "enumValues": [],
+        "fields": [
+          {
+            "args": [
+              {
+                "defaultValue": "",
+                "description": "",
+                "name": "text",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "string",
+                  "ofType": null
+                }
+              }
+            ],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "addMessage",
+            "type": {
+              "kind": "SCALAR",
+              "name": "bool",
+              "ofType": null
+            }
+          },
+          {
+            "args": [
+              {
+                "defaultValue": "",
+                "description": "",
+                "name": "messageId",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "int64",
+                  "ofType": null
+                }
+              },
+              {
+                "defaultValue": "",
+                "description": "",
+                "name": "reaction",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "string",
+                  "ofType": null
+                }
+              }
+            ],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "addReaction",
+            "type": {
+              "kind": "SCALAR",
+              "name": "bool",
+              "ofType": null
+            }
+          },
+          {
+            "args": [
+              {
+                "defaultValue": "",
+                "description": "",
+                "name": "id",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "int64",
+                  "ofType": null
+                }
+              }
+            ],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "deleteMessage",
+            "type": {
+              "kind": "SCALAR",
+              "name": "bool",
+              "ofType": null
+            }
+          }
+        ],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "OBJECT",
+        "name": "Mutation",
+        "possibleTypes": []
+      },
+      {
+        "description": "",
+        "enumValues": [],
+        "fields": [
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "messages",
+            "type": {
+              "kind": "LIST",
+              "name": "",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Message",
+                "ofType": null
+              }
+            }
+          }
+        ],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "OBJECT",
+        "name": "Query",
+        "possibleTypes": []
+      },
+      {
+        "description": "",
+        "enumValues": [],
+        "fields": [
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "count",
+            "type": {
+              "kind": "SCALAR",
+              "name": "int",
+              "ofType": null
+            }
+          },
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "reaction",
+            "type": {
+              "kind": "SCALAR",
+              "name": "string",
+              "ofType": null
+            }
+          }
+        ],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "OBJECT",
+        "name": "Reaction",
+        "possibleTypes": []
+      },
+      {
+        "description": "",
+        "enumValues": [],
+        "fields": [],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "SCALAR",
+        "name": "bool",
+        "possibleTypes": []
+      },
+      {
+        "description": "",
+        "enumValues": [],
+        "fields": [],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "SCALAR",
+        "name": "int",
+        "possibleTypes": []
+      },
+      {
+        "description": "",
+        "enumValues": [],
+        "fields": [],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "SCALAR",
+        "name": "int64",
+        "possibleTypes": []
+      },
+      {
+        "description": "",
+        "enumValues": [],
+        "fields": [],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "SCALAR",
+        "name": "string",
+        "possibleTypes": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
One can generate a schema JSON object that can be used for generating
type information for a GraphQL client
(e.g. https://github.com/apollographql/apollo-codegen).