### PR TITLE
graphql: fix issue where suffixed with Input would fail

### DIFF
--- a/graphql/introspection/test-schema.json
+++ b/graphql/introspection/test-schema.json
@@ -142,7 +142,7 @@
                 "name": "include",
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "UserInput",
+                  "name": "User_InputObject",
                   "ofType": null
                 }
               },
@@ -242,7 +242,7 @@
         ],
         "interfaces": [],
         "kind": "INPUT_OBJECT",
-        "name": "UserInput",
+        "name": "User_InputObject",
         "possibleTypes": []
       },
       {

--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -246,8 +246,8 @@ func makeStructParser(typ reflect.Type) (*argParser, graphql.Type, error) {
 		Name:        typ.Name(),
 		InputFields: make(map[string]graphql.Type),
 	}
-	if argType.Name != "" && !strings.HasSuffix(argType.Name, "Input") {
-		argType.Name += "Input"
+	if argType.Name != "" {
+		argType.Name += "_InputObject"
 	}
 
 	for i := 0; i < typ.NumField(); i++ {


### PR DESCRIPTION
In the case where the same struct is used as both a field and an input argument, AND it was suffixed with `Input`, we would re-use the output types as an input type in the graphql schema. This would cause some tools using the schema output to fail to use the separate introspected types.