### PR TITLE
thunder batch: Increase DefaultWaitInterval to 1ms

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -24,7 +24,7 @@ import (
 )
 
 // DefaultWaitInterval is the default WaitInterval for Func.
-const DefaultWaitInterval = 200 * time.Microsecond
+const DefaultWaitInterval = 1 * time.Millisecond
 
 // DefaultMaxDuration is the default MaxDuration for Func.
 const DefaultMaxDuration = 20 * time.Millisecond


### PR DESCRIPTION
Bumping up the default wait interval from 200us to 1ms, to better
accumulate function invocations into batch requests.