### PR TITLE
sqlgen/livesql: Improve error logging

### DIFF
--- a/livesql/binlog.go
+++ b/livesql/binlog.go
@@ -215,7 +215,7 @@ func parseBinlogRow(table *sqlgen.Table, binlogRow []interface{}, columnMap *col
 		scanner := scanners[i].(*fields.Scanner)
 		scanner.Target(field)
 		if err := scanner.Scan(binlogRow[j]); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("binlog: `%s`.`%s` error: %v", table.Name, table.Columns[i].Name, err)
 		}
 	}
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,36 @@
+package logger
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// Logger takes in a message and tag pairs.
+type Logger interface {
+	Debug(msg string, tags ...interface{})
+	Info(msg string, tags ...interface{})
+	Warn(msg string, tags ...interface{})
+	Error(msg string, tags ...interface{})
+}
+
+type logger struct{ out io.Writer }
+
+// New creates a logger that writes to stdout.
+func New() Logger { return &logger{os.Stdout} }
+
+func (l *logger) print(msg string, tags ...interface{}) {
+	fmt.Fprintln(l.out, append([]interface{}{msg}, tags...))
+}
+
+// Debug creates a debug log entry.
+func (l *logger) Debug(msg string, tags ...interface{}) { l.print(msg, tags...) }
+
+// Info creates an info log entry.
+func (l *logger) Info(msg string, tags ...interface{}) { l.print(msg, tags...) }
+
+// Warn creates a warn log entry.
+func (l *logger) Warn(msg string, tags ...interface{}) { l.print(msg, tags...) }
+
+// Error creates an error log entry.
+func (l *logger) Error(msg string, tags ...interface{}) { l.print(msg, tags...) }

--- a/sqlgen/reflect.go
+++ b/sqlgen/reflect.go
@@ -61,7 +61,7 @@ func UnbuildStruct(table *Table, strct interface{}) ([]interface{}, error) {
 		var err error
 		values[i], err = column.Descriptor.Valuer(val).Value()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("sqlgen: serialization error for `%s`.`%s`: %v", table.Name, column.Name, err)
 		}
 	}
 
@@ -88,7 +88,8 @@ func parseQueryRow(table *Table, scanner *sql.Rows) (interface{}, error) {
 	}
 
 	if err := scanner.Scan(scanners...); err != nil {
-		return nil, err
+		columns, _ := scanner.Columns()
+		return nil, fmt.Errorf("sqlgen: parsing error for `%s`.(%v): %v", table.Name, columns, err)
 	}
 
 	return ptr.Interface(), nil
@@ -345,7 +346,7 @@ func makeWhere(table *Table, filter Filter) (*SimpleWhere, error) {
 
 		v, err := column.Descriptor.Valuer(reflect.ValueOf(value)).Value()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("sqlgen: filter error for `%s`.`%s`: %v", table.Name, column.Name, err)
 		}
 		l = append(l, whereElem{column: column, value: v})
 	}


### PR DESCRIPTION
1. Allow for the destination of error output to be customized
2. Provide table and column information when parsing fails in `livesql` and `sqlgen`