### PR TITLE
graphql: include query name in error

### DIFF
--- a/graphql/end_to_end_test.go
+++ b/graphql/end_to_end_test.go
@@ -63,9 +63,9 @@ func TestPathError(t *testing.T) {
 	q := graphql.MustParse(`
 		{
 			inner { inners { expensive { expensives { err } } } }
-        }`, nil).SelectionSet
+        }`, nil)
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q); err != nil {
+	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -78,9 +78,9 @@ func TestPathError(t *testing.T) {
 	q = graphql.MustParse(`
 		{
 			safe
-		}`, nil).SelectionSet
+		}`, nil)
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q); err != nil {
+	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -144,9 +144,9 @@ func TestEndToEndAwaitAndCache(t *testing.T) {
 				name
 				slow { count }
             }
-        }`, nil).SelectionSet
+        }`, nil)
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q); err != nil {
+	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 

--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -273,11 +273,14 @@ type Executor struct {
 }
 
 // Execute executes a query by dispatches according to typ
-func (e *Executor) Execute(ctx context.Context, typ Type, source interface{}, selectionSet *SelectionSet) (interface{}, error) {
+func (e *Executor) Execute(ctx context.Context, typ Type, source interface{}, query *Query) (interface{}, error) {
 	e.mu.Lock()
-	value, err := e.execute(ctx, typ, source, selectionSet)
+	value, err := e.execute(ctx, typ, source, query.SelectionSet)
 	e.mu.Unlock()
 	if err != nil {
+		if query.Name != "" {
+			err = nestPathError(query.Name, err)
+		}
 		return nil, err
 	}
 	return await(value)

--- a/graphql/executor_test.go
+++ b/graphql/executor_test.go
@@ -95,9 +95,9 @@ func TestBasic(t *testing.T) {
 		static
 		a { value nested { value } }
 		as { value }
-	}`, nil).SelectionSet
+	}`, nil)
 
-	if err := PrepareQuery(query, q); err != nil {
+	if err := PrepareQuery(query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 	e := Executor{}
@@ -182,18 +182,18 @@ func TestError(t *testing.T) {
 	query := makeQuery()
 
 	q := MustParse(`
-		{
+		query foo {
 			error
 		}
-	`, map[string]interface{}{}).SelectionSet
+	`, map[string]interface{}{})
 
-	if err := PrepareQuery(query, q); err != nil {
+	if err := PrepareQuery(query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
 	e := Executor{}
 	_, err := e.Execute(context.Background(), query, nil, q)
-	if err == nil || !strings.Contains(err.Error(), "test error") {
+	if err == nil || err.Error() != "foo.error: test error" {
 		t.Error("expected test error")
 	}
 }
@@ -207,9 +207,9 @@ func TestPanic(t *testing.T) {
 		{
 			panic
 		}
-	`, nil).SelectionSet
+	`, nil)
 
-	if err := PrepareQuery(query, q); err != nil {
+	if err := PrepareQuery(query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 

--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -331,7 +331,7 @@ func ComputeSchemaJSON(schemaBuilderSchema schemabuilder.Schema) ([]byte, error)
 	}
 
 	executor := graphql.Executor{}
-	value, err := executor.Execute(context.Background(), schema.Query, nil, query.SelectionSet)
+	value, err := executor.Execute(context.Background(), schema.Query, nil, query)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/schemabuilder/perf_test.go
+++ b/graphql/schemabuilder/perf_test.go
@@ -37,9 +37,9 @@ func BenchmarkSimpleExecute(b *testing.B) {
 				age
 			}
 		}
-	`, nil).SelectionSet
+	`, nil)
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q); err != nil {
+	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
 		b.Error(err)
 	}
 

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -141,9 +141,9 @@ func TestExecuteGood(t *testing.T) {
 			root { nested { time bar: yyy bytes alias } }
 			weirdKey { key }
 		}
-	`, map[string]interface{}{"var": float64(3)}).SelectionSet
+	`, map[string]interface{}{"var": float64(3)})
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q); err != nil {
+	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 

--- a/graphql/server.go
+++ b/graphql/server.go
@@ -166,7 +166,7 @@ func (c *conn) handleSubscribe(id string, subscribe *subscribeMessage) error {
 		start := time.Now()
 		span, ctx := opentracing.StartSpanFromContext(ctx, "thunder.subscription")
 		c.logger.StartExecution(ctx, tags, initial)
-		current, err := e.Execute(ctx, c.schema.Query, nil, query.SelectionSet)
+		current, err := e.Execute(ctx, c.schema.Query, nil, query)
 		c.logger.FinishExecution(ctx, tags, time.Since(start))
 		span.Finish()
 
@@ -225,7 +225,7 @@ func (c *conn) handleMutate(id string, mutate *mutateMessage) error {
 
 		start := time.Now()
 		c.logger.StartExecution(ctx, tags, true)
-		current, err := e.Execute(ctx, c.schema.Mutation, c.schema.Mutation, query.SelectionSet)
+		current, err := e.Execute(ctx, c.schema.Mutation, c.schema.Mutation, query)
 		c.logger.FinishExecution(ctx, tags, time.Since(start))
 
 		if err != nil {


### PR DESCRIPTION
When eg.
```
  query testQuery {
    user {
      name
    }
  }
```
fails to resolve user.name with error "RPC failed", the error now
prints as "testQuery.user.name: RPC failed". The addition of
"testQuery." is new.

To make this work, start passing around a query object instead of the
raw selection set.