### PR TITLE
reactive/diff: use standard JSON objects, add documentation

### DIFF
--- a/graphql/executor_test.go
+++ b/graphql/executor_test.go
@@ -111,15 +111,17 @@ func TestBasic(t *testing.T) {
 			"static": "static",
 			"a": {
 				"value": 0,
+				"__key": 0,
 				"nested": {
-					"value": 1
+					"value": 1,
+					"__key": 1
 				}
 			},
 			"as": [
-				{"value": 0},
-				{"value": 1},
-				{"value": 2},
-				{"value": 3}
+				{"value": 0, "__key": 0},
+				{"value": 1, "__key": 1},
+				{"value": 2, "__key": 2},
+				{"value": 3, "__key": 3}
 			]
 		}`)) {
 		t.Error("bad value", spew.Sdump(internal.AsJSON(result)))

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/internal"
-	"github.com/samsarahq/thunder/reactive/diff"
 )
 
 type alias int64
@@ -143,8 +142,8 @@ func TestExecuteGood(t *testing.T) {
 
 	if !reflect.DeepEqual(internal.AsJSON(result), internal.ParseJSON(`
 		{"users": [
-			{"name": "Alice", "foo": 10, "friends": []},
-			{"name": "Bob", "foo": 20, "friends": []}
+			{"name": "Alice", "foo": 10, "friends": [], "__key": "Alice"},
+			{"name": "Bob", "foo": 20, "friends": [], "__key": "Bob"}
 		],
 		"nilObject": null,
 		"nilSlice": [],
@@ -155,15 +154,11 @@ func TestExecuteGood(t *testing.T) {
 		"ints": [1, 2, 3, 4],
 		"getCtx": "hello there",
 		"sum": 4,
-		"ptr": {"name": "Charlie", "age": 5, "byRef": "byRef", "byVal": "byVal"},
-		"plain": {"name": "Jane", "age": 5, "byRef": "byRef", "byVal": "byVal"},
+		"ptr": {"name": "Charlie", "age": 5, "byRef": "byRef", "byVal": "byVal", "__key": "Charlie"},
+		"plain": {"name": "Jane", "age": 5, "byRef": "byRef", "byVal": "byVal", "__key": "Jane"},
 		"root": {"nested": {"time": "2016-03-23T18:31:51Z", "bytes": "YmFy", "bar": 1234, "alias": 999}}
 		}`)) {
 		t.Error("bad value")
-	}
-
-	if result.(*diff.Object).Fields["users"].(*diff.List).Items[0].(*diff.Object).Key != "Alice" {
-		t.Error("expected key")
 	}
 }
 

--- a/graphql/server.go
+++ b/graphql/server.go
@@ -179,12 +179,12 @@ func (c *conn) handleSubscribe(id string, subscribe *subscribeMessage) error {
 			return nil, err
 		}
 
-		delta, changed := diff.Diff(previous, current)
+		d := diff.Diff(previous, current)
 		previous = current
 		initial = false
 
-		if changed {
-			c.writeOrClose(id, "update", diff.PrepareForMarshal(delta))
+		if initial || d != nil {
+			c.writeOrClose(id, "update", d)
 		}
 
 		return nil, nil
@@ -232,8 +232,7 @@ func (c *conn) handleMutate(id string, mutate *mutateMessage) error {
 			return nil, err
 		}
 
-		delta, _ := diff.Diff(nil, current)
-		c.writeOrClose(id, "result", diff.PrepareForMarshal(delta))
+		c.writeOrClose(id, "result", diff.Diff(nil, current))
 
 		return nil, errors.New("stop")
 	}, MinRerunInterval)

--- a/reactive/diff/diff_test.go
+++ b/reactive/diff/diff_test.go
@@ -8,37 +8,21 @@ import (
 	"github.com/samsarahq/thunder/reactive/diff"
 )
 
-func obj(key string, fields map[string]interface{}) *diff.Object {
-	if fields == nil {
-		fields = map[string]interface{}{}
-	}
-	return &diff.Object{
-		Key:    key,
-		Fields: fields,
-	}
-}
-
-func list(items ...interface{}) *diff.List {
-	return &diff.List{
-		Items: items,
-	}
-}
-
 func TestDiffListString(t *testing.T) {
-	delta, _ := diff.Diff(list(
+	d := diff.Diff([]interface{}{
 		"0",
 		"1",
 		"2",
 		"3",
-	), list(
+	}, []interface{}{
 		"3",
 		"-1",
 		"0",
 		"1",
 		"4",
-	))
+	})
 
-	if !reflect.DeepEqual(internal.AsJSON(diff.PrepareForMarshal(delta)), internal.ParseJSON(`
+	if !reflect.DeepEqual(internal.AsJSON(d), internal.ParseJSON(`
 		{"$": [3, -1, [0, 2], -1], "1": "-1", "4": "4"}
 	`)) {
 		t.Error("bad reorder")
@@ -46,66 +30,66 @@ func TestDiffListString(t *testing.T) {
 }
 
 func TestDiffListOrder(t *testing.T) {
-	delta, _ := diff.Diff(list(
-		obj("0", nil),
-		obj("1", nil),
-		obj("2", nil),
-		obj("3", nil),
-	), list(
-		obj("3", nil),
-		obj("-1", nil),
-		obj("0", nil),
-		obj("1", nil),
-		obj("4", nil),
-	))
+	d := diff.Diff([]interface{}{
+		map[string]interface{}{"__key": "0"},
+		map[string]interface{}{"__key": "1"},
+		map[string]interface{}{"__key": "2"},
+		map[string]interface{}{"__key": "3"},
+	}, []interface{}{
+		map[string]interface{}{"__key": "3"},
+		map[string]interface{}{"__key": "-1"},
+		map[string]interface{}{"__key": "0"},
+		map[string]interface{}{"__key": "1"},
+		map[string]interface{}{"__key": "4"},
+	})
 
-	if !reflect.DeepEqual(internal.AsJSON(diff.PrepareForMarshal(delta)), internal.ParseJSON(`
+	if !reflect.DeepEqual(internal.AsJSON(d), internal.ParseJSON(`
 		{"$": [3, -1, [0, 2], -1], "1": [{}], "4": [{}]}
 	`)) {
 		t.Error("bad reorder")
 	}
 
-	_, changed := diff.Diff(list(
-		obj("0", nil),
-		obj("1", nil),
-		obj("2", nil),
-		obj("3", nil),
-	), list(
-		obj("0", nil),
-		obj("1", nil),
-		obj("2", nil),
-		obj("3", nil),
-	))
-	if changed {
+	d = diff.Diff([]interface{}{
+		map[string]interface{}{"__key": "0"},
+		map[string]interface{}{"__key": "1"},
+		map[string]interface{}{"__key": "2"},
+		map[string]interface{}{"__key": "3"},
+	}, []interface{}{
+		map[string]interface{}{"__key": "0"},
+		map[string]interface{}{"__key": "1"},
+		map[string]interface{}{"__key": "2"},
+		map[string]interface{}{"__key": "3"},
+	})
+	if d != nil {
 		t.Error("bad identical")
 	}
 
-	delta, _ = diff.Diff(list(
-		obj("0", nil),
-		obj("1", nil),
-		obj("2", nil),
-		obj("3", nil),
-	), list(
-		obj("0", nil),
-		obj("1", nil),
-	))
+	d = diff.Diff([]interface{}{
+		map[string]interface{}{"__key": "0"},
+		map[string]interface{}{"__key": "1"},
+		map[string]interface{}{"__key": "2"},
+		map[string]interface{}{"__key": "3"},
+	}, []interface{}{
+		map[string]interface{}{"__key": "0"},
+		map[string]interface{}{"__key": "1"},
+	})
 
-	if !reflect.DeepEqual(internal.AsJSON(diff.PrepareForMarshal(delta)), internal.ParseJSON(`
+	if !reflect.DeepEqual(internal.AsJSON(d), internal.ParseJSON(`
 		{"$": [[0, 2]]}
 	`)) {
 		t.Error("bad truncated")
 	}
 
-	delta, _ = diff.Diff(list(
-		obj("0", nil),
-		obj("1", nil),
-	), list(
-		obj("0", nil),
-		obj("1", nil),
-		obj("2", nil),
-	))
+	d = diff.Diff([]interface{}{
+		map[string]interface{}{"__key": "0"},
+		map[string]interface{}{"__key": "1"},
+	}, []interface{}{
+		map[string]interface{}{"__key": "0"},
+		map[string]interface{}{"__key": "1"},
+		map[string]interface{}{"__key": "2"},
+	})
 
-	if !reflect.DeepEqual(internal.AsJSON(diff.PrepareForMarshal(delta)), internal.ParseJSON(`
+	if !reflect.DeepEqual(internal.AsJSON(d), internal.ParseJSON(`
 		{"$": [[0, 2], -1], "2": [{}]}
 	`)) {
 		t.Error("bad appended")
@@ -113,75 +97,89 @@ func TestDiffListOrder(t *testing.T) {
 }
 
 func TestDiffObjects(t *testing.T) {
-	delta, _ := diff.Diff(obj("a", map[string]interface{}{
+	d := diff.Diff(map[string]interface{}{
+		"__key":   "a",
 		"changed": 0,
 		"removed": "foo",
 		"same":    "bar",
-	}), obj("a", map[string]interface{}{
+	}, map[string]interface{}{
+		"__key":   "a",
 		"changed": 1,
 		"same":    "bar",
-	}))
-	if !reflect.DeepEqual(internal.AsJSON(diff.PrepareForMarshal(delta)), internal.ParseJSON(`
+	})
+	if !reflect.DeepEqual(internal.AsJSON(d), internal.ParseJSON(`
 		{"changed": 1, "removed": []}
 	`)) {
 		t.Error("bad diff")
 	}
 
-	delta, _ = diff.Diff(obj("a", map[string]interface{}{
-		"foo": "bar",
-	}), obj("b", map[string]interface{}{
-		"foo": "bar",
-	}))
-	if !reflect.DeepEqual(internal.AsJSON(diff.PrepareForMarshal(delta)), internal.ParseJSON(`
+	d = diff.Diff(map[string]interface{}{
+		"__key": "a",
+		"foo":   "bar",
+	}, map[string]interface{}{
+		"__key": "b",
+		"foo":   "bar",
+	})
+	if !reflect.DeepEqual(internal.AsJSON(d), internal.ParseJSON(`
 		[{"foo": "bar"}]
 	`)) {
 		t.Error("bad changed key")
 	}
 
-	_, changed := diff.Diff(obj("a", map[string]interface{}{
-		"foo": "bar",
-	}), obj("a", map[string]interface{}{
-		"foo": "bar",
-	}))
-	if changed {
+	d = diff.Diff(map[string]interface{}{
+		"__key": "a",
+		"foo":   "bar",
+	}, map[string]interface{}{
+		"__key": "a",
+		"foo":   "bar",
+	})
+	if d != nil {
 		t.Error("bad identical")
 	}
-
 }
 
 func TestKitchenSink(t *testing.T) {
-	delta, _ := diff.Diff(obj("a", map[string]interface{}{
-		"users": list(
-			obj("alice", map[string]interface{}{
-				"age": 30,
-				"address": obj("10", map[string]interface{}{
-					"city": "sf",
-				}),
-			}),
-			obj("bob", map[string]interface{}{
-				"age": 300,
-			}),
-			obj("charlie", map[string]interface{}{
-				"age": 3000,
-			}),
-		),
+	d := diff.Diff(map[string]interface{}{
+		"__key": "a",
+		"users": []interface{}{
+			map[string]interface{}{
+				"__key": "alice",
+				"age":   30,
+				"address": map[string]interface{}{
+					"__key": "10",
+					"city":  "sf",
+				},
+			},
+			map[string]interface{}{
+				"__key": "bob",
+				"age":   300,
+			},
+			map[string]interface{}{
+				"__key": "charlie",
+				"age":   3000,
+			},
+		},
 		"foo": "bar",
-	}), obj("a", map[string]interface{}{
-		"users": list(
-			obj("bob", map[string]interface{}{
-				"age": 300,
-			}),
-			obj("alice", map[string]interface{}{
-				"age": 30000,
-				"address": obj("10", map[string]interface{}{
-					"city": "berkeley",
-				}),
-			}),
-		),
+	}, map[string]interface{}{
+		"__key": "a",
+		"users": []interface{}{
+			map[string]interface{}{
+				"__key": "bob",
+				"age":   300,
+			},
+			map[string]interface{}{
+				"__key": "alice",
+				"age":   30000,
+				"address": map[string]interface{}{
+					"__key": "10",
+					"city":  "berkeley",
+				},
+			},
+		},
 		"bar": "baz",
-	}))
+	})
 
-	if !reflect.DeepEqual(internal.AsJSON(diff.PrepareForMarshal(delta)), internal.ParseJSON(`
+	if !reflect.DeepEqual(internal.AsJSON(d), internal.ParseJSON(`
 		{"foo": [], "bar": "baz", "users": {
 			"$": [1, 0],
 			"1": {"age": 30000, "address": {"city": "berkeley"}}


### PR DESCRIPTION
This commit removes the diff.Object and diff.List intermediate objects
and computes diffs over standard JSON objects instead. This simplifies
the API and all callsites, since they no longer have to wrangle these
special types.