### PR TITLE
Bugfix: sort/filter fields now support pointer sources

### DIFF
--- a/graphql/connection_test.go
+++ b/graphql/connection_test.go
@@ -62,6 +62,9 @@ func TestConnection(t *testing.T) {
 		"foo": func(ctx context.Context, i Item) string {
 			return i.FilterText
 		},
+		"bar": func(ctx context.Context, i *Item) string {
+			return ""
+		},
 	})
 	inner.FieldFunc("innerConnectionWithSort", func() []Item {
 		return []Item{
@@ -75,7 +78,7 @@ func TestConnection(t *testing.T) {
 		"numbers": func(ctx context.Context, i Item) int64 {
 			return i.Number
 		},
-		"strings": func(ctx context.Context, i Item) string {
+		"strings": func(ctx context.Context, i *Item) string {
 			return i.String
 		},
 		"floats": func(ctx context.Context, i Item) float64 {

--- a/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
+++ b/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
@@ -200,9 +200,13 @@
                     "kind": "NON_NULL",
                     "name": "",
                     "ofType": {
-                      "kind": "OBJECT",
-                      "name": "user",
-                      "ofType": null
+                      "kind": "NON_NULL",
+                      "name": "",
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "user",
+                        "ofType": null
+                      }
                     }
                   }
                 }
@@ -686,9 +690,13 @@
                   "isDeprecated": false,
                   "name": "node",
                   "type": {
-                    "kind": "OBJECT",
-                    "name": "user",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "user",
+                      "ofType": null
+                    }
                   }
                 }
               ],

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -831,11 +831,18 @@ func (sb *schemaBuilder) buildPaginatedField(typ reflect.Type, m *method) (*grap
 		return nil, err
 	}
 
-	if err := c.consumeTextFilters(sb, m, nodeType); err != nil {
+	// If the node type is a pointer, get a non-pointer reference for building text filter and
+	// sort FieldFuncs.
+	nonPtrNodeType := nodeType
+	if nodeType.Kind() == reflect.Ptr {
+		nonPtrNodeType = nodeType.Elem()
+	}
+
+	if err := c.consumeTextFilters(sb, m, nonPtrNodeType); err != nil {
 		return nil, err
 	}
 
-	if err := c.consumeSorts(sb, m, nodeType); err != nil {
+	if err := c.consumeSorts(sb, m, nonPtrNodeType); err != nil {
 		return nil, err
 	}
 

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -208,7 +208,7 @@ func (sb *schemaBuilder) constructEdgeType(typ reflect.Type) (graphql.Type, erro
 			return nil, fmt.Errorf("error resolving node in edge")
 
 		},
-		Type:           nodeType,
+		Type:           &graphql.NonNull{Type: nodeType},
 		ParseArguments: nilParseArguments,
 	}
 	fieldMap["node"] = nodeField

--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -684,6 +684,10 @@ func (funcCtx *funcContext) prepareResolveArgs(source interface{}, args interfac
 func (sb *schemaBuilder) buildFunction(typ reflect.Type, m *method) (*graphql.Field, error) {
 	funcCtx := &funcContext{typ: typ}
 
+	if typ.Kind() == reflect.Ptr {
+		return nil, fmt.Errorf("source-type of buildFunction cannot be a pointer (got: %v)", typ)
+	}
+
 	fun, err := funcCtx.getFuncVal(m)
 	if err != nil {
 		return nil, err

--- a/sqlgen/integration_test.go
+++ b/sqlgen/integration_test.go
@@ -277,12 +277,12 @@ func BenchmarkSql(b *testing.B) {
 	}{
 		{"Read", func() error {
 			user := &User{}
-			row := db.Conn.QueryRowContext(ctx, `SELECT * from users`)
+			row := db.Conn.QueryRowContext(ctx, `SELECT id, name, uuid, mood from users`)
 			return row.Scan(&user.Id, &user.Name, &user.Uuid, &user.Mood)
 		}},
 		{"Read_Where", func() error {
 			user := &User{}
-			row := db.Conn.QueryRowContext(ctx, `SELECT * from users where users.name = ?`, "Bob")
+			row := db.Conn.QueryRowContext(ctx, `SELECT id, name, uuid, mood from users where users.name = ?`, "Bob")
 			return row.Scan(&user.Id, &user.Name, &user.Uuid, &user.Mood)
 		}},
 		{"Create", func() error {


### PR DESCRIPTION
When pointers are passed into buildFunction it gets things wrong.

When determining if the function is a ptr-func, it checks to see if the ptr representation of a type
matches what is passed in as an argument to the function.

Because we are passing in a pointer, that pointer representation ends up being a dual pointer.

Added an error so that we can't shoot ourselves in the foot this way again.

Also in this PR:
- Nodes on connections are marked as non-null