### PR TITLE
[WIP] graphql: support default variables in queries

### DIFF
--- a/graphql/parser.go
+++ b/graphql/parser.go
@@ -36,7 +36,7 @@ func valueToJson(value ast.Value, vars map[string]interface{}) (interface{}, err
 	case *ast.Variable:
 		actual, ok := vars[value.Name.Value]
 		if !ok {
-			return nil, NewClientError("unknown var: %s", value.Name.Value)
+			return nil, nil
 		}
 		return actual, nil
 	case *ast.ObjectValue:

--- a/graphql/parser.go
+++ b/graphql/parser.go
@@ -374,6 +374,24 @@ func Parse(source string, vars map[string]interface{}) (*Query, error) {
 		name = queryDefinition.Name.Value
 	}
 
+	// assert that default value matches variable type
+	// write default values to vars, or nil if variable doesn't exist and default value doesn't exist
+	for _, vd := range queryDefinition.VariableDefinitions {
+		_, ok := vars[vd.Variable.Name.Value]
+		if !ok {
+			// variable was not passed in. check and apply default value.
+			defaultValue := vd.DefaultValue.GetValue()
+			if defaultValue != "" {
+				// default value passed in.
+				// FIXME: cast the default value to the right type. it currently seems to always be string.
+				vars[vd.Variable.Name.Value] = defaultValue
+			} else {
+				// default value not passed in. apply nil.
+				vars[vd.Variable.Name.Value] = nil
+			}
+		}
+	}
+
 	rv := &Query{
 		Name:         name,
 		Kind:         kind,


### PR DESCRIPTION
This doesn't actually work, because variables is used elsewhere outside the call to Parser. And we still need to cast the default value to the proper type.