### PR TITLE
Check variable definition in parse step, support default arguments

### DIFF
--- a/graphql/end_to_end_test.go
+++ b/graphql/end_to_end_test.go
@@ -261,14 +261,4 @@ func TestArgumentOptionality(t *testing.T) {
 		query getMandatory($testArg: int64!) {
 			mandatory(x: $testArg)
 		}`, filledVariables, `{"mandatory": 5}`)
-
-	// A mandatory argument that is omitted causes an error.
-	q := graphql.MustParse(`
-		query getMandatory($testArg: int64!) {
-			mandatory(x: $testArg)
-		}`, emptyVariables)
-
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err.Error() != "error parsing args for \"mandatory\": x: not a number" {
-		t.Error(err)
-	}
 }

--- a/graphql/parser.go
+++ b/graphql/parser.go
@@ -368,6 +368,14 @@ func Parse(source string, vars map[string]interface{}) (*Query, error) {
 		return nil, NewClientError("must have a single query")
 	}
 
+	for _, variableDefinition := range queryDefinition.VariableDefinitions {
+		if _, ok := variableDefinition.Type.(*ast.NonNull); ok {
+			if vars[variableDefinition.Variable.Name.Value] == nil {
+				return nil, NewClientError("required variable not provided: $%s", variableDefinition.Variable.Name.Value)
+			}
+		}
+	}
+
 	kind := queryDefinition.Operation
 	var name string
 	if queryDefinition.Name != nil {

--- a/graphql/parser.go
+++ b/graphql/parser.go
@@ -368,12 +368,50 @@ func Parse(source string, vars map[string]interface{}) (*Query, error) {
 		return nil, NewClientError("must have a single query")
 	}
 
+	// Parse variable definitions, default values, etc.
+	var defaultedVars map[string]interface{}
 	for _, variableDefinition := range queryDefinition.VariableDefinitions {
+		name := variableDefinition.Variable.Name.Value
+
 		if _, ok := variableDefinition.Type.(*ast.NonNull); ok {
-			if vars[variableDefinition.Variable.Name.Value] == nil {
-				return nil, NewClientError("required variable not provided: $%s", variableDefinition.Variable.Name.Value)
+			if variableDefinition.DefaultValue != nil {
+				return nil, NewClientError("required varaible cannot provide a default value: $%s", name)
 			}
+
+			if vars[name] == nil {
+				return nil, NewClientError("required variable not provided: $%s", name)
+			}
+
+			continue
 		}
+
+		if variableDefinition.DefaultValue != nil {
+			// Ignore default if the value exists.
+			if vars[name] != nil {
+				continue
+			}
+
+			// Lazily initialize defaultedVars if needed.
+			if defaultedVars == nil {
+				defaultedVars = make(map[string]interface{})
+				for k, v := range vars {
+					defaultedVars[k] = v
+				}
+			}
+
+			// TODO: properly implement coerceValue.
+			// See: https://github.com/graphql/graphql-js/blob/17a0bfd5292f39cafe4eec5b3bd0e22514243b68/src/execution/values.js#L84
+			val, err := valueToJson(variableDefinition.DefaultValue, nil)
+			if err != nil {
+				return nil, NewClientError("failed to parse default value: %s", err.Error())
+			}
+
+			defaultedVars[name] = val
+		}
+	}
+
+	if defaultedVars != nil {
+		vars = defaultedVars
 	}
 
 	kind := queryDefinition.Operation

--- a/graphql/parser_test.go
+++ b/graphql/parser_test.go
@@ -248,3 +248,14 @@ fragment foo on Foo {
 		t.Error("expected unused fragment to fail", err)
 	}
 }
+
+func TestParseNullVariableDefinitions(t *testing.T) {
+	_, err := Parse(`
+query Operation($x: int64!) {
+	field(x: $x)
+}	`, map[string]interface{}{})
+
+	if err == nil || err.Error() != "required variable not provided: $x" {
+		t.Error("expected unfulfilled required argument to fail, but got", err)
+	}
+}


### PR DESCRIPTION
This PR adds support for checking that non-null operation variables are correctly passed in, fixing #70.

It also adds base support for default values.