### PR TITLE
go sqlgen: tests were failing for the wrong reasons

### DIFF
--- a/sqlgen/reflect_test.go
+++ b/sqlgen/reflect_test.go
@@ -95,11 +95,11 @@ func TestRegisterType(t *testing.T) {
 		t.Error("expected duplicate fields to fail")
 	}
 
-	if err := s.RegisterType("e", AutoIncrement, &anonymous{}); err == nil {
+	if err := s.RegisterType("e", AutoIncrement, anonymous{}); err == nil {
 		t.Error("expected anonymous fields to fail")
 	}
 
-	if err := s.RegisterType("f", AutoIncrement, &unsupported{}); err == nil {
+	if err := s.RegisterType("f", AutoIncrement, unsupported{}); err == nil {
 		t.Error("expected unsupported fields to fail")
 	}
 }


### PR DESCRIPTION
These tests were failing because they are pointers to structs. They now fail for the right reasons.