### PR TITLE
Revert "graphql: check for required operation variables"

### DIFF
--- a/graphql/parser.go
+++ b/graphql/parser.go
@@ -390,10 +390,6 @@ func Parse(source string, vars map[string]interface{}) (*Query, error) {
 				return rv, NewClientError("required variable cannot provide a default value: $%s", name)
 			}
 
-			if vars[name] == nil {
-				return rv, NewClientError("required variable not provided: $%s", name)
-			}
-
 			continue
 		}
 

--- a/graphql/parser_test.go
+++ b/graphql/parser_test.go
@@ -249,18 +249,6 @@ fragment foo on Foo {
 	}
 }
 
-func TestParseVariableDefinitions(t *testing.T) {
-	// Expect required variables to be provided.
-	_, err := Parse(`
-query Operation($x: int64!) {
-	field(x: $x)
-}	`, map[string]interface{}{})
-
-	if err == nil || err.Error() != "required variable not provided: $x" {
-		t.Error("expected unfulfilled required argument to fail, but got", err)
-	}
-}
-
 func TestParseRequiredVariableDefinitionWithDefaultValue(t *testing.T) {
 	// Expect required variables to be provided.
 	_, err := Parse(`


### PR DESCRIPTION
This reverts commit 7828561be8596c2904b42ba681684067466513f4. The reverted commit is technically a breaking change since the old server did not validate these problems.