### PR TITLE
graphql: track query name and report name in tags

### DIFF
--- a/graphql/end_to_end_test.go
+++ b/graphql/end_to_end_test.go
@@ -63,7 +63,7 @@ func TestPathError(t *testing.T) {
 	q := graphql.MustParse(`
 		{
 			inner { inners { expensive { expensives { err } } } }
-        }`, nil)
+        }`, nil).SelectionSet
 
 	if err := graphql.PrepareQuery(builtSchema.Query, q); err != nil {
 		t.Error(err)
@@ -78,7 +78,7 @@ func TestPathError(t *testing.T) {
 	q = graphql.MustParse(`
 		{
 			safe
-		}`, nil)
+		}`, nil).SelectionSet
 
 	if err := graphql.PrepareQuery(builtSchema.Query, q); err != nil {
 		t.Error(err)
@@ -144,7 +144,7 @@ func TestEndToEndAwaitAndCache(t *testing.T) {
 				name
 				slow { count }
             }
-        }`, nil)
+        }`, nil).SelectionSet
 
 	if err := graphql.PrepareQuery(builtSchema.Query, q); err != nil {
 		t.Error(err)

--- a/graphql/executor_test.go
+++ b/graphql/executor_test.go
@@ -95,7 +95,7 @@ func TestBasic(t *testing.T) {
 		static
 		a { value nested { value } }
 		as { value }
-	}`, nil)
+	}`, nil).SelectionSet
 
 	if err := PrepareQuery(query, q); err != nil {
 		t.Error(err)
@@ -185,7 +185,7 @@ func TestError(t *testing.T) {
 		{
 			error
 		}
-	`, map[string]interface{}{})
+	`, map[string]interface{}{}).SelectionSet
 
 	if err := PrepareQuery(query, q); err != nil {
 		t.Error(err)
@@ -207,7 +207,7 @@ func TestPanic(t *testing.T) {
 		{
 			panic
 		}
-	`, nil)
+	`, nil).SelectionSet
 
 	if err := PrepareQuery(query, q); err != nil {
 		t.Error(err)

--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -321,17 +321,17 @@ func ComputeSchemaJSON(schemaBuilderSchema schemabuilder.Schema) ([]byte, error)
 	schema := schemaBuilderSchema.MustBuild()
 	AddIntrospectionToSchema(schema)
 
-	selectionSet, err := graphql.Parse(introspectionQuery, map[string]interface{}{})
+	query, err := graphql.Parse(introspectionQuery, map[string]interface{}{})
 	if err != nil {
 		return nil, err
 	}
 
-	if err := graphql.PrepareQuery(schema.Query, selectionSet); err != nil {
+	if err := graphql.PrepareQuery(schema.Query, query.SelectionSet); err != nil {
 		return nil, err
 	}
 
 	executor := graphql.Executor{}
-	value, err := executor.Execute(context.Background(), schema.Query, nil, selectionSet)
+	value, err := executor.Execute(context.Background(), schema.Query, nil, query.SelectionSet)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/parser_test.go
+++ b/graphql/parser_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestParseSupported(t *testing.T) {
-	selections, err := Parse(`
+	query, err := Parse(`
 {
 	foo {
 		alias: bar
@@ -34,80 +34,84 @@ fragment Bar on Foo {
 		t.Error("unexpected error", err)
 	}
 
-	expected := &SelectionSet{
-		Complex: true,
-		Selections: []*Selection{
-			{
-				Name:  "foo",
-				Alias: "foo",
-				Args:  map[string]interface{}{},
-				SelectionSet: &SelectionSet{
-					Complex: true,
-					Selections: []*Selection{
-						{
-							Name:  "bar",
-							Alias: "alias",
-							Args:  map[string]interface{}{},
-						},
-						{
-							Name:  "bar",
-							Alias: "alias",
-							Args:  map[string]interface{}{},
-						},
-						{
-							Name:  "baz",
-							Alias: "baz",
-							Args: map[string]interface{}{
-								"arg": float64(3),
+	expected := &Query{
+		Name: "",
+		Kind: "query",
+		SelectionSet: &SelectionSet{
+			Complex: true,
+			Selections: []*Selection{
+				{
+					Name:  "foo",
+					Alias: "foo",
+					Args:  map[string]interface{}{},
+					SelectionSet: &SelectionSet{
+						Complex: true,
+						Selections: []*Selection{
+							{
+								Name:  "bar",
+								Alias: "alias",
+								Args:  map[string]interface{}{},
 							},
-							SelectionSet: &SelectionSet{
-								Selections: []*Selection{
-									{
-										Name:  "bah",
-										Alias: "bah",
-										Args: map[string]interface{}{
-											"x": float64(1),
-											"y": "123",
-											"z": true,
-										},
-									},
-									{
-										Name:  "hum",
-										Alias: "hum",
-										Args: map[string]interface{}{
-											"foo": map[string]interface{}{
-												"x": "var value!!",
+							{
+								Name:  "bar",
+								Alias: "alias",
+								Args:  map[string]interface{}{},
+							},
+							{
+								Name:  "baz",
+								Alias: "baz",
+								Args: map[string]interface{}{
+									"arg": float64(3),
+								},
+								SelectionSet: &SelectionSet{
+									Selections: []*Selection{
+										{
+											Name:  "bah",
+											Alias: "bah",
+											Args: map[string]interface{}{
+												"x": float64(1),
+												"y": "123",
+												"z": true,
 											},
-											"bug": []interface{}{
-												float64(1), float64(2),
-												[]interface{}{float64(4), float64(5)},
+										},
+										{
+											Name:  "hum",
+											Alias: "hum",
+											Args: map[string]interface{}{
+												"foo": map[string]interface{}{
+													"x": "var value!!",
+												},
+												"bug": []interface{}{
+													float64(1), float64(2),
+													[]interface{}{float64(4), float64(5)},
+												},
 											},
 										},
 									},
 								},
 							},
 						},
-					},
-					Fragments: []*Fragment{
-						{
-							On: "Foo",
-							SelectionSet: &SelectionSet{
-								Selections: []*Selection{
-									{
-										Name:  "asd",
-										Alias: "asd",
-										Args:  map[string]interface{}{},
+						Fragments: []*Fragment{
+							{
+								On: "Foo",
+								SelectionSet: &SelectionSet{
+									Selections: []*Selection{
+										{
+											Name:  "asd",
+											Alias: "asd",
+											Args:  map[string]interface{}{},
+										},
 									},
-								},
-								Fragments: []*Fragment{
-									{
-										On: "Foo",
-										SelectionSet: &SelectionSet{
-											Selections: []*Selection{
-												{
-													Name:  "zxc",
-													Alias: "zxc",
-													Args:  map[string]interface{}{},
+									Fragments: []*Fragment{
+										{
+											On: "Foo",
+											SelectionSet: &SelectionSet{
+												Selections: []*Selection{
+													{
+														Name:  "zxc",
+														Alias: "zxc",
+														Args:  map[string]interface{}{},
+													},
 												},
 											},
 										},
@@ -117,20 +121,20 @@ fragment Bar on Foo {
 						},
 					},
 				},
-			},
-			{
-				Name:  "xyz",
-				Alias: "xyz",
-				Args:  map[string]interface{}{},
+				{
+					Name:  "xyz",
+					Alias: "xyz",
+					Args:  map[string]interface{}{},
+				},
 			},
 		},
 	}
 
-	if !reflect.DeepEqual(selections, expected) {
+	if !reflect.DeepEqual(query, expected) {
 		t.Error("unexpected parse")
 	}
 
-	selections, err = Parse(`
+	query, err = Parse(`
 mutation foo($var: bar) {
 	baz
 }
@@ -141,17 +145,20 @@ mutation foo($var: bar) {
 		t.Error("unexpected error", err)
 	}
 
-	expected = &SelectionSet{
-		Selections: []*Selection{
-			{
-				Name:  "baz",
-				Alias: "baz",
-				Args:  map[string]interface{}{},
+	expected = &Query{
+		Name: "foo",
+		Kind: "mutation",
+		SelectionSet: &SelectionSet{
+			Selections: []*Selection{
+				{
+					Name:  "baz",
+					Alias: "baz",
+					Args:  map[string]interface{}{},
+				},
 			},
 		},
 	}
-
-	if !reflect.DeepEqual(selections, expected) {
+	if !reflect.DeepEqual(query, expected) {
 		t.Error("unexpected parse")
 	}
 }

--- a/graphql/schemabuilder/perf_test.go
+++ b/graphql/schemabuilder/perf_test.go
@@ -37,7 +37,7 @@ func BenchmarkSimpleExecute(b *testing.B) {
 				age
 			}
 		}
-	`, nil)
+	`, nil).SelectionSet
 
 	if err := graphql.PrepareQuery(builtSchema.Query, q); err != nil {
 		b.Error(err)

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -141,7 +141,7 @@ func TestExecuteGood(t *testing.T) {
 			root { nested { time bar: yyy bytes alias } }
 			weirdKey { key }
 		}
-	`, map[string]interface{}{"var": float64(3)})
+	`, map[string]interface{}{"var": float64(3)}).SelectionSet
 
 	if err := graphql.PrepareQuery(builtSchema.Query, q); err != nil {
 		t.Error(err)


### PR DESCRIPTION
Query names are helpful in monitoring, so keep track of them after
parsing and during execution.