### PR TITLE
diff: support diffing byte slices []uint8

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -79,6 +79,7 @@
 package diff
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 )
@@ -310,6 +311,11 @@ func Diff(old interface{}, new interface{}) interface{} {
 		return diffMap(old, new)
 	case []interface{}:
 		return diffArray(old, new)
+	case []uint8:
+		if new, ok := new.([]uint8); ok && bytes.Equal(old, new) {
+			return nil
+		}
+		return markReplaced(new)
 	default:
 		if old != new {
 			return markReplaced(new)

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -29,6 +29,22 @@ func TestDiffListString(t *testing.T) {
 	}
 }
 
+func TestDiffBytes(t *testing.T) {
+	d := diff.Diff([]interface{}{
+		[]byte("123"),
+		[]byte("456"),
+	}, []interface{}{
+		[]byte("123"),
+		[]byte("789"),
+	})
+
+	if !reflect.DeepEqual(internal.AsJSON(d), internal.ParseJSON(`
+		{"1": ["Nzg5"]}
+	`)) {
+		t.Error("bad reorder")
+	}
+}
+
 func TestDiffListRepeatedStrings(t *testing.T) {
 	var testcases = []struct {
 		old  interface{}


### PR DESCRIPTION
They show up in JSON sometimes to encode binary as base64 data. Allow
that.