### PR TITLE
doc comments corrected for schemabuilder union

### DIFF
--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -89,7 +89,7 @@ type Methods map[string]*method
 // For example, to denote that a return value that may be a *Asset or
 // *Vehicle might look like:
 //   type GatewayUnion struct {
-//     graphql.Union
+//     schemabuilder.Union
 //     *Asset
 //     *Vehicle
 //   }


### PR DESCRIPTION
Changed the embeddable Union type to appropriate type in the GoDoc comments.