### PR TITLE
go sqlgen: add baseline benchmark running against native sql

### DIFF
--- a/sqlgen/integration_test.go
+++ b/sqlgen/integration_test.go
@@ -188,3 +188,64 @@ func Benchmark(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkSql(b *testing.B) {
+	tdb, db, err := setup()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer tdb.Close()
+
+	ctx := context.Background()
+
+	mood := testfixtures.CustomType{'f', 'o', 'o', 'o', 'o', 'o', 'o'}
+	user := &User{
+		Id:   1,
+		Name: "Bob",
+		Uuid: testfixtures.CustomType{'1', '1', '2', '3', '8', '4', '9', '1', '2', '9', '3'},
+		Mood: &mood,
+	}
+
+	if _, err := db.InsertRow(ctx, user); err != nil {
+		b.Fatal(err)
+	}
+
+	benchmarks := []struct {
+		name string
+		fn   func() error
+	}{
+		{"Read", func() error {
+			user := &User{}
+			row := db.Conn.QueryRowContext(ctx, `SELECT * from users`)
+			return row.Scan(&user.Id, &user.Name, &user.Uuid, &user.Mood)
+		}},
+		{"Read_Where", func() error {
+			user := &User{}
+			row := db.Conn.QueryRowContext(ctx, `SELECT * from users where users.name = ?`, "Bob")
+			return row.Scan(&user.Id, &user.Name, &user.Uuid, &user.Mood)
+		}},
+		{"Create", func() error {
+			_, err := db.Conn.ExecContext(ctx, `INSERT INTO users (name, uuid, mood) VALUES (?, ?, ?)`, user.Name, user.Uuid, user.Mood)
+			return err
+		}},
+		{"Update", func() error {
+			_, err := db.Conn.ExecContext(ctx, `UPDATE users SET name = ?, uuid = ?, mood = ? WHERE users.id = ?`, user.Name, user.Uuid, user.Mood, user.Id)
+			return err
+		}},
+		{"Delete", func() error {
+			_, err := db.Conn.ExecContext(ctx, `DELETE FROM users WHERE users.id = ?`, user.Id)
+			return err
+		}},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if err := bm.fn(); err != nil {
+					b.Error(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a benchmark for "native" (go stdlib) sql queries to compare our other benchmark against. It might also be worth moving the blank struct allocation out of the loop.

```
Benchmark/Read-2 	           10000	    159543 ns/op	    1665 B/op	      43 allocs/op
Benchmark/Read_Where-2         	    5000	    285107 ns/op	    2337 B/op	      56 allocs/op
Benchmark/Create-2             	    1000	   1956704 ns/op	    1120 B/op	      26 allocs/op
Benchmark/Update-2             	    5000	    261100 ns/op	    1496 B/op	      32 allocs/op
Benchmark/Delete-2             	    5000	    237507 ns/op	     808 B/op	      25 allocs/op

BenchmarkSql/Read-2            	   10000	    145322 ns/op	     932 B/op	      25 allocs/op
BenchmarkSql/Read_Where-2      	    5000	    260387 ns/op	    1136 B/op	      30 allocs/op
BenchmarkSql/Create-2          	    1000	   1596524 ns/op	     656 B/op	      17 allocs/op
BenchmarkSql/Update-2          	    5000	    256125 ns/op	     760 B/op	      18 allocs/op
BenchmarkSql/Delete-2          	    5000	    234697 ns/op	     216 B/op	       8 allocs/op
```