### PR TITLE
graphql: add support for metadata on incoming envelopes

### DIFF
--- a/graphql/middleware.go
+++ b/graphql/middleware.go
@@ -11,6 +11,7 @@ type ComputationInput struct {
 	Variables   map[string]interface{}
 	Ctx         context.Context
 	Previous    interface{}
+	Extensions  map[string]interface{}
 }
 
 type ComputationOutput struct {


### PR DESCRIPTION
Useful for passing arbitrary metadata down. For instance, we can use this to send request ids or trace ids down to the server.

Other ideas for this kind of mechanism are welcome.