### PR TITLE
graphql: export ErrorCause helper

### DIFF
--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -38,7 +38,7 @@ func nestPathError(key string, err error) error {
 	}
 }
 
-func extractPathError(err error) error {
+func ErrorCause(err error) error {
 	if pe, ok := err.(*pathError); ok {
 		return pe.inner
 	}

--- a/graphql/http.go
+++ b/graphql/http.go
@@ -104,7 +104,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		current, err := output.Current, output.Error
 
 		if err != nil {
-			if extractPathError(err) == context.Canceled {
+			if ErrorCause(err) == context.Canceled {
 				return nil, err
 			}
 

--- a/graphql/server.go
+++ b/graphql/server.go
@@ -237,7 +237,7 @@ func (c *conn) handleSubscribe(in *inEnvelope) error {
 		c.logger.FinishExecution(ctx, tags, time.Since(start))
 
 		if err != nil {
-			if extractPathError(err) == context.Canceled {
+			if ErrorCause(err) == context.Canceled {
 				go c.closeSubscription(id)
 				return nil, err
 			}
@@ -373,7 +373,7 @@ func (c *conn) handleMutate(in *inEnvelope) error {
 
 			go c.closeSubscription(id)
 
-			if extractPathError(err) == context.Canceled {
+			if ErrorCause(err) == context.Canceled {
 				return nil, err
 			}
 


### PR DESCRIPTION
This PR exports `ErrorCause` which allows client code to extract the root, unwrapped error for checking. It is useful for checking root case, e.g.:

```golang
if graphql.ErrorCause(err) == context.Canceled {
  // ...
}
```