### PR TITLE
Parse Selection Args Only Once

### DIFF
--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -90,11 +90,15 @@ func PrepareQuery(typ Type, selectionSet *SelectionSet) error {
 				return NewSafeError(`unknown field "%s"`, selection.Name)
 			}
 
-			parsed, err := field.ParseArguments(selection.Args)
-			if err != nil {
-				return NewSafeError(`error parsing args for "%s": %s`, selection.Name, err)
+			// Only parse args once for a given selection.
+			if !selection.parsed {
+				parsed, err := field.ParseArguments(selection.Args)
+				if err != nil {
+					return NewSafeError(`error parsing args for "%s": %s`, selection.Name, err)
+				}
+				selection.Args = parsed
+				selection.parsed = true
 			}
-			selection.Args = parsed
 
 			if err := PrepareQuery(field.Type, selection.SelectionSet); err != nil {
 				return err

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -140,6 +140,10 @@ type Selection struct {
 	Alias        string
 	Args         interface{}
 	SelectionSet *SelectionSet
+
+	// The parsed flag is used to make sure the args for this Selection are only
+	// parsed once.
+	parsed bool
 }
 
 // A Fragment represents a reusable part of a GraphQL query

--- a/livesql/binlog.go
+++ b/livesql/binlog.go
@@ -88,7 +88,7 @@ func NewBinlog(ldb *LiveDB, host string, port uint16, username, password, databa
 		return nil, err
 	}
 
-	syncer := replication.NewBinlogSyncer(&replication.BinlogSyncerConfig{
+	syncer := replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
 		ServerID: binary.LittleEndian.Uint32(slaveId),
 		Host:     host,
 		Port:     port,


### PR DESCRIPTION
Fixes a bug when the same fragment is used multiple times
in a query and the args of its selections are parsed
multiple times, causing query preparation errors
(I observed [this one](https://github.com/samsarahq/thunder/blob/master/graphql/schemabuilder/reflect.go#L304) specifically).

Tested manually. Also ran all unit tests locally and they passed.