### PR TITLE
hook in AddDependency

### DIFF
--- a/livesql/marshal.go
+++ b/livesql/marshal.go
@@ -41,7 +41,8 @@ func valueToField(value driver.Value) (*thunderpb.Field, error) {
 	}
 }
 
-func fieldToValue(field *thunderpb.Field) (driver.Value, error) {
+// FieldToValue converts thunderpb.Field to driver.Value.
+func FieldToValue(field *thunderpb.Field) (driver.Value, error) {
 	switch field.Kind {
 	case thunderpb.FieldKind_Null:
 		return nil, nil
@@ -112,7 +113,7 @@ func filterFromProto(schema *sqlgen.Schema, proto *thunderpb.SQLFilter) (string,
 
 	filter := make(sqlgen.Filter, len(proto.Fields))
 	for col, field := range proto.Fields {
-		val, err := fieldToValue(field)
+		val, err := FieldToValue(field)
 		if err != nil {
 			return "", nil, err
 		}


### PR DESCRIPTION
This is a hack to support binlog invalidation outside livesql.

Two commits:
```
go reactive: add dependency callback

We want to move binlog invalidation out of sqlgen/livesql.
By adding a hook in AddDependency, we can add a child
resource in the computation node that caches SQL result,
and kick off custom invalidations.
```

```
go livesql: expose FieldToValue

We'd like to parse driver.Value from thunderpb.Field added
in AddDependency calls in DependencyCallback.
```