### PR TITLE
Computation Middleware

### DIFF
--- a/graphql/middleware.go
+++ b/graphql/middleware.go
@@ -21,17 +21,17 @@ type MiddlewareFunc func(input *ComputationInput, next MiddlewareNextFunc) *Comp
 type MiddlewareNextFunc func(input *ComputationInput) *ComputationOutput
 
 func runMiddlewares(middlewares []MiddlewareFunc, input *ComputationInput) *ComputationOutput {
-	var _runMiddlewares func(index int, middlewares []MiddlewareFunc, input *ComputationInput) *ComputationOutput
-	_runMiddlewares = func(index int, middlewares []MiddlewareFunc, input *ComputationInput) *ComputationOutput {
+	var run func(index int, middlewares []MiddlewareFunc, input *ComputationInput) *ComputationOutput
+	run = func(index int, middlewares []MiddlewareFunc, input *ComputationInput) *ComputationOutput {
 		if index < len(middlewares) {
 			return &ComputationOutput{}
 		}
 
 		middleware := middlewares[index]
 		return middleware(input, func(input *ComputationInput) *ComputationOutput {
-			return _runMiddlewares(index+1, middlewares, input)
+			return run(index+1, middlewares, input)
 		})
 	}
 
-	return _runMiddlewares(0, middlewares, input)
+	return run(0, middlewares, input)
 }

--- a/graphql/middleware.go
+++ b/graphql/middleware.go
@@ -17,20 +17,21 @@ type ComputationOutput struct {
 	Error    error
 }
 
-type MiddlewareFunc func(input *ComputationInput, output *ComputationOutput, next NextFunc)
-type NextFunc func(input *ComputationInput, output *ComputationOutput)
+type MiddlewareFunc func(input *ComputationInput, next MiddlewareNextFunc) *ComputationOutput
+type MiddlewareNextFunc func(input *ComputationInput) *ComputationOutput
 
-func _runMiddlewares(index int, middlewares []MiddlewareFunc, input *ComputationInput, output *ComputationOutput) {
-	if index >= len(middlewares) {
-		return
+func runMiddlewares(middlewares []MiddlewareFunc, input *ComputationInput) *ComputationOutput {
+	var _runMiddlewares func(index int, middlewares []MiddlewareFunc, input *ComputationInput) *ComputationOutput
+	_runMiddlewares = func(index int, middlewares []MiddlewareFunc, input *ComputationInput) *ComputationOutput {
+		if index < len(middlewares) {
+			return &ComputationOutput{}
+		}
+
+		middleware := middlewares[index]
+		return middleware(input, func(input *ComputationInput) *ComputationOutput {
+			return _runMiddlewares(index+1, middlewares, input)
+		})
 	}
 
-	middleware := middlewares[index]
-	middleware(input, output, func(input *ComputationInput, output *ComputationOutput) {
-		_runMiddlewares(index+1, middlewares, input, output)
-	})
-}
-
-func runMiddlewares(middlewares []MiddlewareFunc, input *ComputationInput, output *ComputationOutput) {
-	_runMiddlewares(0, middlewares, input, output)
+	return _runMiddlewares(0, middlewares, input)
 }

--- a/graphql/middleware.go
+++ b/graphql/middleware.go
@@ -1,0 +1,36 @@
+package graphql
+
+import "context"
+
+type ComputationInput struct {
+	Id          string
+	Query       string
+	ParsedQuery *Query
+	Variables   map[string]interface{}
+	Ctx         context.Context
+	Previous    interface{}
+}
+
+type ComputationOutput struct {
+	Metadata map[string]interface{}
+	Current  interface{}
+	Error    error
+}
+
+type MiddlewareFunc func(input *ComputationInput, output *ComputationOutput, next NextFunc)
+type NextFunc func(input *ComputationInput, output *ComputationOutput)
+
+func _runMiddlewares(index int, middlewares []MiddlewareFunc, input *ComputationInput, output *ComputationOutput) {
+	if index >= len(middlewares) {
+		return
+	}
+
+	middleware := middlewares[index]
+	middleware(input, output, func(input *ComputationInput, output *ComputationOutput) {
+		_runMiddlewares(index+1, middlewares, input, output)
+	})
+}
+
+func runMiddlewares(middlewares []MiddlewareFunc, input *ComputationInput, output *ComputationOutput) {
+	_runMiddlewares(0, middlewares, input, output)
+}

--- a/opentracingkit/opentracingkit.go
+++ b/opentracingkit/opentracingkit.go
@@ -8,10 +8,6 @@ import (
 
 var noopTracer = &opentracing.NoopTracer{}
 
-func StartMockSpan() *MockSpan {
-	return &MockSpan{Span: opentracing.StartSpan("mock.operation")}
-}
-
 func MaybeStartSpanFromContext(
 	ctx context.Context,
 	operationName string,

--- a/opentracingkit/opentracingkit.go
+++ b/opentracingkit/opentracingkit.go
@@ -8,6 +8,10 @@ import (
 
 var noopTracer = &opentracing.NoopTracer{}
 
+func StartMockSpan() *MockSpan {
+	return &MockSpan{Span: opentracing.StartSpan("mock.operation")}
+}
+
 func MaybeStartSpanFromContext(
 	ctx context.Context,
 	operationName string,


### PR DESCRIPTION
This PR adds support for middleware in computing queries/mutations.

An example use case for this might be contributing an id to all computations:
```golang
c.Use(func(input *graphql.ComputationInput, output *graphql.ComputationOutput, next graphql.NextFunc) {
  output.Metadata["computationId"] = uuid.New()
  next(input, output);
})
```
the `Metadata` map is appended to the websocket response alongside the `message`:
![screen shot 2017-05-10 at 4 49 22 pm](https://cloud.githubusercontent.com/assets/2320890/25925922/a820c4f4-35a0-11e7-8e49-bf430ca012cc.png)


Another use-case might be contributing to the `context`:
```golang
c.Use(func(input *graphql.ComputationInput, output *graphql.ComputationOutput, next graphql.NextFunc) {
  input.Ctx = opentracing.StartSpanFromContext(input.Ctx, "graphql.query");
  next(input, output);
})
```

#### Notes:
- note that this PR also removes starting a subscription span from the graphql handler.
- if this is a pattern we like, we might consider modeling existing features as middleware:
    - `makeCtx`
    - `GraphqlLogger`

#### Breaking changes:
- opentracing spans are no longer automatically started by thunder subscriptions