### PR TITLE
graphql: use reflect.TypeOf to compare types instead of directly comp…

### DIFF
--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -747,7 +747,7 @@ func NewSchema() *Schema {
 
 func (s *Schema) Object(name string, typ interface{}) *Object {
 	if object, ok := s.objects[name]; ok {
-		if object.Type != typ {
+		if reflect.TypeOf(object.Type) != reflect.TypeOf(typ) {
 			panic("re-registered object with different type")
 		}
 		return object


### PR DESCRIPTION
…aring type in Object

Process of elimination:
```
> reflect.TypeOf(object)
  *schemabuilder.Object
> typ
  {0 0 0 <nil> false 0 false 0 0 0 0   [] [] false 0 0 0   <nil>  0 0 0 false 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC <nil> 0001-01-01 00:00:00 +0000 UTC 0 0 0      0 0 false   0 0}
> reflect.TypeOf(object.Type)
  models.Device
> object.Type
  {0 0 0 <nil> false 0 false 0 0 0 0   [] [] false 0 0 0   <nil>  0 0 0 false 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC <nil> 0001-01-01 00:00:00 +0000 UTC 0 0 0      0 0 false   0 0}
> reflect.TypeOf(typ)
  models.Device
```

TODO
- [ ] update or write a test for this