### PR TITLE
graphql: parse name/kind before variables

### DIFF
--- a/graphql/parser_test.go
+++ b/graphql/parser_test.go
@@ -268,7 +268,7 @@ query Operation($x: int64! = 2) {
 	field(x: $x)
 }	`, map[string]interface{}{})
 
-	if err == nil || err.Error() != "required varaible cannot provide a default value: $x" {
+	if err == nil || err.Error() != "required variable cannot provide a default value: $x" {
 		t.Error("expected required argument with default value to fail, but got", err)
 	}
 }


### PR DESCRIPTION
This PR changes the parser to parser the query kind/name earlier so that it will show up in case of client parsing errors.