### PR TITLE
graphql schemabuilder: allow invoking Object twice to extend types

### DIFF
--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -736,19 +736,27 @@ func (sb *schemaBuilder) getType(t reflect.Type) (graphql.Type, error) {
 }
 
 type Schema struct {
-	objects []*Object
+	objects map[string]*Object
 }
 
 func NewSchema() *Schema {
-	return &Schema{}
+	return &Schema{
+		objects: make(map[string]*Object),
+	}
 }
 
 func (s *Schema) Object(name string, typ interface{}) *Object {
+	if object, ok := s.objects[name]; ok {
+		if object.Type != typ {
+			panic("re-registered object with different type")
+		}
+		return object
+	}
 	object := &Object{
 		Name: name,
 		Type: typ,
 	}
-	s.objects = append(s.objects, object)
+	s.objects[name] = object
 	return object
 }
 

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -114,6 +114,11 @@ func TestExecuteGood(t *testing.T) {
 		return []*User{}
 	})
 
+	extendUser := schema.Object("User", User{})
+	extendUser.FieldFunc("extended", func(u User) string {
+		return "extended"
+	})
+
 	weirdKey := schema.Object("weirdKey", WeirdKey{})
 	weirdKey.Key("key")
 	weirdKey.FieldFunc("key", func(w WeirdKey) int64 {
@@ -130,6 +135,7 @@ func TestExecuteGood(t *testing.T) {
 				name
 				foo: age
 				friends { name }
+				extended
 			}
 			ints
 			getCtx
@@ -160,8 +166,8 @@ func TestExecuteGood(t *testing.T) {
 
 	if !reflect.DeepEqual(internal.AsJSON(result), internal.ParseJSON(`
 		{"users": [
-			{"name": "Alice", "foo": 10, "friends": [], "__key": "Alice"},
-			{"name": "Bob", "foo": 20, "friends": [], "__key": "Bob"}
+			{"name": "Alice", "foo": 10, "friends": [], "extended": "extended", "__key": "Alice"},
+			{"name": "Bob", "foo": 20, "friends": [], "extended": "extended", "__key": "Bob"}
 		],
 		"nilObject": null,
 		"nilSlice": [],

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -49,6 +49,9 @@ func (s *Object) FieldFunc(name string, f interface{}, options ...FieldFuncOptio
 		option(m)
 	}
 
+	if _, ok := s.Methods[name]; ok {
+		panic("duplicate method")
+	}
 	s.Methods[name] = m
 }
 


### PR DESCRIPTION
To split large graphql schemas across multiple packages, we need a
mechanism for registering functions on the same type in different
places.

With the approach in this commit, a meta-package can pass the same
schemabuilder.Schema to two different sub-packages that both add fields
to common types.