### PR TITLE
go sqlgen: add BuildStruct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 - `sqlgen.Tester` now compares `driver.Value`s. ([#170](https://github.com/samsarahq/thunder/pull/170))
 - Support converting the zero value of fields to NULL in the db with tag `sql:",implicitnull"`. ([#181](https://github.com/samsarahq/thunder/pull/181))
 - Support non-pointer protobuf structs. ([#185](https://github.com/samsarahq/thunder/pull/185))
+- `BuildStruct` is added back and defined on `sqlgen.Schema`. ([#195](https://github.com/samsarahq/thunder/pull/195))
+- `UnbuildStruct` is now defined `sqlgen.Schema`. It's not a package level
+  function anymore. ([#195](https://github.com/samsarahq/thunder/pull/195))
 
 ## [0.4.0] - 2018-09-13
 

--- a/sqlgen/reflect_test.go
+++ b/sqlgen/reflect_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/samsarahq/thunder/internal/fields"
 	"github.com/samsarahq/thunder/internal/testfixtures"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testMakeSnake(t *testing.T, s, expected string) {
@@ -544,4 +545,20 @@ func TestDriverValuesEqual(t *testing.T) {
 			assert.Equal(t, c.equal, driverValuesEqual(c.right, c.left))
 		})
 	}
+}
+
+func TestBuildStruct(t *testing.T) {
+	s := NewSchema()
+	require.NoError(t, s.RegisterType("users", AutoIncrement, user{}))
+
+	u, err := s.BuildStruct("users", []driver.Value{
+		1, "foo", 18, nil, []byte("bar"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, &user{
+		Id:   1,
+		Name: "foo",
+		Age:  18,
+		Uuid: testfixtures.CustomTypeFromString("bar"),
+	}, u)
 }


### PR DESCRIPTION
Add BuildStruct method back into sqlgen so we can parse
binlog row event the same way we scan from MySQL driver.

This was removed in https://github.com/samsarahq/thunder/pull/166.