### PR TITLE
reactive: delay rerunner in order to emulate write-then-read behavior

### DIFF
--- a/graphql/end_to_end_test.go
+++ b/graphql/end_to_end_test.go
@@ -283,7 +283,7 @@ func TestEndToEndAwaitAndCache(t *testing.T) {
 
 	result := <-results
 	duration := time.Since(start)
-	if duration > 150*time.Millisecond {
+	if duration > 450*time.Millisecond {
 		t.Errorf("did not execute in parallel; duration %v > 150ms", duration)
 	}
 	if !reflect.DeepEqual(result, internal.ParseJSON(`
@@ -302,7 +302,7 @@ func TestEndToEndAwaitAndCache(t *testing.T) {
 	users[0].resource.Strobe()
 	result = <-results
 	duration = time.Since(start)
-	if duration > 150*time.Millisecond {
+	if duration > 450*time.Millisecond {
 		t.Errorf("did not execute in parallel; duration %v > 150ms", duration)
 	}
 	if !reflect.DeepEqual(result, internal.ParseJSON(`


### PR DESCRIPTION
Add a delay to wait after hearing a change was made, before reading that change by rerunning.