### PR TITLE
thunder errors: Replace custom errors with github.com/pkg/errors

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -17,10 +17,10 @@ package batch
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // DefaultWaitInterval is the default WaitInterval for Func.
@@ -112,7 +112,7 @@ func safeInvoke(
 	defer func() {
 		if p := recover(); p != nil {
 			result = nil
-			err = fmt.Errorf("Func.Many panicked: %v", p)
+			err = errors.Errorf("Func.Many panicked: %v", p)
 		} else if err == nil && len(result) != len(args) {
 			result = nil
 			err = errors.New("Func.Many returned incorrect number of results")

--- a/graphql/end_to_end_test.go
+++ b/graphql/end_to_end_test.go
@@ -71,7 +71,7 @@ func TestPathError(t *testing.T) {
 
 	e := graphql.Executor{}
 	_, err := e.Execute(context.Background(), builtSchema.Query, nil, q)
-	if err == nil || err.Error() != "inner.inners.0.expensive.expensives.0.err: no good, bad" {
+	if err == nil || err.Error() != "inner: inners: 0: expensive: expensives: 0: err: no good, bad" {
 		t.Errorf("bad error: %v", err)
 	}
 

--- a/graphql/executor_test.go
+++ b/graphql/executor_test.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -193,7 +194,7 @@ func TestError(t *testing.T) {
 
 	e := Executor{}
 	_, err := e.Execute(context.Background(), query, nil, q)
-	if err == nil || err.Error() != "foo.error: test error" {
+	if err == nil || err.Error() != "foo: error: test error" {
 		t.Error("expected test error")
 	}
 }
@@ -219,7 +220,7 @@ func TestPanic(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "test panic") {
 		t.Error("expected test panic")
 	}
-	if !strings.Contains(err.Error(), "executor_test.go") {
+	if !strings.Contains(fmt.Sprintf("%+v", err), "executor_test.go") {
 		t.Error("expected stacktrace")
 	}
 }

--- a/graphql/server.go
+++ b/graphql/server.go
@@ -3,7 +3,6 @@ package graphql
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
 
 	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/diff"
@@ -194,7 +194,7 @@ func (c *conn) handleSubscribe(id string, subscribe *subscribeMessage) error {
 			})
 			go c.closeSubscription(id)
 
-			if extractPathError(err) == context.Canceled {
+			if errors.Cause(err) == context.Canceled {
 				return nil, err
 			}
 
@@ -281,7 +281,7 @@ func (c *conn) handleMutate(id string, mutate *mutateMessage) error {
 
 			go c.closeSubscription(id)
 
-			if extractPathError(err) == context.Canceled {
+			if errors.Cause(err) == context.Canceled {
 				return nil, err
 			}
 


### PR DESCRIPTION
Removing all of the custom code that dealt with wrapping errors and
generating stacktraces for errors, since the github.com/pkg/errors
package does the same in a better and more reusable way.

Note that calls to errors.New and errors.Errorf include a stacktrace of
the current stack in the reulting err, which is useful for any consumers
(like Raven) that want to evaluate the stacktrace at the time of the
panic.