### PR TITLE
reactive: fix race/out of order setting for lastRun

### DIFF
--- a/reactive/rerunner.go
+++ b/reactive/rerunner.go
@@ -257,14 +257,13 @@ func (r *Rerunner) run() {
 	r.cache.cleanInvalidated()
 	ctx := context.WithValue(r.ctx, cacheKey{}, r.cache)
 
-	// Run f, and release the old computation right after.
 	computation, err := run(ctx, r.f)
 	r.lastRun = time.Now()
 	if err != nil {
 		if err == RetrySentinelError {
 			r.retryDelay = r.retryDelay * 2
 
-			// Max out the retry delay to at 1 minute
+			// Max out the retry delay to at 1 minute.
 			if r.retryDelay > time.Minute {
 				r.retryDelay = time.Minute
 			}
@@ -275,7 +274,7 @@ func (r *Rerunner) run() {
 			return
 		}
 	} else {
-		// If we succeeded in the computation, we can replace the old computation
+		// If we succeeded in the computation, we can release the old computation
 		// and reset the retry delay.
 		if r.computation != nil {
 			go r.computation.node.release()
@@ -285,7 +284,7 @@ func (r *Rerunner) run() {
 		r.computation = computation
 		r.retryDelay = r.minRerunInterval
 
-		// schedule a rerun whenever our node becomes invalidated (which might already
+		// Schedule a rerun whenever our node becomes invalidated (which might already
 		// have happened!)
 		computation.node.handleInvalidate(r.run)
 	}

--- a/reactive/rerunner.go
+++ b/reactive/rerunner.go
@@ -259,6 +259,7 @@ func (r *Rerunner) run() {
 
 	// Run f, and release the old computation right after.
 	computation, err := run(ctx, r.f)
+	r.lastRun = time.Now()
 	if err != nil {
 		if err == RetrySentinelError {
 			r.retryDelay = r.retryDelay * 2
@@ -288,8 +289,6 @@ func (r *Rerunner) run() {
 		// have happened!)
 		computation.node.handleInvalidate(r.run)
 	}
-
-	r.lastRun = time.Now()
 }
 
 func (r *Rerunner) Stop() {


### PR DESCRIPTION
In both branches, lastRun needs to be set before we scheduled or attempt a new run so that the next run has an accurate delay timer.