### PR TITLE
go sqlgen: Add support for converting "Zero" value fields to NULL in the db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 #### `sqlgen`
 
 - `sqlgen.Tester` now compares `driver.Value`s. ([#170](https://github.com/samsarahq/thunder/pull/170))
+- Support converting the zero value of fields to NULL in the db with tag `sql:",implicitnull"`. ([#181](https://github.com/samsarahq/thunder/pull/181))
 
 ## [0.4.0] - 2018-09-13
 

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -8,6 +8,6 @@ services:
     ports:
       - "3307:3306"
     environment:
-      MYSQL_ROOT_PASSWORD: ""
+      MYSQL_ROOT_PASSWORD: "dev"
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 

--- a/internal/fields/reflect.go
+++ b/internal/fields/reflect.go
@@ -1,0 +1,35 @@
+package fields
+
+import (
+	"reflect"
+)
+
+// isZero returns whether the value of the passed in reflect value is the
+// zero value of that type.
+// Mostly copied from https://github.com/golang/go/issues/7501
+// Works for mostly everything except zero initialized arrays (e.g.
+// `var ray [5]string` will not be "Zero")
+func isZero(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return v.IsNil()
+	case reflect.Struct:
+		// This is a special case comparison for struct types.
+		return v.Interface() == reflect.Zero(v.Type()).Interface()
+	case reflect.Invalid:
+		// Invalid types are, by definition, "Zero" values
+		return true
+	}
+
+	return false
+}

--- a/internal/fields/reflect_test.go
+++ b/internal/fields/reflect_test.go
@@ -1,0 +1,58 @@
+package fields
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsZero(t *testing.T) {
+	var zeroSlice []string
+	var zeroMap map[string]string
+	var zeroPointer *time.Location
+	var zeroInterface testing.TB
+	var nonZeroInterface testing.TB
+	nonZeroInterface = t
+
+	tests := []struct {
+		Name   string
+		Give   interface{}
+		IsZero bool
+	}{
+		{"zero int", int(0), true},
+		{"int", int(1), false},
+		{"zero int64", int64(0), true},
+		{"int64", int64(1), false},
+		{"zero bool", false, true},
+		{"bool", true, false},
+		{"zero uint", uint(0), true},
+		{"Uint", uint(1), false},
+		{"zero float", float64(0), true},
+		{"float", float64(12.2), false},
+		{"zero string", "", true},
+		{"string", "not zero", false},
+		{"zero array", [0]string{}, true},
+		{"array", [4]string{"1", "2", "3", "4"}, false},
+		{"zero slice", ([]string)(nil), true},
+		{"type zero slice", zeroSlice, true},
+		{"slice", []string{}, false},
+		{"zero map", (map[string]string)(nil), true},
+		{"type zero map", zeroMap, true},
+		{"map", map[string]string{}, false},
+		{"zero pointer", (*time.Location)(nil), true},
+		{"type zero pointer", zeroPointer, true},
+		{"pointer", time.UTC, false},
+		{"type zero interface", zeroInterface, true},
+		{"interface", nonZeroInterface, false},
+		{"zero struct", time.Time{}, true},
+		{"struct", time.Now(), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			assert.Equal(t, tt.IsZero, isZero(reflect.ValueOf(tt.Give)))
+		})
+	}
+}

--- a/internal/fields/sql.go
+++ b/internal/fields/sql.go
@@ -77,6 +77,10 @@ func (f Valuer) Value() (driver.Value, error) {
 			return iface.MarshalJSON()
 		}
 		return json.Marshal(i)
+	case f.Tags.Contains("implicitnull"):
+		if isZero(f.value) {
+			return nil, nil
+		}
 	}
 
 	// At this point we have already handled `nil` above, so we can assume that all

--- a/internal/fields/sql.go
+++ b/internal/fields/sql.go
@@ -115,8 +115,7 @@ var _ driver.Valuer = &Valuer{}
 // into the type dictated by our descriptor.
 type Scanner struct {
 	*Descriptor
-	value   reflect.Value
-	isValid bool
+	value reflect.Value
 }
 
 func (s *Scanner) Target(value reflect.Value) {
@@ -137,9 +136,9 @@ func (s *Scanner) Scan(src interface{}) error {
 	defer func() { s.value = reflect.Value{} }()
 
 	// Keep track of whether our value was empty.
-	s.isValid = src != nil
+	isValid := src != nil
 
-	if s.isValid && s.Ptr {
+	if isValid && s.Ptr {
 		s.value.Set(reflect.New(s.Type))
 	}
 
@@ -166,14 +165,14 @@ func (s *Scanner) Scan(src interface{}) error {
 		}
 
 		// If we have a scanner it will handle its own validity.
-		s.isValid = true
+		isValid = true
 		return scanner.Scan(src)
 	}
 
 	// Null values are simply set to zero. Because we're not holding on to pointers, we need to
 	// represent this as a boolean. This comes _after_ the scanner step, just in case the scanner
 	// handles nil differently.
-	if !s.isValid {
+	if !isValid {
 		return nil
 	}
 

--- a/internal/integrationtest/helpers.go
+++ b/internal/integrationtest/helpers.go
@@ -1,0 +1,59 @@
+package integrationtest
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/samsarahq/thunder/internal/testfixtures"
+	"github.com/samsarahq/thunder/livesql"
+	"github.com/samsarahq/thunder/sqlgen"
+	"github.com/stretchr/testify/require"
+)
+
+// DB is an interface that satisfies both sqlgen.DB and LiveDB
+type DB interface {
+	Query(ctx context.Context, result interface{}, filter sqlgen.Filter, options *sqlgen.SelectOptions) error
+	QueryRow(ctx context.Context, result interface{}, filter sqlgen.Filter, options *sqlgen.SelectOptions) error
+	InsertRow(ctx context.Context, row interface{}) (sql.Result, error)
+	UpsertRow(ctx context.Context, row interface{}) (sql.Result, error)
+	UpdateRow(ctx context.Context, row interface{}) error
+	DeleteRow(ctx context.Context, row interface{}) error
+}
+
+// DBGenerator is a struct that contains the ability to build a database.
+type DBGenerator struct {
+	Name      string
+	Generator func(t *testing.T) (db DB, sqlDB *sql.DB, close func())
+}
+
+// NewDBGenerators is a function that will return a list of database
+// "generators" which own the lifecycle of a database (both live and sqlgen)
+func NewDBGenerators(dbSetup func(testDB *testfixtures.TestDatabase, schema *sqlgen.Schema) error) []DBGenerator {
+	return []DBGenerator{
+		{
+			Name: "sqlgen",
+			Generator: func(t *testing.T) (db DB, sqlDB *sql.DB, close func()) {
+				testDb, err := testfixtures.NewTestDatabase()
+				require.NoError(t, err)
+				schema := sqlgen.NewSchema()
+
+				require.NoError(t, dbSetup(testDb, schema))
+
+				return sqlgen.NewDB(testDb.DB, schema), testDb.DB, func() { require.NoError(t, testDb.Close()) }
+			},
+		},
+		{
+			Name: "livedb",
+			Generator: func(t *testing.T) (db DB, sqlDB *sql.DB, close func()) {
+				testDb, err := testfixtures.NewTestDatabase()
+				require.NoError(t, err)
+				schema := sqlgen.NewSchema()
+
+				require.NoError(t, dbSetup(testDb, schema))
+
+				return livesql.NewLiveDB(sqlgen.NewDB(testDb.DB, schema)), testDb.DB, func() { require.NoError(t, testDb.Close()) }
+			},
+		},
+	}
+}

--- a/internal/integrationtest/implicitnull_test.go
+++ b/internal/integrationtest/implicitnull_test.go
@@ -1,0 +1,410 @@
+package integrationtest
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/samsarahq/thunder/batch"
+	"github.com/samsarahq/thunder/internal/testfixtures"
+	"github.com/samsarahq/thunder/sqlgen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type ImplicitNull struct {
+	Id        int64     `sql:",primary"`
+	NullStr   string    `sql:",implicitnull"`
+	NullInt   int64     `sql:",implicitnull"`
+	NullFloat float64   `sql:",implicitnull"`
+	NullBool  bool      `sql:",implicitnull"`
+	NullByte  []byte    `sql:",implicitnull"`
+	NullTime  time.Time `sql:",implicitnull"`
+}
+
+func TestImplicitNullIsNullInDB(t *testing.T) {
+	tests := []struct {
+		name              string
+		giveStruct        *ImplicitNull
+		wantNullFields    []string
+		wantNonNullFields []string
+	}{
+		{
+			name:           "all null",
+			giveStruct:     &ImplicitNull{},
+			wantNullFields: []string{"null_str", "null_int", "null_float", "null_bool", "null_byte", "null_time"},
+		},
+		{
+			name: "no null",
+			giveStruct: &ImplicitNull{
+				NullStr:   "hello",
+				NullInt:   123,
+				NullFloat: 1.23,
+				NullBool:  true,
+				NullByte:  []byte("hello there"),
+				NullTime:  time.Date(2000, 10, 3, 0, 0, 0, 0, time.UTC),
+			},
+			wantNonNullFields: []string{"null_str", "null_int", "null_float", "null_bool", "null_byte", "null_time"},
+		},
+	}
+
+	for _, dbGen := range getImplicitDBGenerators() {
+		for _, testctx := range getTestContexts() {
+			for _, tt := range tests {
+				t.Run(fmt.Sprintf("%s-%s-%s", dbGen.Name, tt.name, testctx.name), func(t *testing.T) {
+					db, sqlDb, closer := dbGen.Generator(t)
+					defer closer()
+					ctx := testctx.ctx
+
+					if _, err := db.InsertRow(ctx, tt.giveStruct); err != nil {
+						t.Error(err)
+					}
+
+					for _, field := range tt.wantNullFields {
+						assertFieldIsNull(t, sqlDb, field)
+					}
+
+					for _, field := range tt.wantNonNullFields {
+						assertFieldIsNotNull(t, sqlDb, field)
+					}
+
+					var res *ImplicitNull
+					require.NoError(t, db.QueryRow(ctx, &res, nil, nil))
+					tt.giveStruct.Id = 1
+					assert.Equal(t, tt.giveStruct, res)
+				})
+			}
+		}
+	}
+}
+
+func TestInvalidImplicitNullField(t *testing.T) {
+	type InvalidImplicitNull struct {
+		Id      int64   `sql:",primary"`
+		NullStr *string `sql:",implicitnull"` // Should not allow pointers
+	}
+
+	schema := sqlgen.NewSchema()
+	err := schema.RegisterType("invalidimplicitnull", sqlgen.AutoIncrement, InvalidImplicitNull{})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "column null_str cannot use `implicitnull` with pointer type")
+}
+
+func TestImplicitNullFiltersWorkForNonNull(t *testing.T) {
+	for _, dbGen := range getImplicitDBGenerators() {
+		for _, tt := range getTestContexts() {
+			t.Run(fmt.Sprintf("%s-%s", dbGen.Name, tt.name), func(t *testing.T) {
+				db, _, closer := dbGen.Generator(t)
+				defer closer()
+				ctx := tt.ctx
+
+				timeField := time.Date(2000, 10, 3, 0, 0, 0, 0, time.UTC)
+				newRow := &ImplicitNull{
+					NullStr:   "hello",
+					NullInt:   123,
+					NullFloat: 1.23,
+					NullBool:  true,
+					NullByte:  []byte("hello there"),
+					NullTime:  timeField,
+				}
+				if _, err := db.InsertRow(ctx, newRow); err != nil {
+					t.Error(err)
+				}
+				var imp *ImplicitNull
+
+				require.NoError(t, db.QueryRow(ctx, &imp, sqlgen.Filter{"id": int64(1)}, nil))
+				require.NoError(t, db.QueryRow(ctx, &imp, sqlgen.Filter{"null_str": "hello"}, nil))
+				require.NoError(t, db.QueryRow(ctx, &imp, sqlgen.Filter{"null_int": int64(123)}, nil))
+				require.NoError(t, db.QueryRow(ctx, &imp, sqlgen.Filter{"null_float": 1.23}, nil))
+				require.NoError(t, db.QueryRow(ctx, &imp, sqlgen.Filter{"null_bool": true}, nil))
+				require.NoError(t, db.QueryRow(ctx, &imp, sqlgen.Filter{"null_byte": []byte("hello there")}, nil))
+				require.NoError(t, db.QueryRow(ctx, &imp, sqlgen.Filter{"null_time": timeField}, nil))
+
+				newRow.Id = 1
+				var rows []*ImplicitNull
+				require.NoError(t, db.Query(context.Background(), &rows, nil, nil))
+				assert.Equal(t, []*ImplicitNull{
+					newRow,
+				}, rows)
+			})
+		}
+	}
+}
+
+func TestImplicitNullFillsWithZeroValue(t *testing.T) {
+	for _, dbGen := range getImplicitDBGenerators() {
+		for _, tt := range getTestContexts() {
+			t.Run(fmt.Sprintf("%s-%s", dbGen.Name, tt.name), func(t *testing.T) {
+				db, _, closer := dbGen.Generator(t)
+				defer closer()
+				ctx := tt.ctx
+
+				newRow := &ImplicitNull{}
+				if _, err := db.InsertRow(ctx, newRow); err != nil {
+					t.Error(err)
+				}
+
+				var imp *ImplicitNull
+				require.NoError(t, db.QueryRow(ctx, &imp, sqlgen.Filter{"id": int64(1)}, nil))
+
+				expectedRow := &ImplicitNull{Id: 1} // The rest is zero value
+				assert.Equal(t, expectedRow, imp)
+			})
+		}
+	}
+}
+
+func TestImplicitNullUpdate(t *testing.T) {
+	tests := []struct {
+		name              string
+		giveStruct        *ImplicitNull
+		giveUpdate        *ImplicitNull
+		wantResult        *ImplicitNull
+		wantNullFields    []string
+		wantNonNullFields []string
+	}{
+		{
+			name:       "all null updated",
+			giveStruct: &ImplicitNull{},
+			giveUpdate: &ImplicitNull{
+				NullStr:   "hello",
+				NullInt:   123,
+				NullFloat: 1.23,
+				NullBool:  true,
+				NullByte:  []byte("hello there"),
+				NullTime:  time.Date(2000, 10, 3, 0, 0, 0, 0, time.UTC),
+			},
+			wantResult: &ImplicitNull{
+				NullStr:   "hello",
+				NullInt:   123,
+				NullFloat: 1.23,
+				NullBool:  true,
+				NullByte:  []byte("hello there"),
+				NullTime:  time.Date(2000, 10, 3, 0, 0, 0, 0, time.UTC),
+			},
+			wantNonNullFields: []string{"null_str", "null_int", "null_float", "null_bool", "null_byte", "null_time"},
+		},
+		{
+			name: "all updated to null",
+			giveStruct: &ImplicitNull{
+				NullStr:   "hello",
+				NullInt:   123,
+				NullFloat: 1.23,
+				NullBool:  true,
+				NullByte:  []byte("hello there"),
+				NullTime:  time.Date(2000, 10, 3, 0, 0, 0, 0, time.UTC),
+			},
+			giveUpdate:     &ImplicitNull{},
+			wantResult:     &ImplicitNull{},
+			wantNullFields: []string{"null_str", "null_int", "null_float", "null_bool", "null_byte", "null_time"},
+		},
+		{
+			name: "partial update",
+			giveStruct: &ImplicitNull{
+				NullStr:   "hello",
+				NullInt:   123,
+				NullFloat: 1.23,
+			},
+			giveUpdate: &ImplicitNull{
+				NullFloat: 1.23,
+				NullBool:  true,
+				NullByte:  []byte("hello there"),
+				NullTime:  time.Date(2000, 10, 3, 0, 0, 0, 0, time.UTC),
+			},
+			wantResult: &ImplicitNull{
+				NullFloat: 1.23,
+				NullBool:  true,
+				NullByte:  []byte("hello there"),
+				NullTime:  time.Date(2000, 10, 3, 0, 0, 0, 0, time.UTC),
+			},
+			wantNullFields:    []string{"null_str", "null_int"},
+			wantNonNullFields: []string{"null_float", "null_bool", "null_byte", "null_time"},
+		},
+	}
+
+	for _, dbGen := range getImplicitDBGenerators() {
+		for _, testctx := range getTestContexts() {
+			for _, tt := range tests {
+				t.Run(fmt.Sprintf("%s-%s-%s", dbGen.Name, tt.name, testctx.name), func(t *testing.T) {
+					db, sqlDB, closer := dbGen.Generator(t)
+					defer closer()
+
+					ctx := testctx.ctx
+
+					if _, err := db.InsertRow(ctx, tt.giveStruct); err != nil {
+						t.Error(err)
+					}
+
+					tt.giveUpdate.Id = 1
+					if err := db.UpdateRow(ctx, tt.giveUpdate); err != nil {
+						t.Error(err)
+					}
+
+					for _, field := range tt.wantNullFields {
+						assertFieldIsNull(t, sqlDB, field)
+					}
+
+					for _, field := range tt.wantNonNullFields {
+						assertFieldIsNotNull(t, sqlDB, field)
+					}
+
+					var res *ImplicitNull
+					require.NoError(t, db.QueryRow(ctx, &res, nil, nil))
+					tt.wantResult.Id = 1
+					assert.Equal(t, tt.wantResult, res)
+				})
+			}
+		}
+	}
+}
+
+func TestImplicitNullDelete(t *testing.T) {
+	tests := []struct {
+		name       string
+		giveStruct *ImplicitNull
+		giveDelete *ImplicitNull
+	}{
+		{
+			name:       "all null delete (same)",
+			giveStruct: &ImplicitNull{},
+			giveDelete: &ImplicitNull{},
+		},
+		{
+			name: "all nonnull delete (same)",
+			giveStruct: &ImplicitNull{
+				NullStr:   "hello",
+				NullInt:   123,
+				NullFloat: 1.23,
+				NullBool:  true,
+				NullByte:  []byte("hello there"),
+				NullTime:  time.Date(2000, 10, 3, 0, 0, 0, 0, time.UTC),
+			},
+			giveDelete: &ImplicitNull{
+				NullStr:   "hello",
+				NullInt:   123,
+				NullFloat: 1.23,
+				NullBool:  true,
+				NullByte:  []byte("hello there"),
+				NullTime:  time.Date(2000, 10, 3, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name:       "all null deleted by full",
+			giveStruct: &ImplicitNull{},
+			giveDelete: &ImplicitNull{
+				NullStr:   "hello",
+				NullInt:   123,
+				NullFloat: 1.23,
+				NullBool:  true,
+				NullByte:  []byte("hello there"),
+				NullTime:  time.Date(2000, 10, 3, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "all null deleted by full",
+			giveStruct: &ImplicitNull{
+				NullStr:   "hello",
+				NullInt:   123,
+				NullFloat: 1.23,
+				NullBool:  true,
+				NullByte:  []byte("hello there"),
+				NullTime:  time.Date(2000, 10, 3, 0, 0, 0, 0, time.UTC),
+			},
+			giveDelete: &ImplicitNull{},
+		},
+	}
+
+	for _, dbGen := range getImplicitDBGenerators() {
+		for _, testctx := range getTestContexts() {
+			for _, tt := range tests {
+				t.Run(fmt.Sprintf("%s-%s-%s", dbGen.Name, tt.name, testctx.name), func(t *testing.T) {
+					db, _, closer := dbGen.Generator(t)
+					defer closer()
+
+					ctx := testctx.ctx
+
+					if _, err := db.InsertRow(ctx, tt.giveStruct); err != nil {
+						t.Error(err)
+					}
+
+					tt.giveDelete.Id = 1
+					if err := db.DeleteRow(ctx, tt.giveDelete); err != nil {
+						t.Error(err)
+					}
+
+					var res *ImplicitNull
+					err := db.QueryRow(ctx, &res, nil, nil)
+					require.Error(t, err)
+					require.Equal(t, err, sql.ErrNoRows)
+				})
+			}
+		}
+	}
+}
+
+func getImplicitDBGenerators() []DBGenerator {
+	return NewDBGenerators(
+		func(testDB *testfixtures.TestDatabase, schema *sqlgen.Schema) error {
+			if _, err := testDB.Exec(`
+		CREATE TABLE implicitnull (
+			id   BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+			null_str VARCHAR(255),
+			null_int BIGINT,
+			null_float DOUBLE,
+			null_bool TINYINT(1),
+			null_byte BLOB,
+			null_time DATETIME(6)
+		)
+	`); err != nil {
+				return err
+			}
+			schema.MustRegisterType("implicitnull", sqlgen.AutoIncrement, ImplicitNull{})
+			return nil
+		},
+	)
+}
+
+func getTestContexts() []struct {
+	name string
+	ctx  context.Context
+} {
+	return []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"batch", batch.WithBatching(context.Background())},
+		{"background", context.Background()},
+	}
+}
+
+func assertFieldIsNull(t *testing.T, db *sql.DB, field string) {
+	count, err := getCount(db, fmt.Sprintf("SELECT COUNT(*) FROM implicitnull WHERE %s IS NULL", field))
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "Expected %s to be null", field)
+}
+
+func assertFieldIsNotNull(t *testing.T, db *sql.DB, field string) {
+	count, err := getCount(db, fmt.Sprintf("SELECT COUNT(*) FROM implicitnull WHERE %s IS NULL", field))
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "Expected %s to not be null", field)
+}
+
+func getCount(db *sql.DB, countQuery string) (int, error) {
+	dbrows, err := db.Query(countQuery)
+	if err != nil {
+		return 0, err
+	}
+
+	var c int
+	for dbrows.Next() {
+		if err := dbrows.Scan(&c); err != nil {
+			return 0, err
+		}
+	}
+
+	return c, nil
+}

--- a/internal/testfixtures/db.go
+++ b/internal/testfixtures/db.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"math/rand"
-	"os"
 )
 
 type DBConfig struct {
@@ -20,15 +19,9 @@ func (d DBConfig) String() string {
 
 var DefaultDBConfig = DBConfig{
 	Username: "root",
-	Password: "",
+	Password: "dev",
 	Hostname: "localhost",
 	Port:     3307,
-}
-
-func init() {
-	if pw := os.Getenv("DB_PASSWORD"); pw != "" {
-		DefaultDBConfig.Password = pw
-	}
 }
 
 type TestDatabase struct {

--- a/sqlgen/integration_test.go
+++ b/sqlgen/integration_test.go
@@ -23,7 +23,8 @@ func setup() (*testfixtures.TestDatabase, *DB, error) {
 			id   BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
 			name VARCHAR(255),
 			uuid VARCHAR(255),
-			mood VARCHAR(255)
+			mood VARCHAR(255),
+			implicit_null VARCHAR(255)
 		)
 	`); err != nil {
 		return nil, nil, err
@@ -35,18 +36,20 @@ func setup() (*testfixtures.TestDatabase, *DB, error) {
 }
 
 type User struct {
-	Id   int64 `sql:",primary"`
-	Name string
-	Uuid testfixtures.CustomType
-	Mood *testfixtures.CustomType
+	Id           int64 `sql:",primary"`
+	Name         string
+	Uuid         testfixtures.CustomType
+	Mood         *testfixtures.CustomType
+	ImplicitNull string `sql:",implicitnull"`
 }
 
 type Complex struct {
-	Id       int64 `sql:",primary"`
-	Name     string
-	Text     []byte            `sql:",string"`
-	Blob     []byte            `sql:",binary"`
-	Mappings map[string]string `sql:",json"`
+	Id           int64 `sql:",primary"`
+	Name         string
+	Text         []byte            `sql:",string"`
+	Blob         []byte            `sql:",binary"`
+	Mappings     map[string]string `sql:",json"`
+	ImplicitNull string            `sql:",implicitnull"`
 }
 
 func TestTagOverrides(t *testing.T) {
@@ -201,10 +204,11 @@ func Benchmark(b *testing.B) {
 
 	mood := testfixtures.CustomType{'f', 'o', 'o', 'o', 'o', 'o', 'o'}
 	user := &User{
-		Id:   1,
-		Name: "Bob",
-		Uuid: testfixtures.CustomType{'1', '1', '2', '3', '8', '4', '9', '1', '2', '9', '3'},
-		Mood: &mood,
+		Id:           1,
+		Name:         "Bob",
+		Uuid:         testfixtures.CustomType{'1', '1', '2', '3', '8', '4', '9', '1', '2', '9', '3'},
+		Mood:         &mood,
+		ImplicitNull: "test",
 	}
 
 	if _, err := db.InsertRow(ctx, user); err != nil {

--- a/sqlgen/reflect.go
+++ b/sqlgen/reflect.go
@@ -193,6 +193,10 @@ func (s *Schema) buildDescriptor(table string, primaryKeyType PrimaryKeyType, ty
 					primary = true
 				case "binary", "json", "string":
 					// Do nothing, fields will handle these.
+				case "implicitnull":
+					if field.Type.Kind() == reflect.Ptr {
+						return nil, fmt.Errorf("bad type %s: column %s cannot use `implicitnull` with pointer type", typ, column)
+					}
 				default:
 					return nil, fmt.Errorf("bad type %s: column %s has unexpected tag %s", typ, column, tag)
 				}


### PR DESCRIPTION
Summary: Adds support to sqlgen to convert "Zero" value model fields to NULL in 
the database.  This only needs to be applied when inserting a value to the 
database because when we read from the db NULL values are noop (leaving the 
zero value).

I put some cleanups in the PR as well, would be easy to pull them out if we want.

Additionally, I wrote tests for the "Main" use cases, but I'm very open 
to add tests for other edge cases, let me know and I'll add them.