### PR TITLE
diff: do not rearrange identical elements

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -201,15 +201,22 @@ func reorderKey(i interface{}) interface{} {
 // identified using the __key field, if present. Otherwise, the values are used
 // as map keys if they are comparable.
 func computeReorderIndices(old, new []interface{}) []int {
-	oldIndices := make(map[interface{}]int)
+	oldIndices := make(map[interface{}][]int)
 	for i, item := range old {
-		oldIndices[reorderKey(item)] = i
+		key := reorderKey(item)
+		if oldIndices[key] == nil {
+			oldIndices[key] = []int{i}
+		} else {
+			oldIndices[key] = append(oldIndices[key], i)
+		}
 	}
 
 	indices := make([]int, len(new))
 	for i, item := range new {
-		if index, ok := oldIndices[reorderKey(item)]; ok {
-			indices[i] = index
+		key := reorderKey(item)
+		if index, ok := oldIndices[key]; ok {
+			indices[i] = index[0]
+			oldIndices[key] = index[1:]
 		} else {
 			indices[i] = -1
 		}

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -29,6 +29,22 @@ func TestDiffListString(t *testing.T) {
 	}
 }
 
+func TestDiffListRepeatedStrings(t *testing.T) {
+	d := diff.Diff([]interface{}{
+		"1",
+		"2",
+		"1",
+	}, []interface{}{
+		"1",
+		"2",
+		"1",
+	})
+
+	if internal.AsJSON(d) != nil {
+		t.Errorf("expected no diff, but received %s", d)
+	}
+}
+
 func TestStripKey(t *testing.T) {
 	d := diff.StripKey(map[string]interface{}{
 		"__key": "foo",


### PR DESCRIPTION
When elements are identical in the output, do not re-arrange them. Otherwise, this causes unnecessary diffs to be sent to the client.