### PR TITLE
graphql: by default, use passed schema as mutation schema

### DIFF
--- a/graphql/server.go
+++ b/graphql/server.go
@@ -518,6 +518,7 @@ func CreateConnection(ctx context.Context, socket JSONSocket, schema *Schema, op
 		socket:             socket,
 		ctx:                ctx,
 		schema:             schema,
+		mutationSchema:     schema,
 		subscriptions:      make(map[string]*reactive.Rerunner),
 		subscriptionLogger: &nopSubscriptionLogger{},
 		logger:             &nopGraphqlLogger{},


### PR DESCRIPTION
Otherwise, the whole thing panics.

Let's also add a test for this later.