### PR TITLE
Support GraphQL errors as in GraphQL spec

### DIFF
--- a/graphql/http.go
+++ b/graphql/http.go
@@ -29,15 +29,34 @@ type httpPostBody struct {
 }
 
 type httpResponse struct {
-	Data   interface{} `json:"data"`
-	Errors []string    `json:"errors"`
+	Data   interface{}   `json:"data"`
+	Errors []interface{} `json:"errors"`
 }
 
 func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	writeResponse := func(value interface{}, err error) {
 		response := httpResponse{}
 		if err != nil {
-			response.Errors = []string{err.Error()}
+			if ge, ok := err.(GQLError); ok {
+				gqlError := map[string]interface{}{
+					"message": ge.Error(),
+				}
+
+				if ge.locations != nil {
+					gqlError["locations"] = ge.locations
+				}
+				if ge.path != nil {
+					gqlError["path"] = ge.path
+				}
+				if ge.extensions != nil {
+					gqlError["extensions"] = ge.extensions
+				}
+
+				response.Errors = []interface{}{gqlError}
+			} else {
+				response.Errors = []interface{}{err.Error()}
+			}
+
 		} else {
 			response.Data = value
 		}

--- a/graphql/server.go
+++ b/graphql/server.go
@@ -99,6 +99,13 @@ type SanitizedError interface {
 	SanitizedError() string
 }
 
+type GQLError struct {
+	message    string
+	locations  *[]map[string]interface{}
+	path       *[]interface{}
+	extensions *map[string]interface{}
+}
+
 type SafeError struct {
 	message string
 }
@@ -121,12 +128,29 @@ func (e SafeError) SanitizedError() string {
 	return e.message
 }
 
+func (e GQLError) SanitizedError() string {
+	return e.message
+}
+
+func (e GQLError) Error() string {
+	return e.message
+}
+
 func NewClientError(format string, a ...interface{}) error {
 	return ClientError{message: fmt.Sprintf(format, a...)}
 }
 
 func NewSafeError(format string, a ...interface{}) error {
 	return SafeError{message: fmt.Sprintf(format, a...)}
+}
+
+func NewGQLError(message string, locations *[]map[string]interface{}, path *[]interface{}, extensions *map[string]interface{}) error {
+	return GQLError{
+		message:    message,
+		locations:  locations,
+		path:       path,
+		extensions: extensions,
+	}
 }
 
 func sanitizeError(err error) string {


### PR DESCRIPTION
Following issue #148, what about something like that that could avoid introducing a breaking change and still handle valid GraphQL errors as in official GraphQL specification ? 

I've implemented it on HTTP only for the moment (as a proof of concept) and it could definitely be improved by doing things similar to path errors ...

If it's something interesting for you, I'll pursue on that direction.