### PR TITLE
go diff: don't panic on nil array value

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -182,6 +182,9 @@ func diffMap(old map[string]interface{}, newAny interface{}) interface{} {
 
 // reoderKey returns the key to use for a
 func reorderKey(i interface{}) interface{} {
+	if i == nil {
+		return i
+	}
 	if object, ok := i.(map[string]interface{}); ok {
 		if key, ok := object["__key"]; ok {
 			return key

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/samsarahq/thunder/diff"
 	"github.com/samsarahq/thunder/internal"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDiffListString(t *testing.T) {
@@ -125,7 +126,9 @@ func TestDiffListOrder(t *testing.T) {
 		map[string]interface{}{"__key": "1"},
 		map[string]interface{}{"__key": "2"},
 		map[string]interface{}{"__key": "3"},
+		nil,
 	}, []interface{}{
+		nil,
 		map[string]interface{}{"__key": "3"},
 		map[string]interface{}{"__key": "-1"},
 		map[string]interface{}{"__key": "0"},
@@ -133,22 +136,22 @@ func TestDiffListOrder(t *testing.T) {
 		map[string]interface{}{"__key": "4"},
 	})
 
-	if !reflect.DeepEqual(internal.AsJSON(d), internal.ParseJSON(`
-		{"$": [3, -1, [0, 2], -1], "1": [{}], "4": [{}]}
-	`)) {
-		t.Error("bad reorder")
-	}
+	assert.Equal(t, internal.ParseJSON(`
+		{"$": [4, 3, -1, [0, 2], -1], "2": [{}], "5": [{}]}
+	`), internal.AsJSON(d))
 
 	d = diff.Diff([]interface{}{
 		map[string]interface{}{"__key": "0"},
 		map[string]interface{}{"__key": "1"},
 		map[string]interface{}{"__key": "2"},
 		map[string]interface{}{"__key": "3"},
+		nil,
 	}, []interface{}{
 		map[string]interface{}{"__key": "0"},
 		map[string]interface{}{"__key": "1"},
 		map[string]interface{}{"__key": "2"},
 		map[string]interface{}{"__key": "3"},
+		nil,
 	})
 	if d != nil {
 		t.Error("bad identical")


### PR DESCRIPTION
## What changed?

When passed an array with nil values, `diff.Diff` would panic. This no longer happens.

## Test plan

Updated unit tests to add breaking case, the diff seems reasonable. The tests also worked without updating the tests file, which means there is no breaking behavior here.