### PR TITLE
Non-nullable resolver functions

### DIFF
--- a/graphql/introspection/introspection_test.go
+++ b/graphql/introspection/introspection_test.go
@@ -24,7 +24,10 @@ func makeSchema() *schemabuilder.Schema {
 		return User{Name: "me"}
 	})
 	query.FieldFunc("noone", func() *User {
-		return nil
+		return &User{Name: "me"}
+	}, schemabuilder.NonNullable)
+	query.FieldFunc("nullableUser", func() (*User, error) {
+		return nil, nil
 	})
 
 	// Add a non-null field after "noone" to test that caching

--- a/graphql/introspection/test-schema.json
+++ b/graphql/introspection/test-schema.json
@@ -62,6 +62,22 @@
             "isDeprecated": false,
             "name": "noone",
             "type": {
+              "kind": "NON_NULL",
+              "name": "",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            }
+          },
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "nullableUser",
+            "type": {
               "kind": "OBJECT",
               "name": "User",
               "ofType": null

--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -518,6 +518,11 @@ func (sb *schemaBuilder) buildFunction(typ reflect.Type, m *method) (*graphql.Fi
 			var result interface{}
 			if hasRet {
 				result = out[0].Interface()
+				if _, ok := retType.(*graphql.NonNull); ok {
+					if out[0].Kind() == reflect.Ptr && out[0].IsNil() {
+						return nil, fmt.Errorf("%s is marked non-nullable but returned a null value", funcType)
+					}
+				}
 				out = out[1:]
 			} else {
 				result = true

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -51,6 +51,9 @@ func TestExecuteGood(t *testing.T) {
 	query.FieldFunc("nilObject", func() *User {
 		return nil
 	})
+	query.FieldFunc("requiredObject", func() *User {
+		return &User{}
+	}, NonNullable)
 	query.FieldFunc("nilSlice", func() []*User {
 		return nil
 	})

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -11,6 +11,16 @@ type Object struct {
 	key string
 }
 
+// FieldFuncOption is an interface for the variadic options that can be passed
+// to a FieldFunc for configuring options on that function.
+type FieldFuncOption func(*method)
+
+// NonNullable is an option that can be passed to a FieldFunc to indicate that
+// its return value is required, even if the return value is a pointer type.
+func NonNullable(m *method) {
+	m.MarkedNonNullable = true
+}
+
 // FieldFunc exposes a field on an object. The function f can take a number of
 // optional arguments:
 // func([ctx context.Context], [o *Type], [args struct {}]) ([Result], [error])
@@ -29,16 +39,27 @@ type Object struct {
 //        userID, err := db.AddUser(ctx, args.FirstName, args.LastName)
 //        return userID, err
 //    })
-func (s *Object) FieldFunc(name string, f interface{}) {
+func (s *Object) FieldFunc(name string, f interface{}, options ...FieldFuncOption) {
 	if s.Methods == nil {
 		s.Methods = make(Methods)
 	}
-	s.Methods[name] = f
+
+	m := &method{Fn: f}
+	for _, option := range options {
+		option(m)
+	}
+
+	s.Methods[name] = m
 }
 
 func (s *Object) Key(f string) {
 	s.key = f
 }
 
+type method struct {
+	MarkedNonNullable bool
+	Fn                interface{}
+}
+
 // A Methods map represents the set of methods exposed on a Object.
-type Methods map[string]interface{}
+type Methods map[string]*method


### PR DESCRIPTION
This PR allows resolvers to be marked non-nullable. By default, pointer types will continue to be nullable, but can be marked otherwise.

```golang
object.FieldFunc("optional", function(ctx context.Context) (*User, object) {
  // ...
})

object.FieldFunc("required", function(ctx context.Context) (*User, object) {
  // ...
}, schemabuilder.NonNullable)
```