### PR TITLE
Provide a non-live http interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,33 @@ func main() {
 }
 ```
 
+## Using Thunder without Websockets (POST requests)
+
+For use with non-live clients (e.g. [Relay](https://facebook.github.io/relay/), [Apollo](https://www.apollographql.com/client/)) thunder provides an HTTP handler that can serve
+POST requests, instead of having the client connect over a websocket. In this mode, thunder
+does not provide live query updates.
+
+In the above example, the `main` function would be changed to look like:
+
+```go
+func main() {
+  // Instantiate a server, build a server, and serve the schema on port 3030.
+  server := &server{
+    posts: []post{
+      {Title: "first post!", Body: "I was here first!", CreatedAt: time.Now()},
+      {Title: "graphql", Body: "did you hear about Thunder?", CreatedAt: time.Now()},
+    },
+  }
+
+  schema := server.schema()
+  introspection.AddIntrospectionToSchema(schema)
+
+  // Expose GraphQL POST endpoint.
+  http.Handle("/graphql", graphql.HTTPHandler(schema))
+  http.ListenAndServe(":3030", nil)
+}
+```
+
 ## Code organization
 
 The source code in this repository is organized as follows:

--- a/graphql/http.go
+++ b/graphql/http.go
@@ -1,0 +1,121 @@
+package graphql
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sync"
+
+	"github.com/samsarahq/thunder/batch"
+	"github.com/samsarahq/thunder/reactive"
+)
+
+func HTTPHandler(schema *Schema, middlewares ...MiddlewareFunc) http.Handler {
+	return &httpHandler{
+		schema:      schema,
+		middlewares: middlewares,
+	}
+}
+
+type httpHandler struct {
+	schema      *Schema
+	middlewares []MiddlewareFunc
+}
+
+type httpPostBody struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables"`
+}
+
+type httpResponse struct {
+	Data   interface{} `json:"data"`
+	Errors []string    `json:"errors"`
+}
+
+func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	writeResponse := func(value interface{}, err error) {
+		response := httpResponse{}
+		if err != nil {
+			response.Errors = []string{err.Error()}
+		} else {
+			response.Data = value
+		}
+
+		responseJSON, err := json.Marshal(response)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		http.Error(w, string(responseJSON), http.StatusOK)
+	}
+
+	if r.Method != "POST" {
+		writeResponse(nil, errors.New("request must be a POST"))
+		return
+	}
+
+	if r.Body == nil {
+		writeResponse(nil, errors.New("request must include a query"))
+		return
+	}
+
+	var params httpPostBody
+	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+		writeResponse(nil, err)
+		return
+	}
+
+	query, err := Parse(params.Query, params.Variables)
+	if err != nil {
+		writeResponse(nil, err)
+		return
+	}
+
+	if err := PrepareQuery(h.schema.Query, query.SelectionSet); err != nil {
+		writeResponse(nil, err)
+		return
+	}
+
+	var wg sync.WaitGroup
+	e := Executor{}
+
+	wg.Add(1)
+	runner := reactive.NewRerunner(r.Context(), func(ctx context.Context) (interface{}, error) {
+		defer wg.Done()
+
+		ctx = batch.WithBatching(ctx)
+
+		var middlewares []MiddlewareFunc
+		middlewares = append(middlewares, h.middlewares...)
+		middlewares = append(middlewares, func(input *ComputationInput, next MiddlewareNextFunc) *ComputationOutput {
+			output := next(input)
+			output.Current, output.Error = e.Execute(input.Ctx, h.schema.Query, nil, input.ParsedQuery)
+			return output
+		})
+
+		output := runMiddlewares(middlewares, &ComputationInput{
+			Ctx:         ctx,
+			ParsedQuery: query,
+			Query:       params.Query,
+			Variables:   params.Variables,
+		})
+		current, err := output.Current, output.Error
+
+		if err != nil {
+			if extractPathError(err) == context.Canceled {
+				return nil, err
+			}
+
+			writeResponse(nil, err)
+			return nil, err
+		}
+
+		writeResponse(current, nil)
+		return nil, nil
+	}, MinRerunInterval)
+
+	wg.Wait()
+	runner.Stop()
+}

--- a/graphql/http_test.go
+++ b/graphql/http_test.go
@@ -1,0 +1,98 @@
+package graphql_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+
+	"github.com/samsarahq/thunder/graphql"
+	"github.com/samsarahq/thunder/graphql/schemabuilder"
+)
+
+func testHTTPRequest(req *http.Request) *httptest.ResponseRecorder {
+	schema := schemabuilder.NewSchema()
+
+	query := schema.Query()
+	query.FieldFunc("mirror", func(args struct{ Value int64 }) int64 {
+		return args.Value * -1
+	})
+
+	builtSchema := schema.MustBuild()
+
+	rr := httptest.NewRecorder()
+	handler := graphql.HTTPHandler(builtSchema)
+
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestHTTPMustPost(t *testing.T) {
+	req, err := http.NewRequest("GET", "/graphql", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := testHTTPRequest(req)
+
+	if rr.Code != 200 {
+		t.Errorf("expected 200, but received %d", rr.Code)
+	}
+
+	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"request must be a POST\"]}\n"); diff != "" {
+		t.Errorf("expected response to match, but received %s", diff)
+	}
+}
+
+func TestHTTPParseQuery(t *testing.T) {
+	req, err := http.NewRequest("POST", "/graphql", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := testHTTPRequest(req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, but received %d", rr.Code)
+	}
+
+	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"request must include a query\"]}\n"); diff != "" {
+		t.Errorf("expected response to match, but received %s", diff)
+	}
+}
+
+func TestHTTPMustHaveQuery(t *testing.T) {
+	req, err := http.NewRequest("POST", "/graphql", strings.NewReader(`{"query":""}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := testHTTPRequest(req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, but received %d", rr.Code)
+	}
+
+	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"must have a single query\"]}\n"); diff != "" {
+		t.Errorf("expected response to match, but received %s", diff)
+	}
+}
+
+func TestHTTPSuccess(t *testing.T) {
+	req, err := http.NewRequest("POST", "/graphql", strings.NewReader(`{"query": "query TestQuery($value: int64) { mirror(value: $value) }", "variables": { "value": 1 }}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := testHTTPRequest(req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, but received %d", rr.Code)
+	}
+
+	if diff := pretty.Compare(rr.Body.String(), "{\"data\":{\"mirror\":-1},\"errors\":null}\n"); diff != "" {
+		t.Errorf("expected response to match, but received %s", diff)
+	}
+}


### PR DESCRIPTION
This PR provides an http interface to use thunder for those who do not want to use websockets/live queries but still like all of our other sweet features.