### PR TITLE
Fix <Query> shouldComponentUpdate

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/jest": "^23.1.1",
     "@types/node": "^10.3.4",
+    "@types/react-dom": "^16.0.6",
     "babel-cli": "^6.26.0",
     "babel-env": "^2.4.1",
     "babel-plugin-external-helpers": "^6.22.0",
@@ -28,6 +29,7 @@
     "jest": "^23.1.0",
     "prettier": "^1.13.0",
     "react": "^16.4.1",
+    "react-dom": "^16.4.1",
     "rollup": "^0.60.1",
     "rollup-plugin-babel": "^3.0.4",
     "rollup-plugin-commonjs": "^9.1.3",

--- a/client/src/query.tsx
+++ b/client/src/query.tsx
@@ -111,8 +111,8 @@ class GraphQLRenderer<
   ) {
     const { query, variables } = nextProps;
     if (
-      isEqual(query, this.state.query) &&
-      isEqual(variables, this.state.variables)
+      isEqual(query, this.props.query) &&
+      isEqual(variables, this.props.variables)
     ) {
       return;
     }

--- a/client/src/tests/query.spec.tsx
+++ b/client/src/tests/query.spec.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Query } from "../query";
+import { ThunderProvider } from "../context";
+import { Connection } from "../connection";
+import { render } from "react-dom";
+
+describe("fixtures", () => {
+  test("shouldComponentUpdate", () => {
+    const connection = new Connection(
+      async () => new WebSocket("ws://localhost"),
+    );
+    let subscribeCalls = 0;
+    connection.subscribe = (() => {
+      subscribeCalls++;
+      return {
+        close: () => {},
+        data: () => ({}),
+      };
+    }) as any;
+
+    const initialProps = { x: 1 };
+
+    const node = document.createElement("div");
+    render(
+      <ThunderProvider connection={connection}>
+        <Query<{}, { x: number }> query={"query"} variables={initialProps}>
+          {data => <div />}
+        </Query>
+      </ThunderProvider>,
+      node,
+    );
+
+    // newProps are deep equal, but not referentially equal.
+    const newProps = { x: 1 };
+    render(
+      <ThunderProvider connection={connection}>
+        <Query<{}, { x: number }> query={"query"} variables={newProps}>
+          {data => <div />}
+        </Query>
+      </ThunderProvider>,
+      node,
+    );
+
+    expect(subscribeCalls).toStrictEqual(1);
+
+    const newerProps = { x: 2 };
+    render(
+      <ThunderProvider connection={connection}>
+        <Query<{}, { x: number }> query={"query"} variables={newerProps}>
+          {data => <div />}
+        </Query>
+      </ThunderProvider>,
+      node,
+    );
+
+    expect(subscribeCalls).toStrictEqual(2);
+  });
+});

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -42,6 +42,19 @@
   version "10.3.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.4.tgz#c74e8aec19e555df44609b8057311052a2c84d9e"
 
+"@types/react-dom@^16.0.6":
+  version "16.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.6.tgz#f1a65a4e7be8ed5d123f8b3b9eacc913e35a1a3c"
+  dependencies:
+    "@types/node" "*"
+    "@types/react" "*"
+
+"@types/react@*":
+  version "16.4.6"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.6.tgz#5024957c6bcef4f02823accf5974faba2e54fada"
+  dependencies:
+    csstype "^2.2.0"
+
 "@types/react@^16.3.17":
   version "16.3.17"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.17.tgz#d59d1a632570b0713946ed9c2949d994773633c5"
@@ -3615,6 +3628,15 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-dom@^16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react@^16.4.1:
   version "16.4.1"


### PR DESCRIPTION
This PR fixes a bug we've seen where queries get unsubscribed and then re-subscribed before their data even comes in. This ends up happening because the props to the component change, and this check is faulty. It compares the next props with the query/variables stored in `this.state`, but the state is only ever set when new data comes in.

This means that if the props (even superficially) change before the first data loads, then the component starts over.

We've seen in production that this disproportionately affects queries that are already slow.