### PR TITLE
Revert "livesql/binlog: update function params"

### DIFF
--- a/livesql/binlog.go
+++ b/livesql/binlog.go
@@ -88,7 +88,7 @@ func NewBinlog(ldb *LiveDB, host string, port uint16, username, password, databa
 		return nil, err
 	}
 
-	syncer := replication.NewBinlogSyncer(replication.BinlogSyncerConfig{
+	syncer := replication.NewBinlogSyncer(&replication.BinlogSyncerConfig{
 		ServerID: binary.LittleEndian.Uint32(slaveId),
 		Host:     host,
 		Port:     port,


### PR DESCRIPTION
This reverts commit a4f4690203e2f2c3e1e6d26d368ec3a02a8dd4b3.

We are worried that this is too much of a breaking change. Instead, consider vendoring to our older version of the go-mysql package.

This PR will break travis, which we should fix separately.