### PR TITLE
Fix incorrect type inference for non-null fields

### DIFF
--- a/graphql/introspection/introspection_test.go
+++ b/graphql/introspection/introspection_test.go
@@ -27,6 +27,13 @@ func makeSchema() *schemabuilder.Schema {
 		return nil
 	})
 
+	// Add a non-null field after "noone" to test that caching
+	// mechanism in schemabuilder chooses the correct type
+	// for the return value.
+	query.FieldFunc("viewer", func() (User, error) {
+		return User{Name: "me"}, nil
+	})
+
 	user := schema.Object("User", User{})
 	user.FieldFunc("friends", func(u *User) []*User {
 		return nil

--- a/graphql/introspection/test-schema.json
+++ b/graphql/introspection/test-schema.json
@@ -66,6 +66,22 @@
               "name": "User",
               "ofType": null
             }
+          },
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "viewer",
+            "type": {
+              "kind": "NON_NULL",
+              "name": "",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            }
           }
         ],
         "inputFields": [],

--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -673,10 +673,6 @@ func getScalar(typ reflect.Type) (string, bool) {
 }
 
 func (sb *schemaBuilder) getType(t reflect.Type) (graphql.Type, error) {
-	if sb.types[t] != nil {
-		return sb.types[t], nil
-	}
-
 	// Support scalars and optional scalars. Scalars have precedence over structs
 	// to have eg. time.Time function as a scalar.
 	if typ, ok := getScalar(t); ok {


### PR DESCRIPTION
r? @jellevandenhooff 

For context, we cache the type of the known structs that we have already seen so that we do not need to do reflection checks on structs multiple times. However, this cache check prevents the rest of the function from correctly wrapping non-nullable fields in `graphql.NonNull{}`.

In practice, this bug is visible when a resolver returns a non-pointer struct type of a struct type that the schemabuilder has already seen.

In this commit, I've removed the cache check. Note that the buildStruct function still has this same cache check repeated the beginning of its body, so we are still avoiding the penalty of re-reflecting on seen structs, but we are allowing getType to run its null vs. non-null logic.

The first commit adds a failing test case and the second adds the fix.