### PR TITLE
go fields: explicity support non-pointer marshalers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - `sqlgen.Tester` now compares `driver.Value`s. ([#170](https://github.com/samsarahq/thunder/pull/170))
 - Support converting the zero value of fields to NULL in the db with tag `sql:",implicitnull"`. ([#181](https://github.com/samsarahq/thunder/pull/181))
+- Support non-pointer protobuf structs. ([#185](https://github.com/samsarahq/thunder/pull/185))
 
 ## [0.4.0] - 2018-09-13
 

--- a/sqlgen/integration_test.go
+++ b/sqlgen/integration_test.go
@@ -8,6 +8,7 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/samsarahq/thunder/batch"
+	"github.com/samsarahq/thunder/internal/proto"
 	"github.com/samsarahq/thunder/internal/testfixtures"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,10 +21,11 @@ func setup() (*testfixtures.TestDatabase, *DB, error) {
 
 	if _, err = testDb.Exec(`
 		CREATE TABLE users (
-			id   BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-			name VARCHAR(255),
-			uuid VARCHAR(255),
-			mood VARCHAR(255),
+			id            BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+			name          VARCHAR(255),
+			uuid          VARCHAR(255),
+			mood          VARCHAR(255),
+			proto         BLOB,
 			implicit_null VARCHAR(255)
 		)
 	`); err != nil {
@@ -40,7 +42,8 @@ type User struct {
 	Name         string
 	Uuid         testfixtures.CustomType
 	Mood         *testfixtures.CustomType
-	ImplicitNull string `sql:",implicitnull"`
+	Proto        proto.ExampleEvent `sql:",binary"`
+	ImplicitNull string             `sql:",implicitnull"`
 }
 
 type Complex struct {


### PR DESCRIPTION
Because we sometimes might want to use non-pointers for protobuf, check our non-pointer types.

Test plan:
- Create benchmark for the above - maybe we should have benchmarks per supported value
- Run simulation traffic if the benchmarks look significantly different (more than 5%)