### PR TITLE
Add benchmarks to SQLGen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - go get github.com/mattn/goveralls
   - docker-compose -f ci/docker-compose.yml up -d
 
-script: "go test -v ./... -coverprofile=coverage.out -covermode=atomic"
+script: "go test -v ./... -coverprofile=coverage.out -covermode=atomic -bench=./..."
 
 after_success:
   - "$GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken=$COVERALLS_TOKEN"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - go get github.com/mattn/goveralls
   - docker-compose -f ci/docker-compose.yml up -d
 
-script: "go test -v ./... -coverprofile=coverage.out -covermode=count"
+script: "go test -v ./... -coverprofile=coverage.out -covermode=atomic"
 
 after_success:
   - "$GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken=$COVERALLS_TOKEN"


### PR DESCRIPTION
Benchmark output:

```
goos: darwin
goarch: amd64
pkg: github.com/samsarahq/thunder/sqlgen
Benchmark/Read-8         	    5000	    358456 ns/op	    1766 B/op	      45 allocs/op
Benchmark/Create-8       	    2000	    677856 ns/op	    1104 B/op	      23 allocs/op
Benchmark/Update-8       	    2000	    682379 ns/op	    1488 B/op	      30 allocs/op
Benchmark/Delete-8       	    2000	    626050 ns/op	     592 B/op	      16 allocs/op
```