### PR TITLE
graphql/enum types added and tests modified

### DIFF
--- a/example/minimal/main.go
+++ b/example/minimal/main.go
@@ -13,9 +13,11 @@ import (
 type Server struct {
 }
 
+type RoleType int32
 type User struct {
 	FirstName string
 	LastName  string
+	Role      RoleType
 }
 
 func (s *Server) registerUser(schema *schemabuilder.Schema) {
@@ -29,15 +31,26 @@ func (s *Server) registerUser(schema *schemabuilder.Schema) {
 func (s *Server) registerQuery(schema *schemabuilder.Schema) {
 	object := schema.Query()
 
-	object.FieldFunc("users", func(ctx context.Context) ([]*User, error) {
+	var tmp RoleType
+	schema.Enum(tmp, map[string]interface{}{
+		"user":          RoleType(1),
+		"manager":       RoleType(2),
+		"administrator": RoleType(3),
+	})
+
+	object.FieldFunc("users", func(ctx context.Context, args struct {
+		EnumField RoleType
+	}) ([]*User, error) {
 		return []*User{
 			{
 				FirstName: "Bob",
 				LastName:  "Johnson",
+				Role:      args.EnumField,
 			},
 			{
 				FirstName: "Chloe",
 				LastName:  "Kim",
+				Role:      args.EnumField,
 			},
 		}, nil
 	})
@@ -48,6 +61,12 @@ func (s *Server) registerMutation(schema *schemabuilder.Schema) {
 
 	object.FieldFunc("echo", func(ctx context.Context, args struct{ Text string }) (string, error) {
 		return args.Text, nil
+	})
+
+	object.FieldFunc("echoEnum", func(ctx context.Context, args struct {
+		EnumField RoleType
+	}) (RoleType, error) {
+		return args.EnumField, nil
 	})
 }
 

--- a/graphql/introspection/introspection_test.go
+++ b/graphql/introspection/introspection_test.go
@@ -16,9 +16,14 @@ type User struct {
 	MaybeAge *int64
 }
 
+type enumType int32
+
 func makeSchema() *schemabuilder.Schema {
 	schema := schemabuilder.NewSchema()
-
+	var enumField enumType
+	schema.Enum(enumField, map[string]interface{}{
+		"random": enumType(1),
+	})
 	query := schema.Query()
 	query.FieldFunc("me", func() User {
 		return User{Name: "me"}
@@ -42,8 +47,9 @@ func makeSchema() *schemabuilder.Schema {
 		return nil
 	})
 	user.FieldFunc("greet", func(args struct {
-		Other   string
-		Include *User
+		Other     string
+		Include   *User
+		Enumfield enumType
 	}) string {
 		return ""
 	})

--- a/graphql/introspection/test-schema.json
+++ b/graphql/introspection/test-schema.json
@@ -139,6 +139,20 @@
               {
                 "defaultValue": null,
                 "description": "",
+                "name": "enumfield",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "enumType",
+                    "ofType": null
+                  }
+                }
+              },
+              {
+                "defaultValue": null,
+                "description": "",
                 "name": "include",
                 "type": {
                   "kind": "INPUT_OBJECT",
@@ -253,6 +267,23 @@
         "interfaces": [],
         "kind": "SCALAR",
         "name": "bool",
+        "possibleTypes": []
+      },
+      {
+        "description": "",
+        "enumValues": [
+          {
+            "deprecationReason": "",
+            "description": "1",
+            "isDeprecated": false,
+            "name": "random"
+          }
+        ],
+        "fields": [],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "ENUM",
+        "name": "enumType",
         "possibleTypes": []
       },
       {

--- a/graphql/parser.go
+++ b/graphql/parser.go
@@ -33,6 +33,8 @@ func valueToJson(value ast.Value, vars map[string]interface{}) (interface{}, err
 		return value.Value, nil
 	case *ast.BooleanValue:
 		return value.Value, nil
+	case *ast.EnumValue:
+		return value.Value, nil
 	case *ast.Variable:
 		actual, ok := vars[value.Name.Value]
 		if !ok {

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -20,10 +20,12 @@ type Root struct {
 	Bytes []byte
 	Alias alias
 }
+type userEnum int64
 
 type User struct {
-	Name string `graphql:",key"`
-	Age  int
+	Name   string `graphql:",key"`
+	Age    int
+	userID userEnum
 }
 
 type WeirdKey struct {
@@ -35,7 +37,13 @@ func panicFunction() int64 {
 
 func TestExecuteGood(t *testing.T) {
 	schema := NewSchema()
-
+	type enumType int32
+	var enumVar enumType
+	schema.Enum(enumVar, map[string]interface{}{
+		"first":  enumType(1),
+		"second": enumType(2),
+		"third":  enumType(3),
+	})
 	query := schema.Query()
 	query.FieldFunc("users", func() []*User {
 		return []*User{

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -318,7 +318,8 @@ func testArgParseBad(t *testing.T, p *argParser, input interface{}) {
 }
 
 func TestArgParser(t *testing.T) {
-	parser, _, err := makeArgParser(reflect.TypeOf(kitchenSinkArgs{}))
+	sb := &schemaBuilder{}
+	parser, _, err := sb.makeArgParser(reflect.TypeOf(kitchenSinkArgs{}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -459,15 +460,15 @@ func TestArgParser(t *testing.T) {
 		}
 	`))
 
-	if _, _, err := makeArgParser(reflect.TypeOf(&duplicate{})); err == nil {
+	if _, _, err := sb.makeArgParser(reflect.TypeOf(&duplicate{})); err == nil {
 		t.Error("expected duplicate fields to fail")
 	}
 
-	if _, _, err := makeArgParser(reflect.TypeOf(&anonymous{})); err == nil {
+	if _, _, err := sb.makeArgParser(reflect.TypeOf(&anonymous{})); err == nil {
 		t.Error("expected anonymous fields to fail")
 	}
 
-	if _, _, err := makeArgParser(reflect.TypeOf(&unsupported{})); err == nil {
+	if _, _, err := sb.makeArgParser(reflect.TypeOf(&unsupported{})); err == nil {
 		t.Error("expected unsupported fields to fail")
 	}
 }

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -26,6 +26,23 @@ func (s *Scalar) String() string {
 	return s.Type
 }
 
+// Enum is a leaf value
+type Enum struct {
+	Type       string
+	Values     []string
+	ReverseMap map[interface{}]string
+}
+
+func (e *Enum) isType() {}
+
+func (e *Enum) String() string {
+	return e.Type
+}
+
+func (e *Enum) enumValues() []string {
+	return e.Values
+}
+
 // Object is a value with several fields
 type Object struct {
 	Name        string
@@ -79,6 +96,7 @@ var _ Type = &Object{}
 var _ Type = &List{}
 var _ Type = &InputObject{}
 var _ Type = &NonNull{}
+var _ Type = &Enum{}
 
 // A Resolver calculates the value of a field of an object
 type Resolver func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error)


### PR DESCRIPTION
files in graphql/ changed to support enum types. 
example/minimal/main.go changed to test for enums.
tests in end_to_end_test.go are modified however they do not check for mapped values yet.