### PR TITLE
Add union type support

### DIFF
--- a/graphql/introspection/introspection_test.go
+++ b/graphql/introspection/introspection_test.go
@@ -16,6 +16,22 @@ type User struct {
 	MaybeAge *int64
 }
 
+type Vehicle struct {
+	Name  string
+	Speed int64
+}
+type Asset struct {
+	Name         string
+	BatteryLevel int64
+}
+
+type Gateway struct {
+	schemabuilder.Union
+
+	*Vehicle
+	*Asset
+}
+
 type enumType int32
 
 func makeSchema() *schemabuilder.Schema {
@@ -42,6 +58,10 @@ func makeSchema() *schemabuilder.Schema {
 		return nil, nil
 	})
 	query.PaginateFieldFunc("usersConnectionPtr", func() ([]*User, error) {
+		return nil, nil
+	})
+
+	query.FieldFunc("gateway", func() (*Gateway, error) {
 		return nil, nil
 	})
 

--- a/graphql/introspection/test-schema.json
+++ b/graphql/introspection/test-schema.json
@@ -17,6 +17,70 @@
             "deprecationReason": "",
             "description": "",
             "isDeprecated": false,
+            "name": "batteryLevel",
+            "type": {
+              "kind": "NON_NULL",
+              "name": "",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "int64",
+                "ofType": null
+              }
+            }
+          },
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "name",
+            "type": {
+              "kind": "NON_NULL",
+              "name": "",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "string",
+                "ofType": null
+              }
+            }
+          }
+        ],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "OBJECT",
+        "name": "Asset",
+        "possibleTypes": []
+      },
+      {
+        "description": "",
+        "enumValues": [],
+        "fields": [],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "UNION",
+        "name": "Gateway",
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "Asset",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "Vehicle",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "description": "",
+        "enumValues": [],
+        "fields": [
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
             "name": "sayHi",
             "type": {
               "kind": "NON_NULL",
@@ -248,6 +312,18 @@
         "description": "",
         "enumValues": [],
         "fields": [
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "gateway",
+            "type": {
+              "kind": "UNION",
+              "name": "Gateway",
+              "ofType": null
+            }
+          },
           {
             "args": [],
             "deprecationReason": "",
@@ -568,6 +644,49 @@
         "interfaces": [],
         "kind": "INPUT_OBJECT",
         "name": "User_InputObject",
+        "possibleTypes": []
+      },
+      {
+        "description": "",
+        "enumValues": [],
+        "fields": [
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "name",
+            "type": {
+              "kind": "NON_NULL",
+              "name": "",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "string",
+                "ofType": null
+              }
+            }
+          },
+          {
+            "args": [],
+            "deprecationReason": "",
+            "description": "",
+            "isDeprecated": false,
+            "name": "speed",
+            "type": {
+              "kind": "NON_NULL",
+              "name": "",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "int64",
+                "ofType": null
+              }
+            }
+          }
+        ],
+        "inputFields": [],
+        "interfaces": [],
+        "kind": "OBJECT",
+        "name": "Vehicle",
         "possibleTypes": []
       },
       {

--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -1031,19 +1031,19 @@ func NewSchema() *Schema {
 // the corresponding map of the enums.
 //
 // For example a enum could be declared as follows:
-// type enumType int32
-// const (
-//	one   enumType = 1
-//	two   enumType = 2
-//	three enumType = 3
-// )
+//   type enumType int32
+//   const (
+//	  one   enumType = 1
+//	  two   enumType = 2
+//	  three enumType = 3
+//   )
 //
 // Then the Enum can be registered as:
-// s.Enum(enumType(1), map[string]interface{}{
-//	"one":   enumType(1),
-//	"two":   enumType(2),
-//	"three": enumType(3),
-// })
+//   s.Enum(enumType(1), map[string]interface{}{
+//     "one":   enumType(1),
+//     "two":   enumType(2),
+//     "three": enumType(3),
+//   })
 func (s *Schema) Enum(val interface{}, enumMap interface{}) {
 	typ := reflect.TypeOf(val)
 	if s.enumTypes == nil {

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -80,3 +80,18 @@ type method struct {
 
 // A Methods map represents the set of methods exposed on a Object.
 type Methods map[string]*method
+
+// Union is a special marker struct that can be embedded into to denote
+// that a type should be treated as a union type by the schemabuilder.
+//
+// For example, to denote that a return value that may be a *Asset or
+// *Vehicle might look like:
+// type GatewayUnion struct {
+//   graphql.Union
+//   *Asset
+//   *Vehicle
+// }
+//
+// Fields returning a union type should expect to return this type as a
+// one-hot struct, i.e. only Asset or Vehicle should be specified, but not both.
+type Union struct{}

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -66,9 +66,9 @@ func (s *Object) FieldFunc(name string, f interface{}, options ...FieldFuncOptio
 // Key registers the key field on an object. The field should be specified by the name of the
 // graphql field.
 // For example, for an object User:
-// type struct User {
-//	 UserKey int64
-// }
+//   type struct User {
+//	   UserKey int64
+//   }
 // The key will be registered as:
 // object.Key("userKey")
 func (s *Object) Key(f string) {
@@ -88,11 +88,11 @@ type Methods map[string]*method
 //
 // For example, to denote that a return value that may be a *Asset or
 // *Vehicle might look like:
-// type GatewayUnion struct {
-//   graphql.Union
-//   *Asset
-//   *Vehicle
-// }
+//   type GatewayUnion struct {
+//     graphql.Union
+//     *Asset
+//     *Vehicle
+//   }
 //
 // Fields returning a union type should expect to return this type as a
 // one-hot struct, i.e. only Asset or Vehicle should be specified, but not both.

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -1,5 +1,7 @@
 package schemabuilder
 
+import "reflect"
+
 // A Object represents a Go type and set of methods to be converted into an
 // Object in a GraphQL schema.
 type Object struct {
@@ -95,3 +97,5 @@ type Methods map[string]*method
 // Fields returning a union type should expect to return this type as a
 // one-hot struct, i.e. only Asset or Vehicle should be specified, but not both.
 type Union struct{}
+
+var unionType = reflect.TypeOf(Union{})

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -90,6 +90,19 @@ func (n *NonNull) String() string {
 	return fmt.Sprintf("%s!", n.Type)
 }
 
+// Union is a option between multiple types
+type Union struct {
+	Name        string
+	Description string
+	Types       map[string]*Object
+}
+
+func (*Union) isType() {}
+
+func (u *Union) String() string {
+	return u.Name
+}
+
 // Verify *Scalar, *Object, *List, *InputObject, and *NonNull implement Type
 var _ Type = &Scalar{}
 var _ Type = &Object{}
@@ -97,6 +110,7 @@ var _ Type = &List{}
 var _ Type = &InputObject{}
 var _ Type = &NonNull{}
 var _ Type = &Enum{}
+var _ Type = &Union{}
 
 // A Resolver calculates the value of a field of an object
 type Resolver func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error)

--- a/graphql/union_test.go
+++ b/graphql/union_test.go
@@ -1,0 +1,299 @@
+package graphql_test
+
+import (
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/samsarahq/thunder/graphql"
+	"github.com/samsarahq/thunder/graphql/schemabuilder"
+	"github.com/samsarahq/thunder/internal"
+)
+
+type GatewayType int
+
+const (
+	GatewayType_Vehicle GatewayType = iota
+	GatewayType_Asset
+)
+
+func TestUnionType(t *testing.T) {
+	type Vehicle struct {
+		Name  string
+		Speed int64
+	}
+	type Asset struct {
+		Name         string
+		BatteryLevel int64
+	}
+
+	type Gateway struct {
+		schemabuilder.Union
+
+		*Vehicle
+		*Asset
+	}
+
+	schema := schemabuilder.NewSchema()
+	query := schema.Query()
+	schema.Enum(GatewayType(0), map[string]GatewayType{
+		"vehicle": 0,
+		"asset":   1,
+	})
+
+	query.FieldFunc("gateway", func(args struct{ Type GatewayType }) (*Gateway, error) {
+		if args.Type == GatewayType_Vehicle {
+			return &Gateway{
+				Vehicle: &Vehicle{Name: "a", Speed: 50},
+			}, nil
+		}
+
+		return &Gateway{
+			Asset: &Asset{Name: "b", BatteryLevel: 5},
+		}, nil
+	})
+
+	builtSchema := schema.MustBuild()
+
+	ctx := context.Background()
+
+	q := graphql.MustParse(`
+		{
+			asset: gateway(type: "asset") { __typename ... on Asset { name batteryLevel } ... on Vehicle { name speed } }
+			vehicle: gateway(type: "vehicle") { ... on Asset { name batteryLevel } ... on Vehicle { name speed } }
+		}
+	`, map[string]interface{}{"var": float64(3)})
+
+	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+		t.Error(err)
+	}
+
+	e := graphql.Executor{}
+
+	result, err := e.Execute(ctx, builtSchema.Query, nil, q)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if d := pretty.Compare(internal.AsJSON(result), internal.ParseJSON(`
+		{"vehicle": { "name": "a", "speed": 50 }, "asset": { "name": "b", "batteryLevel": 5, "__typename": "Gateway" }}`)); d != "" {
+		t.Errorf("expected did not match result: %s", d)
+	}
+}
+
+type UnionPart1 struct{ OtherThing string }
+type UnionPart2 struct{ Thing string }
+
+type UnionMarkerPtrType struct {
+	*schemabuilder.Union
+
+	*UnionPart1
+	*UnionPart2
+}
+
+func TestBadUnionMarkerPtr(t *testing.T) {
+	schema := schemabuilder.NewSchema()
+	query := schema.Query()
+	query.FieldFunc("union", func() (*UnionMarkerPtrType, error) {
+		return nil, nil
+	})
+
+	_, err := schema.Build()
+	if err == nil {
+		t.Fatalf("expected error, received nil")
+	}
+	if !strings.Contains(err.Error(), "schemabuilder.Union can only be used as an embedded anonymous non-pointer struct") {
+		t.Errorf("expected error, received %s", err.Error())
+	}
+}
+
+type UnionWithNonAnonymousPtrType struct {
+	Something *schemabuilder.Union
+
+	*UnionPart1
+	*UnionPart2
+}
+
+func TestBadUnionNonAnonymousPtr(t *testing.T) {
+	schema := schemabuilder.NewSchema()
+	query := schema.Query()
+	query.FieldFunc("union", func() (*UnionWithNonAnonymousPtrType, error) {
+		return nil, nil
+	})
+
+	_, err := schema.Build()
+	if err == nil {
+		t.Fatalf("expected error, received nil")
+	}
+
+	if !strings.Contains(err.Error(), "schemabuilder.Union can only be used as an embedded anonymous non-pointer struct") {
+		t.Errorf("expected error, received %s", err.Error())
+	}
+}
+
+type UnionNonAnonymousMembersType struct {
+	schemabuilder.Union
+
+	A *UnionPart1
+	B *UnionPart2
+}
+
+func TestBadUnionNonAnonymousMembers(t *testing.T) {
+	schema := schemabuilder.NewSchema()
+	query := schema.Query()
+	query.FieldFunc("union", func() (*UnionNonAnonymousMembersType, error) {
+		return nil, nil
+	})
+
+	_, err := schema.Build()
+	if err == nil {
+		t.Fatalf("expected error, received nil")
+	}
+
+	if !strings.Contains(err.Error(), "union type member types must be anonymous") {
+		t.Errorf("expected error, received %s", err.Error())
+	}
+}
+
+func TestNonPointerOneHot(t *testing.T) {
+	type UnionType struct {
+		schemabuilder.Union
+
+		UnionPart1
+		UnionPart2
+	}
+
+	schema := schemabuilder.NewSchema()
+	query := schema.Query()
+	query.FieldFunc("union", func() (*UnionType, error) {
+		return nil, nil
+	})
+
+	_, err := schema.Build()
+	if err == nil {
+		t.Fatalf("expected error, received nil")
+	}
+
+	if !strings.Contains(err.Error(), "union type member must be a pointer to a struct") {
+		t.Errorf("expected error, received %s", err.Error())
+	}
+}
+
+func TestBadUnionNonOneHot(t *testing.T) {
+	type UnionType struct {
+		schemabuilder.Union
+
+		*UnionPart1
+		*UnionPart2
+	}
+
+	schema := schemabuilder.NewSchema()
+	query := schema.Query()
+	query.FieldFunc("union", func() (*UnionType, error) {
+		return &UnionType{UnionPart1: &UnionPart1{}, UnionPart2: &UnionPart2{}}, nil
+	})
+
+	builtSchema := schema.MustBuild()
+	ctx := context.Background()
+
+	q := graphql.MustParse(`{ union { __typename } }`, map[string]interface{}{"var": float64(3)})
+
+	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+		t.Error(err)
+	}
+
+	e := graphql.Executor{}
+	_, err := e.Execute(ctx, builtSchema.Query, nil, q)
+	if err == nil {
+		t.Error("expected err, received nil")
+	}
+
+	if !strings.Contains(err.Error(), "union type field should only return one value") {
+		t.Errorf("expected err, received %s", err.Error())
+	}
+}
+
+func TestUnionList(t *testing.T) {
+	type UnionType struct {
+		schemabuilder.Union
+
+		*UnionPart1
+		*UnionPart2
+	}
+
+	schema := schemabuilder.NewSchema()
+	query := schema.Query()
+	query.FieldFunc("list", func() ([]*UnionType, error) {
+		return []*UnionType{
+			&UnionType{UnionPart2: &UnionPart2{"b"}},
+			&UnionType{UnionPart1: &UnionPart1{"a"}},
+		}, nil
+	})
+
+	builtSchema := schema.MustBuild()
+	ctx := context.Background()
+
+	q := graphql.MustParse(`{ list { ... on UnionPart1 { otherThing } ... on UnionPart2 { thing } } }`, map[string]interface{}{"var": float64(3)})
+
+	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+		t.Error(err)
+	}
+
+	e := graphql.Executor{}
+	result, err := e.Execute(ctx, builtSchema.Query, nil, q)
+	if err != nil {
+		t.Errorf("expected no error, received %s", err.Error())
+	}
+
+	log.Println(internal.AsJSON(result))
+
+	if d := pretty.Compare(internal.AsJSON(result), internal.ParseJSON(`
+		{ "list": [{"thing": "b"}, { "otherThing": "a" } ] }`)); d != "" {
+		t.Errorf("expected did not match result: %s", d)
+	}
+}
+
+func TestUnionStruct(t *testing.T) {
+	type UnionType struct {
+		schemabuilder.Union
+
+		*UnionPart1
+		*UnionPart2
+	}
+
+	type WrapperType struct {
+		X *UnionType
+	}
+
+	schema := schemabuilder.NewSchema()
+	query := schema.Query()
+	query.FieldFunc("wrapper", func() (*WrapperType, error) {
+		return &WrapperType{
+			X: &UnionType{UnionPart2: &UnionPart2{"b"}},
+		}, nil
+	})
+
+	builtSchema := schema.MustBuild()
+	ctx := context.Background()
+
+	q := graphql.MustParse(`{ wrapper { x {... on UnionPart1 { otherThing } ... on UnionPart2 { thing } } } }`, map[string]interface{}{"var": float64(3)})
+
+	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+		t.Error(err)
+	}
+
+	e := graphql.Executor{}
+	result, err := e.Execute(ctx, builtSchema.Query, nil, q)
+	if err != nil {
+		t.Errorf("expected no error, received %s", err.Error())
+	}
+
+	log.Println(internal.AsJSON(result))
+
+	if d := pretty.Compare(internal.AsJSON(result), internal.ParseJSON(`
+		{ "wrapper": { "x": { "thing": "b"} } }`)); d != "" {
+		t.Errorf("expected did not match result: %s", d)
+	}
+}


### PR DESCRIPTION
This PR adds graphql union type support. Union types are approximated by using a special marker in a return type, `schemabuilder.Union`. Embedding this marker signals to the schemabuilder that the return type is a one-hot union.

### API
```golang
type GatewayUnion struct {
  graphql.Union

  // One-hot fields must be pointer type. Also must be anonymous.
  *models.Gateway
  *models.Vehicle
}
```

An example resolver might look like:
```golang
query.FieldFunc("gateway", func(args struct{ Type GatewayType }) (*Gateway, error) {
	if args.Type == GatewayType_Vehicle {
		return &Gateway{
			Asset: &models.Asset{Name: "b", BatteryLevel: 5},
		}, nil
	}

	return &Gateway{
		Vehicle: &models.Vehicle{Name: "a", Speed: 50},
	}, nil
})
```