### PR TITLE
schemabuilder/reflect: Support GraphQL default scalar types

### DIFF
--- a/graphql/introspection/test-schema.json
+++ b/graphql/introspection/test-schema.json
@@ -9,6 +9,26 @@
     },
     "types": [
       {
+        "description": "",
+        "enumValues": [],
+        "fields": [],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "SCALAR",
+        "name": "Boolean",
+        "possibleTypes": []
+      },
+      {
+        "description": "",
+        "enumValues": [],
+        "fields": [],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "SCALAR",
+        "name": "Int",
+        "possibleTypes": []
+      },
+      {
         "description": "A single message.",
         "enumValues": [],
         "fields": [
@@ -48,7 +68,7 @@
             "name": "text",
             "type": {
               "kind": "SCALAR",
-              "name": "string",
+              "name": "String",
               "ofType": null
             }
           }
@@ -71,7 +91,7 @@
                 "name": "text",
                 "type": {
                   "kind": "SCALAR",
-                  "name": "string",
+                  "name": "String",
                   "ofType": null
                 }
               }
@@ -82,7 +102,7 @@
             "name": "addMessage",
             "type": {
               "kind": "SCALAR",
-              "name": "bool",
+              "name": "Boolean",
               "ofType": null
             }
           },
@@ -104,7 +124,7 @@
                 "name": "reaction",
                 "type": {
                   "kind": "SCALAR",
-                  "name": "string",
+                  "name": "String",
                   "ofType": null
                 }
               }
@@ -115,7 +135,7 @@
             "name": "addReaction",
             "type": {
               "kind": "SCALAR",
-              "name": "bool",
+              "name": "Boolean",
               "ofType": null
             }
           },
@@ -138,7 +158,7 @@
             "name": "deleteMessage",
             "type": {
               "kind": "SCALAR",
-              "name": "bool",
+              "name": "Boolean",
               "ofType": null
             }
           }
@@ -188,7 +208,7 @@
             "name": "count",
             "type": {
               "kind": "SCALAR",
-              "name": "int",
+              "name": "Int",
               "ofType": null
             }
           },
@@ -200,7 +220,7 @@
             "name": "reaction",
             "type": {
               "kind": "SCALAR",
-              "name": "string",
+              "name": "String",
               "ofType": null
             }
           }
@@ -218,17 +238,7 @@
         "inputFields": [],
         "interfaces": [],
         "kind": "SCALAR",
-        "name": "bool",
-        "possibleTypes": []
-      },
-      {
-        "description": "",
-        "enumValues": [],
-        "fields": [],
-        "inputFields": [],
-        "interfaces": [],
-        "kind": "SCALAR",
-        "name": "int",
+        "name": "String",
         "possibleTypes": []
       },
       {
@@ -239,16 +249,6 @@
         "interfaces": [],
         "kind": "SCALAR",
         "name": "int64",
-        "possibleTypes": []
-      },
-      {
-        "description": "",
-        "enumValues": [],
-        "fields": [],
-        "inputFields": [],
-        "interfaces": [],
-        "kind": "SCALAR",
-        "name": "string",
         "possibleTypes": []
       }
     ]

--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -612,8 +612,8 @@ func (sb *schemaBuilder) buildStruct(typ reflect.Type) error {
 }
 
 var scalars = map[reflect.Type]string{
-	reflect.TypeOf(bool(false)): "bool",
-	reflect.TypeOf(int(0)):      "int",
+	reflect.TypeOf(bool(false)): "Boolean",
+	reflect.TypeOf(int(0)):      "Int",
 	reflect.TypeOf(int8(0)):     "int8",
 	reflect.TypeOf(int16(0)):    "int16",
 	reflect.TypeOf(int32(0)):    "int32",
@@ -624,8 +624,8 @@ var scalars = map[reflect.Type]string{
 	reflect.TypeOf(uint32(0)):   "uint32",
 	reflect.TypeOf(uint64(0)):   "uint64",
 	reflect.TypeOf(float32(0)):  "float32",
-	reflect.TypeOf(float64(0)):  "float64",
-	reflect.TypeOf(string("")):  "string",
+	reflect.TypeOf(float64(0)):  "Float",
+	reflect.TypeOf(string("")):  "String",
 	reflect.TypeOf(time.Time{}): "Time",
 	reflect.TypeOf([]byte{}):    "bytes",
 }


### PR DESCRIPTION
Add support for "Int", "Float", "String", and "Boolean" GraphQL scalar
types as defined in: http://graphql.org/learn/schema/#scalar-types