### PR TITLE
Support optional (pointer) alias types

### DIFF
--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -140,6 +140,16 @@ func getScalarArgParser(typ reflect.Type) (*argParser, graphql.Type, bool) {
 			if !ok {
 				panic(typ)
 			}
+
+			if typ != argParser.Type {
+				// The scalar may be a type alias here,
+				// so we annotate the parser to output the
+				// alias instead of the underlying type.
+				newParser := *argParser
+				newParser.Type = typ
+				argParser = &newParser
+			}
+
 			return argParser, &graphql.Scalar{Type: name}, true
 		}
 	}

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -207,6 +207,7 @@ type kitchenSinkArgs struct {
 	OptionalStructs *[]*inner
 	Base64          []byte
 	Alias           alias
+	OptionalAlias   *alias
 }
 
 type anonymous struct {
@@ -271,9 +272,11 @@ func TestArgParser(t *testing.T) {
 		OptionalStructs: nil,
 		Base64:          []byte("foo"),
 		Alias:           999,
+		OptionalAlias:   nil,
 	})
 
 	var ten = int64(10)
+	var aliasTen = alias(10)
 
 	testArgParseOk(t, parser, internal.ParseJSON(`
 		{
@@ -288,7 +291,8 @@ func TestArgParser(t *testing.T) {
 			"ints": [6, 6, 6],
 			"optionalStructs": [{"foo": 1}, {"foo": 2}],
 			"base64": "MQ==",
-			"alias": 1234
+			"alias": 1234,
+			"optionalAlias": 10
 		}
 	`), kitchenSinkArgs{
 		Child:           inner{Custom: 22.5},
@@ -303,6 +307,7 @@ func TestArgParser(t *testing.T) {
 		OptionalStructs: &[]*inner{{Custom: 1}, {Custom: 2}},
 		Base64:          []byte("1"),
 		Alias:           1234,
+		OptionalAlias:   &aliasTen,
 	})
 
 	testArgParseBad(t, parser, internal.ParseJSON(`

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -194,20 +194,24 @@ type inner struct {
 	Custom float64 `graphql:"foo"`
 }
 
+type structAlias inner
+
 type kitchenSinkArgs struct {
-	Child           inner
-	Hello           int64
-	Hello32         int32
-	Hello16         int16
-	FooBar          string
-	Bool            bool
-	OptionalInt     *int64
-	OptionalStruct  *inner
-	Ints            []int64
-	OptionalStructs *[]*inner
-	Base64          []byte
-	Alias           alias
-	OptionalAlias   *alias
+	Child               inner
+	Hello               int64
+	Hello32             int32
+	Hello16             int16
+	FooBar              string
+	Bool                bool
+	OptionalInt         *int64
+	OptionalStruct      *inner
+	Ints                []int64
+	OptionalStructs     *[]*inner
+	Base64              []byte
+	Alias               alias
+	OptionalAlias       *alias
+	StructAlias         structAlias
+	OptionalStructAlias *structAlias
 }
 
 type anonymous struct {
@@ -257,22 +261,25 @@ func TestArgParser(t *testing.T) {
 			"bool": true,
 			"ints": [1, 2, 3],
 			"base64": "Zm9v",
-			"alias": 999
+			"alias": 999,
+			"structAlias": {"foo": 14}
 		}
 	`), kitchenSinkArgs{
-		Child:           inner{Custom: 12.5},
-		Hello:           20,
-		Hello32:         20,
-		Hello16:         20,
-		FooBar:          "foo!",
-		Bool:            true,
-		OptionalInt:     nil,
-		OptionalStruct:  nil,
-		Ints:            []int64{1, 2, 3},
-		OptionalStructs: nil,
-		Base64:          []byte("foo"),
-		Alias:           999,
-		OptionalAlias:   nil,
+		Child:               inner{Custom: 12.5},
+		Hello:               20,
+		Hello32:             20,
+		Hello16:             20,
+		FooBar:              "foo!",
+		Bool:                true,
+		OptionalInt:         nil,
+		OptionalStruct:      nil,
+		Ints:                []int64{1, 2, 3},
+		OptionalStructs:     nil,
+		Base64:              []byte("foo"),
+		Alias:               999,
+		OptionalAlias:       nil,
+		StructAlias:         structAlias{Custom: 14},
+		OptionalStructAlias: nil,
 	})
 
 	var ten = int64(10)
@@ -292,22 +299,26 @@ func TestArgParser(t *testing.T) {
 			"optionalStructs": [{"foo": 1}, {"foo": 2}],
 			"base64": "MQ==",
 			"alias": 1234,
-			"optionalAlias": 10
+			"optionalAlias": 10,
+			"structAlias": {"foo": 14},
+			"optionalStructAlias": {"foo": 17}
 		}
 	`), kitchenSinkArgs{
-		Child:           inner{Custom: 22.5},
-		Hello:           40,
-		Hello32:         40,
-		Hello16:         40,
-		FooBar:          "bar!",
-		Bool:            false,
-		OptionalInt:     &ten,
-		OptionalStruct:  &inner{Custom: 20},
-		Ints:            []int64{6, 6, 6},
-		OptionalStructs: &[]*inner{{Custom: 1}, {Custom: 2}},
-		Base64:          []byte("1"),
-		Alias:           1234,
-		OptionalAlias:   &aliasTen,
+		Child:               inner{Custom: 22.5},
+		Hello:               40,
+		Hello32:             40,
+		Hello16:             40,
+		FooBar:              "bar!",
+		Bool:                false,
+		OptionalInt:         &ten,
+		OptionalStruct:      &inner{Custom: 20},
+		Ints:                []int64{6, 6, 6},
+		OptionalStructs:     &[]*inner{{Custom: 1}, {Custom: 2}},
+		Base64:              []byte("1"),
+		Alias:               1234,
+		OptionalAlias:       &aliasTen,
+		StructAlias:         structAlias{Custom: 14},
+		OptionalStructAlias: &structAlias{Custom: 17},
 	})
 
 	testArgParseBad(t, parser, internal.ParseJSON(`


### PR DESCRIPTION
Fixes a bug where alias types would fail with 
```bash
panic: reflect.Set: value of type *int64 is not assignable to type *schemabuilder.alias
```

(See first commit)