### PR TITLE
go sqlgen: binlog testers should compare driver.Values

### DIFF
--- a/internal/fields/sql.go
+++ b/internal/fields/sql.go
@@ -88,7 +88,7 @@ func (f Valuer) Value() (driver.Value, error) {
 	// Coerce our value into a valid sql/driver.Value (see sql/driver.IsValue).
 	// This not only converts base types into their sql counterparts (like int32 -> int64) but also
 	// handles custom types (like `type customString string` -> string).
-	switch f.Kind {
+	switch f.value.Kind() {
 	case reflect.Bool:
 		return f.value.Bool(), nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:

--- a/internal/fields/sql.go
+++ b/internal/fields/sql.go
@@ -91,10 +91,10 @@ func (f Valuer) Value() (driver.Value, error) {
 	switch f.Kind {
 	case reflect.Bool:
 		return f.value.Bool(), nil
-	case
-		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return f.value.Int(), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return int64(f.value.Uint()), nil
 	case reflect.Float32, reflect.Float64:
 		return f.value.Float(), nil
 	case reflect.String:

--- a/sqlgen/reflect_test.go
+++ b/sqlgen/reflect_test.go
@@ -301,8 +301,8 @@ func TestMakeInsertAutoIncrement(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "users", query.Table)
-	assert.Equal(t, []string{"name", "age", "optional"}, query.Columns)
-	assert.Equal(t, []interface{}{"bob", int64(20), nil}, query.Values)
+	assert.Equal(t, []string{"name", "age", "optional", "uuid"}, query.Columns)
+	assert.Equal(t, []interface{}{"bob", int64(20), nil, make([]byte, 16)}, query.Values)
 }
 
 func TestMakeUpsertAutoIncrement(t *testing.T) {
@@ -335,8 +335,8 @@ func TestMakeUpsertUniqueId(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "users", query.Table)
-	assert.Equal(t, []string{"id", "name", "age", "optional"}, query.Columns)
-	assert.Equal(t, []interface{}{int64(5), "alice", int64(30), "temp"}, query.Values)
+	assert.Equal(t, []string{"id", "name", "age", "optional", "uuid"}, query.Columns)
+	assert.Equal(t, []interface{}{int64(5), "alice", int64(30), "temp", make([]byte, 16)}, query.Values)
 }
 
 func TestMakeUpdateAutoIncrement(t *testing.T) {
@@ -352,8 +352,8 @@ func TestMakeUpdateAutoIncrement(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "users", query.Table)
-	assert.Equal(t, []string{"name", "age", "optional"}, query.Columns)
-	assert.Equal(t, []interface{}{"bob", int64(20), nil}, query.Values)
+	assert.Equal(t, []string{"name", "age", "optional", "uuid"}, query.Columns)
+	assert.Equal(t, []interface{}{"bob", int64(20), nil, make([]byte, 16)}, query.Values)
 	assert.Equal(t, []string{"id"}, query.Where.Columns)
 	assert.Equal(t, []interface{}{int64(10)}, query.Where.Values)
 }
@@ -373,8 +373,8 @@ func TestMakeUpdateUniqueId(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "users", query.Table)
-	assert.Equal(t, []string{"name", "age", "optional"}, query.Columns)
-	assert.Equal(t, []interface{}{"alice", int64(40), "temp"}, query.Values)
+	assert.Equal(t, []string{"name", "age", "optional", "uuid"}, query.Columns)
+	assert.Equal(t, []interface{}{"alice", int64(40), "temp", make([]byte, 16)}, query.Values)
 	assert.Equal(t, []string{"id"}, query.Where.Columns)
 	assert.Equal(t, []interface{}{int64(20)}, query.Where.Values)
 }

--- a/sqlgen/reflect_test.go
+++ b/sqlgen/reflect_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/kylelemons/godebug/pretty"
@@ -469,5 +470,53 @@ func TestMakeTester(t *testing.T) {
 		if actual != c.Expected {
 			t.Errorf("%s: got %v, expected %v", c.Description, actual, c.Expected)
 		}
+	}
+}
+
+func TestDriverValuesEqual(t *testing.T) {
+	cases := []struct {
+		left  driver.Value
+		right driver.Value
+		equal bool
+	}{
+		{left: int64(1), right: int64(1), equal: true},
+		{left: int64(1), right: int64(0), equal: false},
+		{left: int64(1), right: float64(1), equal: false},
+		{left: int64(1), right: bool(false), equal: false},
+		{left: int64(1), right: []byte("1"), equal: false},
+		{left: int64(1), right: string("1"), equal: false},
+		{left: int64(1), right: time.Time{}, equal: false},
+
+		{left: float64(1), right: float64(1), equal: true},
+		{left: float64(1), right: float64(0), equal: false},
+		{left: float64(1), right: bool(false), equal: false},
+		{left: float64(1), right: []byte("1"), equal: false},
+		{left: float64(1), right: string("1"), equal: false},
+		{left: float64(1), right: time.Time{}, equal: false},
+
+		{left: bool(true), right: bool(true), equal: true},
+		{left: bool(true), right: bool(false), equal: false},
+		{left: bool(true), right: []byte("1"), equal: false},
+		{left: bool(true), right: string("1"), equal: false},
+		{left: bool(true), right: time.Time{}, equal: false},
+
+		{left: []byte("1"), right: []byte("1"), equal: true},
+		{left: []byte("1"), right: []byte("0"), equal: false},
+		{left: []byte("1"), right: string("1"), equal: false},
+		{left: []byte("1"), right: time.Time{}, equal: false},
+
+		{left: string("1"), right: string("1"), equal: true},
+		{left: string("1"), right: string("0"), equal: false},
+		{left: string("1"), right: time.Time{}, equal: false},
+
+		{left: time.Time{}, right: time.Time{}, equal: true},
+		{left: time.Time{}, right: time.Now(), equal: false},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, c.equal, driverValuesEqual(c.left, c.right))
+			assert.Equal(t, c.equal, driverValuesEqual(c.right, c.left))
+		})
 	}
 }


### PR DESCRIPTION
Currently binlog tester does not match int32 filter value against a int64 column, for example. It doesn't support custom type either. This fixes both. 