### PR TITLE
concurrencylimiter: bound number of concurrently running resolvers

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/samsarahq/thunder/concurrencylimiter"
 )
 
 // DefaultWaitInterval is the default WaitInterval for Func.
@@ -225,8 +227,10 @@ func (f *Func) Invoke(ctx context.Context, arg interface{}) (interface{}, error)
 		close(bg.doneCh)
 
 	} else {
-		// Wait for the result.
-		<-bg.doneCh
+		concurrencylimiter.Block(ctx, func() {
+			// Wait for the result.
+			<-bg.doneCh
+		})
 	}
 
 	// Return the local result.

--- a/concurrencylimiter/concurrencylimiter.go
+++ b/concurrencylimiter/concurrencylimiter.go
@@ -1,0 +1,120 @@
+package concurrencylimiter
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// A limiter allows goroutines to run with bounded concurrency.
+type limiter struct {
+	// ch limits concurrency by having a bounded capacity. To run a goroutine must
+	// write to ch. This takes up a spot in the channel. After stopping, the
+	// goroutine must read from ch, which frees up a spot in the channel for
+	// another goroutine to run.
+	ch chan struct{}
+}
+
+// limiterKey is the context key used for limiter structs.
+type limiterKey struct{}
+
+// With attaches a new limiter to the context with the given limit.
+func With(ctx context.Context, limit int) context.Context {
+	return context.WithValue(ctx, limiterKey{}, &limiter{
+		ch: make(chan struct{}, limit),
+	})
+}
+
+// holderKey is the context key used for holder structs.
+type holderKey struct{}
+
+// Holder describes the status of a goroutine that has called Acquire. The
+// holder struct is used to refer back to the limiter and to temporarily release
+// the goroutine's token during calls to block.
+//
+// It is impossible to enforce that every goroutine makes it own call to Acquire,
+// so the holder gracefully handles the case where multiple concurrent goroutines
+// call block: Only one of them will release the token, and the other goroutines
+// will run independently. That's not ideal, but an alternative design that
+// lets the other goroutines hang might cause surprise breakages when a context
+// is shared between goroutines.
+type holder struct {
+	l *limiter
+
+	// status tracks if the holder currently has an in item in l.ch. Before
+	// modifying l.ch, first status must be modified using an atomic operation.
+	// This is the concurrency control.
+	status int64
+}
+
+const (
+	acquired = iota
+	blocked
+	released
+)
+
+// release gives up the holder's spot in ch.
+func (h *holder) release() {
+	// If we currently are acquired, release the token. Otherwise, we are either
+	// blocked or already released.
+	if atomic.SwapInt64(&h.status, released) == acquired {
+		<-h.l.ch
+	}
+}
+
+// block temporarily gives up the holder's spot in ch while running f.
+func (h *holder) block(f func()) {
+	// If we are currently acquired, temporarily release the token. Otherwise,
+	// we are either blocked or released.
+	if atomic.CompareAndSwapInt64(&h.status, acquired, blocked) {
+		<-h.l.ch
+
+		// Before returning from f() we must reacquire.
+		defer func() {
+			// If we are still blocked, re-acquire. Otherwise, we just got got released
+			// (and that release used our token we gave up), and should no longer try to
+			// re-acquire.
+			if atomic.CompareAndSwapInt64(&h.status, blocked, acquired) {
+				h.l.ch <- struct{}{}
+			}
+		}()
+	}
+
+	f()
+}
+
+// A ReleaseFunc releases a concurrency limiter token.
+type ReleaseFunc func()
+
+// Acquire acquires a concurrency limiter token. If the context is canceled or
+// if there is no concurrency limit associated with the context it succeeds
+// immediately and returns a no-op release function.
+func Acquire(ctx context.Context) (context.Context, ReleaseFunc) {
+	l, ok := ctx.Value(limiterKey{}).(*limiter)
+	if !ok {
+		return ctx, func() {}
+	}
+
+	select {
+	case l.ch <- struct{}{}:
+	case <-ctx.Done():
+		return ctx, func() {}
+	}
+
+	h := &holder{
+		l:      l,
+		status: acquired,
+	}
+	ctx = context.WithValue(ctx, holderKey{}, h)
+
+	return ctx, h.release
+}
+
+// TemporarilyRelease temporarily releases a concurrency limiter token (if any)
+// while calling a long-running but no-resource-using function f.
+func TemporarilyRelease(ctx context.Context, f func()) {
+	if h, ok := ctx.Value(holderKey{}).(*holder); ok {
+		h.block(f)
+	} else {
+		f()
+	}
+}

--- a/concurrencylimiter/concurrencylimiter_test.go
+++ b/concurrencylimiter/concurrencylimiter_test.go
@@ -1,0 +1,219 @@
+package concurrencylimiter_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/samsarahq/thunder/concurrencylimiter"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestConcurrencyLimiter tests that the concurrency is limited.
+func TestConcurrencyLimiter(t *testing.T) {
+	ctx := concurrencylimiter.With(context.Background(), 2)
+
+	var mu sync.Mutex
+	count := 0
+	maxCount := 0
+
+	// Run 4 goroutines that sleep for 100ms, track how many are running at once.
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			_, release := concurrencylimiter.Acquire(ctx)
+			defer release()
+
+			mu.Lock()
+			count++
+			if count > maxCount {
+				maxCount = count
+			}
+			mu.Unlock()
+
+			time.Sleep(100 * time.Millisecond)
+
+			mu.Lock()
+			count--
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	assert.True(t, maxCount <= 2)
+}
+
+// TestNonLimitedTemporarilyRelease tests that calls to block allow other
+// threads to run.
+func TestNonLimitedTemporarilyRelease(t *testing.T) {
+	ctx := concurrencylimiter.With(context.Background(), 2)
+
+	var mu sync.Mutex
+	count := 0
+	maxCount := 0
+	ran := 0
+	any := false
+
+	// Run 4 goroutines that sleep for 100ms, track how many are running at once.
+	// The first calls sleep in TemporarilyRelease and should not be counted
+	// against the concurrency limit.
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			ctx, release := concurrencylimiter.Acquire(ctx)
+			defer release()
+
+			mu.Lock()
+			count++
+			if count > maxCount {
+				maxCount = count
+			}
+			first := !any
+			any = true
+			mu.Unlock()
+
+			f := func() {
+				time.Sleep(100 * time.Millisecond)
+				mu.Lock()
+				ran++
+				mu.Unlock()
+			}
+
+			if first {
+				concurrencylimiter.TemporarilyRelease(ctx, f)
+			} else {
+				f()
+			}
+
+			mu.Lock()
+			count--
+			mu.Unlock()
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, 3, maxCount)
+	assert.Equal(t, 4, ran)
+}
+
+// TestDoubleTemporarilyRelease calls TemporarilyRelease twice on the same
+// context. Both should run at the same time.
+func TestDoubleTemporarilyRelease(t *testing.T) {
+	ctx := concurrencylimiter.With(context.Background(), 1)
+	ctx, release := concurrencylimiter.Acquire(ctx)
+	defer release()
+
+	var mu sync.Mutex
+	count := 0
+	maxCount := 0
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			concurrencylimiter.TemporarilyRelease(ctx, func() {
+				mu.Lock()
+				count++
+				if count > maxCount {
+					maxCount = count
+				}
+				mu.Unlock()
+
+				time.Sleep(100 * time.Millisecond)
+
+				mu.Lock()
+				count--
+				mu.Unlock()
+			})
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 2, maxCount)
+}
+
+// TestTemporarilyReleaseAfterRelease calls TemporarilyRelease after Release. It should run without
+// problems.
+func TestTemporarilyReleaseAfterRelease(t *testing.T) {
+	ctx := concurrencylimiter.With(context.Background(), 1)
+	ctx, release := concurrencylimiter.Acquire(ctx)
+	release()
+
+	ran := false
+
+	concurrencylimiter.TemporarilyRelease(ctx, func() {
+		ran = true
+	})
+
+	assert.True(t, ran)
+}
+
+// TestTemporarilyReleaseAfterRelease calls TemporarilyRelease without a
+// Limiter. It should run without problems.
+func TestTemporarilyReleaseWithoutLimit(t *testing.T) {
+	ctx := context.Background()
+
+	ran := false
+
+	concurrencylimiter.TemporarilyRelease(ctx, func() {
+		ran = true
+	})
+
+	assert.True(t, ran)
+}
+
+// TestReleaseDuringTemporarilyRelease calls Release and TemporarilyRelease in a
+// race. It should not impact the running TemporarilyRelease.
+func TestReleaseDuringTemporarilyRelease(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		ctx := concurrencylimiter.With(context.Background(), 1)
+		ctx, release := concurrencylimiter.Acquire(ctx)
+
+		var wg sync.WaitGroup
+		ran := false
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			release()
+		}()
+		go func() {
+			defer wg.Done()
+			concurrencylimiter.TemporarilyRelease(ctx, func() {
+				ran = true
+			})
+		}()
+		wg.Wait()
+
+		assert.True(t, ran)
+	}
+}
+
+// TestAcquireContextCanceled tests that Acquire returns when a context is
+// canceled.
+func TestAcquireContextCanceled(t *testing.T) {
+	ctx := concurrencylimiter.With(context.Background(), 0)
+
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	ctx, release := concurrencylimiter.Acquire(ctx)
+	release()
+}
+
+// TestAcquireReleaseNoLimiter tests that Acquire returns when the context
+// has no limiter.
+func TestAcquireReleaseNoLimiter(t *testing.T) {
+	ctx := context.Background()
+
+	ctx, release := concurrencylimiter.Acquire(ctx)
+	release()
+}


### PR DESCRIPTION
The new concurrencylimiter package lets the graphql executor limit the number
of resolvers that are running at the same time. It integrates with the batch
package to allow resolvers that are joining a batched call to unblock other
resolvers.

All of this is opt-in using the concurrencylimiter.With call. Otherwise
everything behaves like before.