### PR TITLE
graphql schemabuilder: gracefully fail if wrong argument type is passed

### DIFF
--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -251,7 +251,7 @@ func makeStructParser(typ reflect.Type) (*argParser, graphql.Type, error) {
 	}
 
 	if typ.Kind() != reflect.Struct {
-		return nil, nil, fmt.Errorf("expected arguments struct but received type %s", typ.Name())
+		return nil, nil, fmt.Errorf("expected struct but received type %s", typ.Name())
 	}
 
 	for i := 0; i < typ.NumField(); i++ {
@@ -407,7 +407,7 @@ func (sb *schemaBuilder) buildFunction(typ reflect.Type, m *method) (*graphql.Fi
 		hasArgs = true
 		var err error
 		if argParser, argType, err = makeStructParser(in[0]); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("attempted to parse %s as arguments struct, but failed: %s", in[0].Name(), err.Error())
 		}
 		in = in[1:]
 	}

--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -250,6 +250,10 @@ func makeStructParser(typ reflect.Type) (*argParser, graphql.Type, error) {
 		argType.Name += "_InputObject"
 	}
 
+	if typ.Kind() != reflect.Struct {
+		return nil, nil, fmt.Errorf("expected arguments struct but received type %s", typ.Name())
+	}
+
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)
 		if field.PkgPath != "" && !field.Anonymous {

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -479,7 +479,7 @@ func TestBadArguments(t *testing.T) {
 		return 1, nil
 	})
 
-	if _, err := schema.Build(); err.Error() != "bad method aField on type schemabuilder.query: expected arguments struct but received type int64" {
-		t.Error("expected non-struct args argument to fail")
+	if _, err := schema.Build(); err.Error() != "bad method aField on type schemabuilder.query: attempted to parse int64 as arguments struct, but failed: expected struct but received type int64" {
+		t.Errorf("expected non-struct args argument to fail, but received %s", err.Error())
 	}
 }

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -471,3 +471,15 @@ func TestArgParser(t *testing.T) {
 		t.Error("expected unsupported fields to fail")
 	}
 }
+
+func TestBadArguments(t *testing.T) {
+	schema := NewSchema()
+	query := schema.Query()
+	query.FieldFunc("aField", func(context context.Context, shouldBeAStruct int64) (int64, error) {
+		return 1, nil
+	})
+
+	if _, err := schema.Build(); err.Error() != "bad method aField on type schemabuilder.query: expected arguments struct but received type int64" {
+		t.Error("expected non-struct args argument to fail")
+	}
+}


### PR DESCRIPTION
cc/ @jbicket

It's a little tricky to provide a better message in case the caller is actually intending the parent "source" instead of an arguments struct since the function signature is overloaded. This at least helps with identifying what field is wrong.

Before, this would just panic and not identify the bad field.