### PR TITLE
graphql: support NonNull in input types

### DIFF
--- a/graphql/introspection/test-schema.json
+++ b/graphql/introspection/test-schema.json
@@ -119,9 +119,13 @@
                 "description": "",
                 "name": "other",
                 "type": {
-                  "kind": "SCALAR",
-                  "name": "string",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
                 }
               }
             ],
@@ -194,9 +198,13 @@
             "description": "",
             "name": "name",
             "type": {
-              "kind": "SCALAR",
-              "name": "string",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": "",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "string",
+                "ofType": null
+              }
             }
           }
         ],


### PR DESCRIPTION
Pointers are nullable, non pointer types are not.

With this commit input and output types still have slightly different
nullability rules (around slices and slice elements), but this commit
brings them closer together.