### PR TITLE
go reactive: dependency does not need to be serializable

### DIFF
--- a/livesql/marshal.go
+++ b/livesql/marshal.go
@@ -69,8 +69,8 @@ func FieldToValue(field *thunderpb.Field) (driver.Value, error) {
 	}
 }
 
-// filterToProto takes a sqlgen.Filter, runs Valuer on each filter value, and returns a thunderpb.SQLFilter.
-func filterToProto(schema *sqlgen.Schema, tableName string, filter sqlgen.Filter) (*thunderpb.SQLFilter, error) {
+// FilterToProto takes a sqlgen.Filter, runs Valuer on each filter value, and returns a thunderpb.SQLFilter.
+func FilterToProto(schema *sqlgen.Schema, tableName string, filter sqlgen.Filter) (*thunderpb.SQLFilter, error) {
 	table, ok := schema.ByName[tableName]
 	if !ok {
 		return nil, fmt.Errorf("unknown table: %s", tableName)
@@ -101,8 +101,8 @@ func filterToProto(schema *sqlgen.Schema, tableName string, filter sqlgen.Filter
 	return &thunderpb.SQLFilter{Table: tableName, Fields: fields}, nil
 }
 
-// filterFromProto takes a thunderpb.SQLFilter, runs Scanner on each field value, and returns a sqlgen.Filter.
-func filterFromProto(schema *sqlgen.Schema, proto *thunderpb.SQLFilter) (string, sqlgen.Filter, error) {
+// FilterFromProto takes a thunderpb.SQLFilter, runs Scanner on each field value, and returns a sqlgen.Filter.
+func FilterFromProto(schema *sqlgen.Schema, proto *thunderpb.SQLFilter) (string, sqlgen.Filter, error) {
 	table, ok := schema.ByName[proto.Table]
 	if !ok {
 		return "", nil, fmt.Errorf("unknown table: %s", proto.Table)

--- a/livesql/marshal_test.go
+++ b/livesql/marshal_test.go
@@ -91,10 +91,10 @@ func TestMarshal(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			proto, err := filterToProto(schema, "users", c.filter)
+			proto, err := FilterToProto(schema, "users", c.filter)
 			assert.NoError(t, err)
 
-			table, filter, err := filterFromProto(schema, proto)
+			table, filter, err := FilterFromProto(schema, proto)
 			if c.err {
 				assert.NotNil(t, err)
 			} else {


### PR DESCRIPTION
We see keeping a dependency set of protobuf message uses
a lot of memory. We think building protobuf messages has
significant overhead. Instead, we will export a QueryDependency
type in livesql, and it will be up the user to call method in livesql
to turn them into protobuf messages.