### PR TITLE
Ryanr/scalar: Unwrap pointers to scalar values

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -50,6 +50,28 @@ func TestStripKey(t *testing.T) {
 	}
 }
 
+func TestDiffIntNullable(t *testing.T) {
+	var testcases = []struct {
+		desc         string
+		left         interface{}
+		right        interface{}
+		expectedDiff interface{}
+	}{
+		{"both nil", nil, nil, nil},
+		{"nil, one", nil, 1, 1},
+		{"one, nil", 1, nil, []interface{}{nil}},
+		{"both one", 1, 1, nil},
+	}
+
+	for _, tc := range testcases {
+		d := diff.Diff(tc.left, tc.right)
+		if !reflect.DeepEqual(internal.AsJSON(d), internal.AsJSON(tc.expectedDiff)) {
+			t.Errorf("%s: bad diff: %s", tc.desc, d)
+		}
+	}
+
+}
+
 func TestDiffListOrder(t *testing.T) {
 	d := diff.Diff([]interface{}{
 		map[string]interface{}{"__key": "0"},

--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -60,6 +60,19 @@ func isNilArgs(args interface{}) bool {
 	return args == nil || (ok && len(m) == 0)
 }
 
+// unwrap will return the value associated with a pointer type, or nil if the
+// pointer is nil
+func unwrap(v interface{}) interface{} {
+	i := reflect.ValueOf(v)
+	for i.Kind() == reflect.Ptr && !i.IsNil() {
+		i = i.Elem()
+	}
+	if i.Kind() == reflect.Invalid {
+		return nil
+	}
+	return i.Interface()
+}
+
 // PrepareQuery checks that the given selectionSet matches the schema typ, and
 // parses the args in selectionSet
 func PrepareQuery(typ Type, selectionSet *SelectionSet) error {
@@ -260,7 +273,7 @@ func (e *Executor) execute(ctx context.Context, typ Type, source interface{}, se
 	}
 	switch typ := typ.(type) {
 	case *Scalar:
-		return source, nil
+		return unwrap(source), nil
 	case *Object:
 		return e.executeObject(ctx, typ, source, selectionSet)
 	case *List:


### PR DESCRIPTION
Updates the executor to unwrap pointers to scalar values to their raw values if the pointer is non-nil. This fixes an issue where pointers were being compared when calculating update diffs instead of underlying values leading to unnecessary updates.

Executor and diff tests were updated to verify the correct behavior.