### PR TITLE
graphql: support arrays in parser

### DIFF
--- a/graphql/parser.go
+++ b/graphql/parser.go
@@ -53,6 +53,16 @@ func valueToJson(value ast.Value, vars map[string]interface{}) (interface{}, err
 			obj[name] = value
 		}
 		return obj, nil
+	case *ast.ListValue:
+		list := make([]interface{}, 0, len(value.Values))
+		for _, item := range value.Values {
+			value, err := valueToJson(item, vars)
+			if err != nil {
+				return nil, err
+			}
+			list = append(list, value)
+		}
+		return list, nil
 	default:
 		return nil, NewSafeError("unsupported value type: %s", value.GetKind())
 	}

--- a/graphql/parser_test.go
+++ b/graphql/parser_test.go
@@ -15,7 +15,7 @@ func TestParseSupported(t *testing.T) {
 		alias: bar
 		baz(arg: 3) {
 			bah(x: 1, y: "123", z: true)
-			hum(foo: {x: $var})
+			hum(foo: {x: $var}, bug: [1, 2, [4, 5]])
 		}
 		... on Foo {
 			asd
@@ -77,6 +77,10 @@ fragment Bar on Foo {
 										Args: map[string]interface{}{
 											"foo": map[string]interface{}{
 												"x": "var value!!",
+											},
+											"bug": []interface{}{
+												float64(1), float64(2),
+												[]interface{}{float64(4), float64(5)},
 											},
 										},
 									},


### PR DESCRIPTION
Arrays were supported in JSON, but not if specified manually in the
query. Fix that.