### PR TITLE
go fields: handle time like we did before, with mysql.NullTime

### DIFF
--- a/fields/sql.go
+++ b/fields/sql.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"reflect"
 	"time"
+
+	"github.com/go-sql-driver/mysql"
 )
 
 // Valuer fulfills the sql/driver.Valuer interface which deserializes our
@@ -186,10 +188,12 @@ func (s *Scanner) Scan(src interface{}) error {
 			return nil
 		}
 	case *time.Time:
-		if _, ok := src.(time.Time); ok {
-			s.value.Set(reflect.ValueOf(src))
-			return nil
+		t := mysql.NullTime{}
+		if err := t.Scan(src); err != nil {
+			return err
 		}
+		s.value.Set(reflect.ValueOf(t.Time))
+		return nil
 	}
 
 	// Override deserialization behavior with tags (these take precedence over how a type would

--- a/fields/sql_test.go
+++ b/fields/sql_test.go
@@ -129,7 +129,11 @@ func TestField_Value(t *testing.T) {
 }
 
 func TestField_Scan(t *testing.T) {
-	time := time.Now()
+	timeNow := time.Now()
+	timeStr := "2008-02-02 12:12:12.000000"
+	timeFromStr, err := time.Parse("2006-01-02 15:04:05.000000", timeStr)
+	assert.NoError(t, err)
+
 	cases := []struct {
 		Type  interface{}
 		In    interface{}
@@ -143,7 +147,11 @@ func TestField_Scan(t *testing.T) {
 		{Type: int64(0), Out: int64(200), In: int64(200)},
 		{Type: float64(0), Out: float64(200), In: float64(200)},
 		{Type: true, Out: true, In: true},
-		{Type: time, Out: time, In: time},
+		{Type: timeNow, Out: timeNow, In: timeNow},
+		{Type: timeNow, Out: timeFromStr, In: timeStr},
+		{Type: timeNow, Out: time.Time{}, In: nil},
+		{Type: &timeNow, Out: &timeFromStr, In: timeStr},
+		{Type: &timeNow, Out: (*time.Time)(nil), In: nil},
 		// Type aliases:
 		{Type: likeString(""), Out: likeString("foo"), In: "foo"},
 		{Type: int8(5), Out: int8(5), In: int64(5)},


### PR DESCRIPTION
See https://github.com/samsarahq/thunder/pull/142/files#diff-ec296ed9b760f4157d5adf8255a5c5c8L102

I looked through our other scalars, and we handle the rest of them (including bytes with our own behavior). This unfortunately couples us back to MySQL.