### PR TITLE
go sqlgen: support nullable (pointer) sql.Scanners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## [0.3.0] - 2018-08-27
+
+### Changed
+
+#### `sqlgen`
+
+- Pointer scanners are no longer allowed to handle `nil`, are forcefully set to
+  `nil` instead.
+
+### Removed
+
+#### `fields`
+
+- Removed `Scanner.Interface()`: this should never have been exposed and
+  wouldn't work the way you would expect it to. Instead, you can only copy to an
+  existing `reflect.Value`.
+
+
 ## [0.2.0] - 2018-08-23
 
 ### Added

--- a/fields/descriptor.go
+++ b/fields/descriptor.go
@@ -62,6 +62,7 @@ func (d Descriptor) copy(from, to reflect.Value, isValid bool) {
 	}
 
 	if !isValid {
+		to.Set(reflect.Zero(to.Type()))
 		return
 	}
 

--- a/fields/sql.go
+++ b/fields/sql.go
@@ -117,14 +117,6 @@ type Scanner struct {
 	isValid bool
 }
 
-// Interface returns the value deserialized into the scanner.
-func (s Scanner) Interface() interface{} {
-	if s.value.IsValid() {
-		return s.value.Interface()
-	}
-	return nil
-}
-
 // CopyTo copies the scanner value to another reflect.Value. This is used for setting structs.
 func (s *Scanner) CopyTo(to reflect.Value) {
 	s.copy(s.value, to, s.isValid)

--- a/fields/sql.go
+++ b/fields/sql.go
@@ -148,16 +148,28 @@ func (s *Scanner) Scan(src interface{}) error {
 	// Our value however should continue referencing a non-pointer for easier assignment.
 	s.value = s.value.Elem()
 
+	// Keep track of whether our value was empty.
+	s.isValid = src != nil
+
 	// If our interface supports sql.Scanner we can immediately short-circuit as this is what the
 	// MySQL driver would do.
 	if scanner, ok := i.(sql.Scanner); ok {
+		// If the scanner base type is nullable (pointer or one of the below), make it nil,
+		// otherwise allow it to scan and handle nil.
+		if s.Ptr && src == nil {
+			return nil
+		}
+		switch s.Kind {
+		case reflect.Chan, reflect.Map, reflect.Func, reflect.Interface, reflect.Slice:
+			if src == nil {
+				return nil
+			}
+		}
+
 		// If we have a scanner it will handle its own validity.
 		s.isValid = true
 		return scanner.Scan(src)
 	}
-
-	// Keep track of whether our value was empty.
-	s.isValid = src != nil
 
 	// Null values are simply set to zero. Because we're not holding on to pointers, we need to
 	// represent this as a boolean. This comes _after_ the scanner step, just in case the scanner

--- a/fields/sql_test.go
+++ b/fields/sql_test.go
@@ -131,53 +131,69 @@ func TestField_Value(t *testing.T) {
 func TestField_Scan(t *testing.T) {
 	time := time.Now()
 	cases := []struct {
+		Type  interface{}
 		In    interface{}
 		Out   interface{}
 		Tag   string
 		Error bool
 	}{
 		// Native types:
-		{Out: "foo", In: "foo"},
-		{Out: []byte("foo"), In: []byte("foo")},
-		{Out: int64(200), In: int64(200)},
-		{Out: float64(200), In: float64(200)},
-		{Out: true, In: true},
-		{Out: time, In: time},
+		{Type: "", Out: "foo", In: "foo"},
+		{Type: []byte{}, Out: []byte("foo"), In: []byte("foo")},
+		{Type: int64(0), Out: int64(200), In: int64(200)},
+		{Type: float64(0), Out: float64(200), In: float64(200)},
+		{Type: true, Out: true, In: true},
+		{Type: time, Out: time, In: time},
 		// Type aliases:
-		{Out: likeString("foo"), In: "foo"},
-		{Out: int8(5), In: int64(5)},
-		{Out: int16(5), In: int64(5)},
-		{Out: int32(5), In: int64(5)},
-		{Out: likeInt(5), In: int64(5)},
-		{Out: float32(5), In: float64(5)},
-		{Out: likeFloat(5), In: float64(5)},
+		{Type: likeString(""), Out: likeString("foo"), In: "foo"},
+		{Type: int8(5), Out: int8(5), In: int64(5)},
+		{Type: int16(5), Out: int16(5), In: int64(5)},
+		{Type: int32(5), Out: int32(5), In: int64(5)},
+		{Type: likeInt(5), Out: likeInt(5), In: int64(5)},
+		{Type: float32(5), Out: float32(5), In: float64(5)},
+		{Type: likeFloat(5), Out: likeFloat(5), In: float64(5)},
 		// Interfaces without tags:
-		{Out: ifaceScanner{[]byte("scan me")}, In: []byte("scan me")},
-		{Out: ifaceValuer{}, In: []byte("value"), Error: true},
-		{Out: ifaceMarshal{}, In: ifaceMarshal{}, Error: true},
-		{Out: ifaceBinaryMarshal{}, In: ifaceBinaryMarshal{}, Error: true},
-		{Out: ifaceTextMarshal{}, In: ifaceTextMarshal{}, Error: true},
-		{Out: ifaceJSONMarshal{}, In: ifaceJSONMarshal{}, Error: true},
+		{Type: ifaceScanner{[]byte("scan me")}, Out: ifaceScanner{[]byte("scan me")}, In: []byte("scan me")},
+		{Type: ifaceMarshal{}, Out: ifaceMarshal{}, In: []byte{}, Error: true},
+		{Type: ifaceBinaryMarshal{}, Out: ifaceBinaryMarshal{}, In: []byte{}, Error: true},
+		{Type: ifaceTextMarshal{}, Out: ifaceTextMarshal{}, In: []byte{}, Error: true},
+		{Type: ifaceJSONMarshal{}, Out: ifaceJSONMarshal{}, In: []byte{}, Error: true},
+		// Pointer scanner with nil:
+		{Type: &ifaceScanner{}, Out: (*ifaceScanner)(nil), In: nil},
+		// Pointer scanner with value:
+		{Type: &ifaceScanner{}, Out: &ifaceScanner{[]byte("scan me")}, In: []byte("scan me")},
 		// Interfaces with tags:
-		{Out: ifaceMarshal{"binary_one"}, In: []byte("binary_one"), Tag: "binary"},
-		{Out: ifaceBinaryMarshal{"binary_two"}, In: []byte("binary_two"), Tag: "binary"},
-		{Out: ifaceTextMarshal{"text"}, In: []byte("text"), Tag: "string"},
-		{Out: ifaceJSONMarshal{[]string{"json"}}, In: []byte("[\"json\"]"), Tag: "json"},
+		{Type: ifaceMarshal{"binary_one"}, Out: ifaceMarshal{"binary_one"}, In: []byte("binary_one"), Tag: "binary"},
+		{Type: ifaceBinaryMarshal{"binary_two"}, Out: ifaceBinaryMarshal{"binary_two"}, In: []byte("binary_two"), Tag: "binary"},
+		{Type: ifaceTextMarshal{"text"}, Out: ifaceTextMarshal{"text"}, In: []byte("text"), Tag: "string"},
+		{Type: ifaceJSONMarshal{[]string{"json"}}, Out: ifaceJSONMarshal{[]string{"json"}}, In: []byte("[\"json\"]"), Tag: "json"},
+		// Pointer interfaces with tags with nil:
+		{Type: &ifaceMarshal{}, Out: (*ifaceMarshal)(nil), In: nil, Tag: "binary"},
+		{Type: &ifaceBinaryMarshal{}, Out: (*ifaceBinaryMarshal)(nil), In: nil, Tag: "binary"},
+		{Type: &ifaceTextMarshal{}, Out: (*ifaceTextMarshal)(nil), In: nil, Tag: "string"},
+		{Type: &ifaceJSONMarshal{}, Out: (*ifaceJSONMarshal)(nil), In: nil, Tag: "json"},
+		// Pointer interfaces with tags with value:
+		{Type: &ifaceMarshal{}, Out: &ifaceMarshal{"binary_one"}, In: []byte("binary_one"), Tag: "binary"},
+		{Type: &ifaceBinaryMarshal{}, Out: &ifaceBinaryMarshal{"binary_two"}, In: []byte("binary_two"), Tag: "binary"},
+		{Type: &ifaceTextMarshal{}, Out: &ifaceTextMarshal{"text"}, In: []byte("text"), Tag: "string"},
+		{Type: &ifaceJSONMarshal{}, Out: &ifaceJSONMarshal{[]string{"json"}}, In: []byte("[\"json\"]"), Tag: "json"},
 	}
 
 	for i, c := range cases {
-		typ := reflect.TypeOf(c.Out)
+		typ := reflect.TypeOf(c.Type)
 		field := fields.New(typ, []string{c.Tag})
 		scanner := field.Scanner()
 
 		err := scanner.Scan(c.In)
-		out := scanner.Interface()
+		out := reflect.New(typ).Elem()
+		scanner.CopyTo(out)
+		got := out.Interface()
 
 		if c.Error {
 			assert.NotNil(t, err, "case %d failed", i)
 		} else {
 			assert.NoError(t, err, "case %d failed", i)
-			assert.Equal(t, c.Out, out, "case %d failed", i)
+			assert.Equal(t, c.Out, got, "case %d failed", i)
 		}
 	}
 }

--- a/fields/sql_test.go
+++ b/fields/sql_test.go
@@ -229,5 +229,7 @@ func TestField_SupportsProtobuf(t *testing.T) {
 
 	scanner := descriptor.Scanner()
 	scanner.Scan(b)
-	assert.Equal(t, *event, scanner.Interface())
+	got := reflect.New(reflect.TypeOf(event)).Elem()
+	scanner.CopyTo(got)
+	assert.Equal(t, event, got.Interface())
 }

--- a/sqlgen/reflect.go
+++ b/sqlgen/reflect.go
@@ -70,11 +70,6 @@ func BuildStruct(table *Table, scanners []*fields.Scanner) interface{} {
 	for i, column := range table.Columns {
 		// These values are all copies (as opposed to references) of database values.
 		// This means there's no funky business that can happen with the database re-using pointers.
-		value := scanners[i].Interface()
-		if value == nil {
-			continue
-		}
-
 		scanners[i].CopyTo(elem.FieldByIndex(column.Index))
 	}
 


### PR DESCRIPTION
Currently, the only way to make sql.Scanner nullable is either by using the sql.NullBool pattern (where we break up the value into `IsValid` and `Bool`/whatever type).

This is because the single de-reference method can't overwrite the pointer to be a null pointer. We also can't define two methods (one for single de-reference and one for double de-reference), so the developer story starts looking a little messy.

In order to support nullable custom types (for real), we will handle `nil` on behalf of the scanner if it's a pointer.

**Side Effect: Remove `Scanner.Interface()`**

This method was exclusively being used in test at this point and won't properly set `nil` for pointers. In order to prevent bad behavior, we need to remove this method.