### PR TITLE
Support computation retries without dumping the cache

### DIFF
--- a/graphql/server.go
+++ b/graphql/server.go
@@ -213,6 +213,16 @@ func (c *conn) handleSubscribe(id string, subscribe *subscribeMessage) error {
 			if !initial {
 				// If this a re-computation, tell the Rerunner to retry the computation
 				// without dumping the contents of the current computation cache.
+				// Note that we are swallowing the propagation of the error in this case,
+				// but we still log it.
+				if _, ok := err.(SanitizedError); !ok {
+					extraTags := map[string]string{"retry": "true"}
+					for k, v := range tags {
+						extraTags[k] = v
+					}
+					c.logger.Error(ctx, err, extraTags)
+				}
+
 				return nil, reactive.RetrySentinelError
 			}
 


### PR DESCRIPTION
This PR changes the rerunner to accept a sentinel for retrying the computation without dumping the previously cached results. For graphql subscriptions, it sends this sentinel value for recomputations that fail.

To keep this change backwards compatible, we do not send an error to the client, since some clients may currently expect the `error` message to also signal the end of a subscription. This means we are effectively swallowing the error on the recomputation path.

Test plan
---------
Added a couple tests for the new behaviors.
