### PR TITLE
graphql: make previous computation mutable by middlewares

### DIFF
--- a/graphql/middleware.go
+++ b/graphql/middleware.go
@@ -5,13 +5,14 @@ import (
 )
 
 type ComputationInput struct {
-	Id          string
-	Query       string
-	ParsedQuery *Query
-	Variables   map[string]interface{}
-	Ctx         context.Context
-	Previous    interface{}
-	Extensions  map[string]interface{}
+	Id                   string
+	Query                string
+	ParsedQuery          *Query
+	Variables            map[string]interface{}
+	Ctx                  context.Context
+	Previous             interface{}
+	IsInitialComputation bool
+	Extensions           map[string]interface{}
 }
 
 type ComputationOutput struct {


### PR DESCRIPTION
Allow middlewares to mutate the previous computation output, for altering the diff sent back.

Also expose whether this is an initial computation to the middlewares.