### PR TITLE
graphql/schemabuilder: change enumMap argument to an interface so tha…

### DIFF
--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/internal"
+	"github.com/stretchr/testify/assert"
 )
 
 type alias int64
@@ -193,6 +194,36 @@ func TestExecuteGood(t *testing.T) {
 		}`)) {
 		t.Error("bad value")
 	}
+}
+
+func TestEnumMapWrongArg(t *testing.T) {
+	schema := NewSchema()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Error("expected a panic")
+		}
+		assert.Equal(t, "Enum function not passed a map", r)
+	}()
+	type enumType int32
+	schema.Enum(enumType(1), int32(1))
+
+}
+
+func TestEnumMapKeys(t *testing.T) {
+	schema := NewSchema()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Error("expected a panic")
+		}
+		assert.Equal(t, "keys are not strings", r)
+	}()
+	type enumType int32
+	schema.Enum(enumType(1), map[int32]int32{
+		1: 1,
+	})
+
 }
 
 func TestExecuteErrorNullReturn(t *testing.T) {


### PR DESCRIPTION
changed enumMap argument to interface type so that an additional function isn't needed to convert maps to a specific type. The type checking is delayed to runtime.