### PR TITLE
sqlgen: change batching scheme to not use tuples

### DIFF
--- a/sqlgen/batch_test.go
+++ b/sqlgen/batch_test.go
@@ -30,7 +30,7 @@ func TestMakeBatchQuery(t *testing.T) {
 				{"id_a": 20, "id_b": "bar"},
 				{"id_a": 30, "id_b": "baz"},
 			},
-			Clause: "(id_a, id_b) IN ((?, ?), (?, ?), (?, ?))",
+			Clause: "(id_a=? AND id_b=?) OR (id_a=? AND id_b=?) OR (id_a=? AND id_b=?)",
 			Args:   []interface{}{10, "foo", 20, "bar", 30, "baz"},
 		},
 		{
@@ -52,7 +52,7 @@ func TestMakeBatchQuery(t *testing.T) {
 				{"id_a": 20, "id_b": "bar"},
 				{"id_a": 30, "id_b": "baz"},
 			},
-			Clause: "id IN (?, ?, ?) OR (id_a, id_b) IN ((?, ?), (?, ?), (?, ?))",
+			Clause: "id IN (?, ?, ?) OR (id_a=? AND id_b=?) OR (id_a=? AND id_b=?) OR (id_a=? AND id_b=?)",
 			Args:   []interface{}{10, 20, 30, 10, "foo", 20, "bar", 30, "baz"},
 		},
 	}


### PR DESCRIPTION
MySQL <= 5.6 fails to optimize index usage when using the IN clause with tuples.
This works around that behavior by constructing AND/OR clauses that can be optimized.

I verified manually that simple / simple + complex forms do not scan the entire table for mysql 5.6.

See: https://bugs.mysql.com/bug.php?id=31188