### PR TITLE
diff: mark root map/array deletions correctly

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -140,6 +140,11 @@ func diffMap(old map[string]interface{}, newAny interface{}) interface{} {
 		return markReplaced(new)
 	}
 
+	// Check if the new map is nil, and mark the entire map replaced if so.
+	if new == nil {
+		return markReplaced(nil)
+	}
+
 	// Check if two map are identical by comparing their pointers, and
 	// short-circuit if so.
 	if reflect.ValueOf(old).Pointer() == reflect.ValueOf(new).Pointer() {
@@ -262,6 +267,11 @@ func diffArray(old []interface{}, newAny interface{}) interface{} {
 	new, ok := newAny.([]interface{})
 	if !ok {
 		return markReplaced(new)
+	}
+
+	// Check if the new array is nil, and mark the entire array replaced if so.
+	if new == nil {
+		return markReplaced(nil)
 	}
 
 	// Check if two arrays are identical by comparing their pointers and length,

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -45,6 +45,31 @@ func TestDiffListRepeatedStrings(t *testing.T) {
 	}
 }
 
+func TestDiffUpdateSliceToNil(t *testing.T) {
+	var emptySlice []interface{}
+	d := diff.Diff([]interface{}{
+		"1",
+		"2",
+		"1",
+	}, emptySlice)
+
+	if !reflect.DeepEqual(internal.AsJSON(d), internal.ParseJSON(`[null]`)) {
+		t.Errorf("expected no diff, but received %s", d)
+	}
+}
+
+func TestDiffUpdateMapToNil(t *testing.T) {
+	var emptyMap map[string]interface{}
+	d := diff.Diff(map[string]interface{}{
+		"__key": "a",
+		"foo":   "bar",
+	}, emptyMap)
+
+	if !reflect.DeepEqual(internal.AsJSON(d), internal.ParseJSON(`[null]`)) {
+		t.Errorf("expected no diff, but received %s", d)
+	}
+}
+
 func TestStripKey(t *testing.T) {
 	d := diff.StripKey(map[string]interface{}{
 		"__key": "foo",


### PR DESCRIPTION
If a map/slice is removed, then we should mark the node as replaced with nil, instead of replaced with an empty map/slice.
