### PR TITLE
go {livesql,sqlgen,internal}: support []byte arguments for live queries

### DIFF
--- a/internal/reflect.go
+++ b/internal/reflect.go
@@ -31,9 +31,9 @@ func init() {
 	interfaceTyp = reflect.TypeOf(&x).Elem()
 }
 
-// ToArray converts a []interface{} slice into an equivalent fixed-length array
+// MakeHashable converts a []interface{} slice into an equivalent fixed-length array
 // [...]interface{} for use as a comparable map key
-func ToArray(s []interface{}) interface{} {
+func MakeHashable(s []interface{}) interface{} {
 	d := make([]interface{}, len(s))
 	// Convert byte slices into strings as they are otherwise not comparable/hashable.
 	for i, elem := range s {

--- a/internal/reflect.go
+++ b/internal/reflect.go
@@ -33,32 +33,42 @@ func init() {
 
 // ToArray converts a []interface{} slice into an equivalent fixed-length array
 // [...]interface{} for use as a comparable map key
-//
 func ToArray(s []interface{}) interface{} {
-	switch len(s) {
+	d := make([]interface{}, len(s))
+	// Convert byte slices into strings as they are otherwise not comparable/hashable.
+	for i, elem := range s {
+		if b, ok := elem.([]byte); ok {
+			d[i] = string(b)
+		} else {
+			d[i] = elem
+		}
+	}
+
+	// Return arrays as they are comparable/hashable.
+	switch len(d) {
 	// fast code paths for short arrays:
 	case 0:
 		return [...]interface{}{}
 	case 1:
-		return [...]interface{}{s[0]}
+		return [...]interface{}{d[0]}
 	case 2:
-		return [...]interface{}{s[0], s[1]}
+		return [...]interface{}{d[0], d[1]}
 	case 3:
-		return [...]interface{}{s[0], s[1], s[2]}
+		return [...]interface{}{d[0], d[1], d[2]}
 	case 4:
-		return [...]interface{}{s[0], s[1], s[2], s[3]}
+		return [...]interface{}{d[0], d[1], d[2], d[3]}
 	case 5:
-		return [...]interface{}{s[0], s[1], s[2], s[3], s[4]}
+		return [...]interface{}{d[0], d[1], d[2], d[3], d[4]}
 	case 6:
-		return [...]interface{}{s[0], s[1], s[2], s[3], s[4], s[5]}
+		return [...]interface{}{d[0], d[1], d[2], d[3], d[4], d[5]}
 	case 7:
-		return [...]interface{}{s[0], s[1], s[2], s[3], s[4], s[5], s[6]}
+		return [...]interface{}{d[0], d[1], d[2], d[3], d[4], d[5], d[6]}
 	case 8:
-		return [...]interface{}{s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]}
+		return [...]interface{}{d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]}
 	default:
 		// slow catch-all:
-		array := reflect.New(reflect.ArrayOf(len(s), interfaceTyp)).Elem()
-		for i, elem := range s {
+		array := reflect.New(reflect.ArrayOf(len(d), interfaceTyp)).Elem()
+		for i, elem := range d {
 			array.Index(i).Set(reflect.ValueOf(elem))
 		}
 		return array.Interface()

--- a/internal/reflect_test.go
+++ b/internal/reflect_test.go
@@ -5,27 +5,27 @@ import (
 	"testing"
 )
 
-func testToArray(t *testing.T, s []interface{}, expected interface{}) {
-	actual := ToArray(s)
+func testMakeHashable(t *testing.T, s []interface{}, expected interface{}) {
+	actual := MakeHashable(s)
 	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("ToArray(%v) = %v, expected %v", s, actual, expected)
+		t.Errorf("MakeHashable(%v) = %v, expected %v", s, actual, expected)
 	}
 }
 
-func TestToArray(t *testing.T) {
-	testToArray(t, nil, [0]interface{}{})
-	testToArray(t, []interface{}{}, [0]interface{}{})
-	testToArray(t, []interface{}{1}, [1]interface{}{1})
-	testToArray(t, []interface{}{1, 2}, [2]interface{}{1, 2})
-	testToArray(t, []interface{}{1, 2, 3}, [3]interface{}{1, 2, 3})
-	testToArray(t, []interface{}{1, 2, 3, 4}, [4]interface{}{1, 2, 3, 4})
-	testToArray(t, []interface{}{1, 2, 3, 4, 5}, [5]interface{}{1, 2, 3, 4, 5})
-	testToArray(t, []interface{}{1, 2, 3, 4, 5, 6}, [6]interface{}{1, 2, 3, 4, 5, 6})
-	testToArray(t, []interface{}{1, 2, 3, 4, 5, 6, 7}, [7]interface{}{1, 2, 3, 4, 5, 6, 7})
-	testToArray(t, []interface{}{1, 2, 3, 4, 5, 6, 7, 8}, [8]interface{}{1, 2, 3, 4, 5, 6, 7, 8})
-	testToArray(t, []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9}, [9]interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9})
-	testToArray(t, []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, [10]interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+func TestMakeHashable(t *testing.T) {
+	testMakeHashable(t, nil, [0]interface{}{})
+	testMakeHashable(t, []interface{}{}, [0]interface{}{})
+	testMakeHashable(t, []interface{}{1}, [1]interface{}{1})
+	testMakeHashable(t, []interface{}{1, 2}, [2]interface{}{1, 2})
+	testMakeHashable(t, []interface{}{1, 2, 3}, [3]interface{}{1, 2, 3})
+	testMakeHashable(t, []interface{}{1, 2, 3, 4}, [4]interface{}{1, 2, 3, 4})
+	testMakeHashable(t, []interface{}{1, 2, 3, 4, 5}, [5]interface{}{1, 2, 3, 4, 5})
+	testMakeHashable(t, []interface{}{1, 2, 3, 4, 5, 6}, [6]interface{}{1, 2, 3, 4, 5, 6})
+	testMakeHashable(t, []interface{}{1, 2, 3, 4, 5, 6, 7}, [7]interface{}{1, 2, 3, 4, 5, 6, 7})
+	testMakeHashable(t, []interface{}{1, 2, 3, 4, 5, 6, 7, 8}, [8]interface{}{1, 2, 3, 4, 5, 6, 7, 8})
+	testMakeHashable(t, []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9}, [9]interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9})
+	testMakeHashable(t, []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, [10]interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
 
 	// Byte slices are converted into strings.
-	testToArray(t, []interface{}{[]byte("hi"), []byte("there")}, [2]interface{}{"hi", "there"})
+	testMakeHashable(t, []interface{}{[]byte("hi"), []byte("there")}, [2]interface{}{"hi", "there"})
 }

--- a/internal/reflect_test.go
+++ b/internal/reflect_test.go
@@ -25,4 +25,7 @@ func TestToArray(t *testing.T) {
 	testToArray(t, []interface{}{1, 2, 3, 4, 5, 6, 7, 8}, [8]interface{}{1, 2, 3, 4, 5, 6, 7, 8})
 	testToArray(t, []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9}, [9]interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9})
 	testToArray(t, []interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, [10]interface{}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+
+	// Byte slices are converted into strings.
+	testToArray(t, []interface{}{[]byte("hi"), []byte("there")}, [2]interface{}{"hi", "there"})
 }

--- a/livesql/integration_test.go
+++ b/livesql/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/internal/testfixtures"
 	"github.com/samsarahq/thunder/livesql"
 	"github.com/samsarahq/thunder/reactive"
@@ -89,4 +90,78 @@ func TestIntegrationBasic(t *testing.T) {
 	err = db.UpdateRow(context.Background(), &User{Id: userId, Name: newName, Uuid: newUuid, Mood: &newMood})
 	assert.NoError(t, err)
 	assert.Equal(t, User{Id: userId, Name: newName, Uuid: newUuid, Mood: &newMood}, <-users)
+}
+
+func TestIntegrationFilterCustomType(t *testing.T) {
+	config := testfixtures.DefaultDBConfig
+	schema := sqlgen.NewSchema()
+	schema.MustRegisterType("users", sqlgen.AutoIncrement, User{})
+	testDb, err := testfixtures.NewTestDatabase()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testDb.Close()
+
+	_, err = testDb.DB.Exec(`
+               CREATE TABLE users (
+                       id   BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                       name VARCHAR(255),
+                       uuid VARCHAR(255),
+                       mood VARCHAR(255)
+               )
+       `)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := livesql.Open(config.Hostname, config.Port, config.Username, config.Password, testDb.DBName, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Values
+	name := "Jean"
+	newName := "Joan"
+	mood := testfixtures.CustomTypeFromString("freeform")
+	newMood := testfixtures.CustomTypeFromString("outrage")
+	uuid := testfixtures.CustomTypeFromString("11238491293")
+	newUuid := testfixtures.CustomTypeFromString("11232481203")
+
+	result, err := db.InsertRow(context.Background(), &User{Name: name, Uuid: uuid, Mood: &mood})
+	assert.NoError(t, err)
+	userId, err := result.LastInsertId()
+	assert.NoError(t, err)
+
+	// We use a channel to pass around query updates for testing.
+	users := make(chan *User)
+	ctx := batch.WithBatching(context.Background())
+	rerunner := reactive.NewRerunner(ctx, func(ctx context.Context) (interface{}, error) {
+		user := &User{}
+		if err := db.QueryRow(ctx, &user, sqlgen.Filter{"mood": &mood}, nil); err != nil {
+			users <- nil
+			return nil, nil
+			// t.Errorf("couldn't query row: %v", err)
+		}
+		users <- user
+		return nil, nil
+	}, 50*time.Millisecond)
+	defer rerunner.Stop()
+
+	// Initial rerunner query matches initial insert.
+	assert.Equal(t, &User{Id: userId, Name: name, Uuid: uuid, Mood: &mood}, <-users)
+
+	// Upon update we get another rerunner result with the updated name.
+	err = db.UpdateRow(context.Background(), &User{Id: userId, Name: newName, Uuid: uuid, Mood: &mood})
+	assert.NoError(t, err)
+	assert.Equal(t, &User{Id: userId, Name: newName, Uuid: uuid, Mood: &mood}, <-users)
+
+	// Upon update we get another rerunner result with the updated uuid.
+	err = db.UpdateRow(context.Background(), &User{Id: userId, Name: newName, Uuid: newUuid, Mood: &mood})
+	assert.NoError(t, err)
+	assert.Equal(t, &User{Id: userId, Name: newName, Uuid: newUuid, Mood: &mood}, <-users)
+
+	// Upon update we get another rerunner result with the updated mood.
+	err = db.UpdateRow(context.Background(), &User{Id: userId, Name: newName, Uuid: newUuid, Mood: &newMood})
+	assert.NoError(t, err)
+	assert.Equal(t, (*User)(nil), <-users)
 }

--- a/livesql/live.go
+++ b/livesql/live.go
@@ -137,7 +137,7 @@ func (ldb *LiveDB) query(ctx context.Context, query *sqlgen.BaseSelectQuery) ([]
 
 	// Build a cache key for the query. Convert the args slice into an array so
 	// it can be stored as a map key.
-	key := queryCacheKey{clause: clause, args: internal.ToArray(args)}
+	key := queryCacheKey{clause: clause, args: internal.MakeHashable(args)}
 
 	result, err := reactive.Cache(ctx, key, func(ctx context.Context) (interface{}, error) {
 		// Build a tester for the dependency.

--- a/sqlgen/matcher.go
+++ b/sqlgen/matcher.go
@@ -81,7 +81,7 @@ func newMatcher() *matcher {
 // add adds a query to the matcher, associating an opaque id with the query.
 func (m *matcher) add(id interface{}, filter Filter) {
 	columnSet := extractColumns(filter)
-	tuple := internal.ToArray(extractValuesTuple(filter, columnSet))
+	tuple := internal.MakeHashable(extractValuesTuple(filter, columnSet))
 	key := columnsKey(columnSet)
 
 	g, ok := m.groups[key]
@@ -105,7 +105,7 @@ func (m *matcher) add(id interface{}, filter Filter) {
 // removes removes a query from the matcher.
 func (m *matcher) remove(id interface{}, filter Filter) {
 	columnSet := extractColumns(filter)
-	tuple := internal.ToArray(extractValuesTuple(filter, columnSet))
+	tuple := internal.MakeHashable(extractValuesTuple(filter, columnSet))
 	key := columnsKey(columnSet)
 
 	g, ok := m.groups[key]
@@ -136,7 +136,7 @@ func (m *matcher) remove(id interface{}, filter Filter) {
 func (m *matcher) match(o map[string]interface{}) []interface{} {
 	var result []interface{}
 	for _, g := range m.groups {
-		for query := range g.queriesByTuple[internal.ToArray(extractValuesTuple(o, g.columns))] {
+		for query := range g.queriesByTuple[internal.MakeHashable(extractValuesTuple(o, g.columns))] {
 			result = append(result, query)
 		}
 	}


### PR DESCRIPTION
## Problem

We have UUIDs which use or convert to `[]byte`. Both livesql and the batcher rely on comparable/hashable values (values that are put into a `map`) to work and panic otherwise. This means that we can't use those custom types with livesql or batching.

## Solution

### LiveSQL
The `ToArray` function has been used for creating hashable/comparable arguments in the past. Renamed it to be more explicit, and also handle `[]byte` arguments, converting them into strings.

The primary use-case for this PR is to support UUIDs. We also get support for anything else that turns into `[]byte`.

The reason we want to serialize our arguments/filters is because (unfortunately) we support type aliases in our filters, and therefore allow you to query a `int64` with `int`/`int8`/etc. In order to maintain backward compatibility there, we have to assume that we're dealing with a SQL value for caching/rerunning.

### Batching

TL;DR: do nothing

Batching deals with go struct types (not go sql types), which means we have many possible permutations of types. We _could_ take our filter values and convert them to their sql values, using that to compare. This would take more time than simply using a `[16]byte` for our UUIDs.

It would properly implement 100% compatibility with custom types. However, I have some concerns about performance in doing so, and given deadline constraints, we can add that on later rather than doing so now.

**Slices in filters will continue not to be supported for batching.**