### PR TITLE
go graphql: Add ability to automatically TextMarshal/Unmarshal types

### DIFF
--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -90,6 +90,11 @@ func PrepareQuery(typ Type, selectionSet *SelectionSet) error {
 			return NewClientError("enum field must have no selections")
 		}
 		return nil
+	case *CustomScalar:
+		if selectionSet != nil {
+			return NewClientError("scalar field must have no selections")
+		}
+		return nil
 	case *Union:
 		if selectionSet == nil {
 			return NewClientError("object field must have selections")
@@ -373,6 +378,8 @@ func (e *Executor) execute(ctx context.Context, typ Type, source interface{}, se
 			return mapVal, nil
 		}
 		return nil, errors.New("enum is not valid")
+	case *CustomScalar:
+		return typ.Unwrapper(source)
 	case *Union:
 		return e.executeUnion(ctx, typ, source, selectionSet)
 	case *Object:

--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -99,6 +99,8 @@ func (s *introspection) registerType(schema *schemabuilder.Schema) {
 			return UNION
 		case *graphql.Scalar:
 			return SCALAR
+		case *graphql.CustomScalar:
+			return SCALAR
 		case *graphql.Enum:
 			return ENUM
 		case *graphql.List:
@@ -120,6 +122,8 @@ func (s *introspection) registerType(schema *schemabuilder.Schema) {
 			return t.Name
 		case *graphql.Scalar:
 			return t.Type
+		case *graphql.CustomScalar:
+			return t.TypeName
 		case *graphql.Enum:
 			return t.Type
 		case *graphql.InputObject:
@@ -278,6 +282,12 @@ func collectTypes(typ graphql.Type, types map[string]graphql.Type) {
 			return
 		}
 		types[typ.Type] = typ
+
+	case *graphql.CustomScalar:
+		if _, ok := types[typ.TypeName]; ok {
+			return
+		}
+		types[typ.TypeName] = typ
 
 	case *graphql.Enum:
 		if _, ok := types[typ.Type]; ok {

--- a/graphql/schemabuilder/build.go
+++ b/graphql/schemabuilder/build.go
@@ -1,6 +1,7 @@
 package schemabuilder
 
 import (
+	"encoding"
 	"fmt"
 	"reflect"
 	"time"
@@ -53,6 +54,10 @@ func (sb *schemaBuilder) getType(nodeType reflect.Type) (graphql.Type, error) {
 		}
 	}
 
+	if nodeType.Implements(textMarshalerType) {
+		return sb.getTextMarshalerType(nodeType)
+	}
+
 	// Structs
 	if nodeType.Kind() == reflect.Struct {
 		if err := sb.buildStruct(nodeType); err != nil {
@@ -84,6 +89,34 @@ func (sb *schemaBuilder) getType(nodeType reflect.Type) (graphql.Type, error) {
 	default:
 		return nil, fmt.Errorf("bad type %s: should be a scalar, slice, or struct type", nodeType)
 	}
+}
+
+// getTextMarshalerType returns a graphQL type that can be used to parse a
+// encoding.TextMarshaler and convert it's value into a string in the graphQL
+// response.
+func (sb *schemaBuilder) getTextMarshalerType(typ reflect.Type) (graphql.Type, error) {
+	scalar := &graphql.CustomScalar{
+		TypeName: "string",
+		Unwrapper: func(source interface{}) (interface{}, error) {
+			i := reflect.ValueOf(source)
+			if i.Kind() == reflect.Ptr && i.IsNil() {
+				return "", nil
+			}
+			marshalVal, ok := i.Interface().(encoding.TextMarshaler)
+			if !ok {
+				return nil, fmt.Errorf("cannot convert field to text")
+			}
+			val, err := marshalVal.MarshalText()
+			if err != nil {
+				return nil, err
+			}
+			return string(val), nil
+		},
+	}
+	if typ.Kind() == reflect.Ptr {
+		return scalar, nil
+	}
+	return &graphql.NonNull{Type: scalar}, nil
 }
 
 // getEnum gets the Enum type information for the passed in reflect.Type by

--- a/graphql/schemabuilder/input.go
+++ b/graphql/schemabuilder/input.go
@@ -1,6 +1,7 @@
 package schemabuilder
 
 import (
+	"encoding"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -171,6 +172,10 @@ func (sb *schemaBuilder) makeArgParserInner(typ reflect.Type) (*argParser, graph
 		return parser, argType, nil
 	}
 
+	if reflect.PtrTo(typ).Implements(textUnmarshalerType) {
+		return sb.makeTextUnmarshalerParser(typ)
+	}
+
 	switch typ.Kind() {
 	case reflect.Struct:
 		parser, argType, err := sb.makeStructParser(typ)
@@ -228,6 +233,26 @@ func (sb *schemaBuilder) getEnumArgParser(typ reflect.Type) (*argParser, graphql
 		return nil
 	}, Type: typ}, &graphql.Enum{Type: typ.Name(), Values: values, ReverseMap: sb.enumMappings[typ].ReverseMap}
 
+}
+
+// makeTextUnmarshalerParser returns an argParser that will read the passed in
+// value as a string and insert it into the destination type using the
+// encoding.TextUnmarshaler API.
+func (sb *schemaBuilder) makeTextUnmarshalerParser(typ reflect.Type) (*argParser, graphql.Type, error) {
+	return &argParser{
+		FromJSON: func(value interface{}, dest reflect.Value) error {
+			asString, ok := value.(string)
+			if !ok {
+				return errors.New("not a string")
+			}
+			unmarshalable, ok := dest.Addr().Interface().(encoding.TextUnmarshaler)
+			if !ok {
+				return errors.New("not unmarshalable")
+			}
+			return unmarshalable.UnmarshalText([]byte(asString))
+		},
+		Type: typ,
+	}, &graphql.Scalar{Type: "string"}, nil
 }
 
 // makeSliceParser creates an arg parser for a slice field.

--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -3,6 +3,7 @@ package schemabuilder
 import (
 	"bytes"
 	"context"
+	"encoding"
 	"fmt"
 	"reflect"
 	"strings"
@@ -85,4 +86,5 @@ func parseGraphQLFieldInfo(field reflect.StructField) (*graphQLFieldInfo, error)
 var errType = reflect.TypeOf((*error)(nil)).Elem()
 var contextType = reflect.TypeOf((*context.Context)(nil)).Elem()
 var selectionSetType = reflect.TypeOf(&graphql.SelectionSet{})
-
+var textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+var textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()

--- a/graphql/testdata/TestTextMarshaling.snapshots.json
+++ b/graphql/testdata/TestTextMarshaling.snapshots.json
@@ -1,0 +1,66 @@
+[
+  {
+    "Name": "happy path all inputs and outputs",
+    "Values": [
+      {
+        "inner": {
+          "ptrUuid": "74771078-5edb-4733-88f2-000000000000",
+          "ptrUuidSlice": [
+            "00000000-0000-0000-0000-000000000000",
+            "",
+            "00000000-0000-0000-0000-000000000001"
+          ],
+          "ptruuidslicefunc": [
+            "00000000-0000-0000-0000-000000000000",
+            "",
+            "00000000-0000-0000-0000-000000000001"
+          ],
+          "uuid": "74771078-5edb-4733-88f2-111111111111",
+          "uuidSlice": [
+            "74771078-5edb-4733-88f2-222222222222",
+            "74771078-5edb-4733-88f2-333333333333",
+            "74771078-5edb-4733-88f2-444444444444"
+          ],
+          "uuidfunc": "74771078-5edb-4733-88f2-111111111111",
+          "uuidslicefunc": [
+            "74771078-5edb-4733-88f2-222222222222",
+            "74771078-5edb-4733-88f2-333333333333",
+            "74771078-5edb-4733-88f2-444444444444"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "Name": "invalid ptr uuid input",
+    "Values": [
+      {
+        "Error": "error parsing args for \"inner\": inputPtrUuid: uuid: incorrect UUID length: invaliduuid"
+      }
+    ]
+  },
+  {
+    "Name": "invalid uuid input",
+    "Values": [
+      {
+        "Error": "error parsing args for \"inner\": inputUuid: uuid: incorrect UUID length: invaliduuid"
+      }
+    ]
+  },
+  {
+    "Name": "invalid uuid slice input",
+    "Values": [
+      {
+        "Error": "error parsing args for \"inner\": inputUuidSlice: uuid: incorrect UUID length: invaliduuid"
+      }
+    ]
+  },
+  {
+    "Name": "invalid uuid func response",
+    "Values": [
+      {
+        "Error": "inner.invaliduuidfunc: invalidUUID"
+      }
+    ]
+  }
+]

--- a/graphql/textmarshal_test.go
+++ b/graphql/textmarshal_test.go
@@ -1,0 +1,169 @@
+package graphql_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/samsarahq/thunder/graphql/schemabuilder"
+	"github.com/samsarahq/thunder/internal/testgraphql"
+	"github.com/satori/go.uuid"
+)
+
+func TestTextMarshaling(t *testing.T) {
+	schema := schemabuilder.NewSchema()
+
+	type Inner struct {
+		PtrUuid      *Uuid
+		Uuid         Uuid
+		UuidSlice    []Uuid
+		PtrUuidSlice []*Uuid
+	}
+
+	o := schema.Object("Inner", Inner{})
+	o.FieldFunc("uuidfunc", func(inner Inner) Uuid {
+		return inner.Uuid
+	})
+	o.FieldFunc("uuidslicefunc", func(inner Inner) []Uuid {
+		return inner.UuidSlice
+	})
+	o.FieldFunc("ptruuidslicefunc", func(inner Inner) []*Uuid {
+		return inner.PtrUuidSlice
+	})
+	o.FieldFunc("invaliduuidfunc", func(inner Inner) Uuid {
+		return Uuid{marshalError: errors.New("invalidUUID")} // Invalid Uuid type (for testing)
+	})
+
+	PtrUuidSliceResp := []*Uuid{
+		NewUuidPtr(),
+		nil,
+		NewUuidPtr(),
+	}
+
+	query := schema.Query()
+	query.FieldFunc("inner", func(input struct {
+		InputPtrUuid   *Uuid
+		InputUuid      Uuid
+		InputUuidSlice []Uuid
+	}) Inner {
+		return Inner{
+			PtrUuid:      input.InputPtrUuid,
+			Uuid:         input.InputUuid,
+			UuidSlice:    input.InputUuidSlice,
+			PtrUuidSlice: PtrUuidSliceResp,
+		}
+	})
+
+	_ = schema.Mutation()
+
+	builtSchema := schema.MustBuild()
+
+	snap := testgraphql.NewSnapshotter(t, builtSchema)
+	defer snap.Verify()
+
+	snap.SnapshotQuery("happy path all inputs and outputs", `{
+		inner(
+			inputPtrUuid: "74771078-5edb-4733-88f2-000000000000", 
+			inputUuid: "74771078-5edb-4733-88f2-111111111111", 
+			inputUuidSlice: ["74771078-5edb-4733-88f2-222222222222", "74771078-5edb-4733-88f2-333333333333", "74771078-5edb-4733-88f2-444444444444"], 
+		) { 
+			ptrUuid
+			uuid
+			uuidSlice
+			ptrUuidSlice
+			uuidfunc
+			uuidslicefunc
+			ptruuidslicefunc
+		}
+	}`)
+
+	snap.SnapshotQuery("invalid ptr uuid input", `{
+		inner(
+			inputPtrUuid: "invaliduuid", 
+			inputUuid: "74771078-5edb-4733-88f2-111111111111", 
+			inputUuidSlice: ["74771078-5edb-4733-88f2-222222222222"], 
+		) { 
+			ptrUuid
+		}
+	}`, testgraphql.RecordError)
+
+	snap.SnapshotQuery("invalid uuid input", `{
+		inner(
+			inputPtrUuid: "74771078-5edb-4733-88f2-000000000000", 
+			inputUuid: "invaliduuid", 
+			inputUuidSlice: ["74771078-5edb-4733-88f2-222222222222"], 
+		) { 
+			uuid
+		}
+	}`, testgraphql.RecordError)
+
+	snap.SnapshotQuery("invalid uuid slice input", `{
+		inner(
+			inputPtrUuid: "74771078-5edb-4733-88f2-000000000000", 
+			inputUuid: "74771078-5edb-4733-88f2-111111111111", 
+			inputUuidSlice: ["74771078-5edb-4733-88f2-222222222222", "invaliduuid"], 
+		) { 
+			uuidSlice
+		}
+	}`, testgraphql.RecordError)
+
+	snap.SnapshotQuery("invalid uuid func response", `{
+		inner(
+			inputPtrUuid: "74771078-5edb-4733-88f2-000000000000", 
+			inputUuid: "74771078-5edb-4733-88f2-111111111111", 
+			inputUuidSlice: ["74771078-5edb-4733-88f2-222222222222"], 
+		) { 
+			invaliduuidfunc
+		}
+	}`, testgraphql.RecordError)
+
+}
+
+// Uuid is a testable version of a "Text Marshalable" type.
+type Uuid struct {
+	bytes        [16]byte
+	marshalError error
+}
+
+func NewUuidPtr() *Uuid {
+	u := NewUuid()
+	return &u
+}
+
+var counter = byte(0)
+
+func NewUuid() Uuid {
+	u := Uuid{
+		bytes: [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, byte(counter)},
+	}
+	counter += 1
+	return u
+}
+
+func (u Uuid) MarshalText() ([]byte, error) {
+	if u.marshalError != nil {
+		return nil, u.marshalError
+	}
+	return []byte(u.string()), nil
+}
+
+func (u Uuid) string() string {
+	uuid, err := uuid.FromBytes([]byte(u.bytes[:]))
+	if err != nil {
+		return ""
+	}
+	return uuid.String()
+}
+
+func (u *Uuid) UnmarshalText(data []byte) error {
+	if string(data) == "" {
+		return nil
+	}
+
+	uu, err := uuid.FromString(string(data))
+	if err != nil {
+		return err
+	}
+
+	*u = Uuid{bytes: uu}
+	return nil
+}

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -43,6 +43,18 @@ func (e *Enum) enumValues() []string {
 	return e.Values
 }
 
+// CustomScalar is a leaf value with a custom Unwrapper function.
+type CustomScalar struct {
+	TypeName  string
+	Unwrapper func(interface{}) (interface{}, error)
+}
+
+func (c *CustomScalar) isType() {}
+
+func (c *CustomScalar) String() string {
+	return c.TypeName
+}
+
 // Object is a value with several fields
 type Object struct {
 	Name        string

--- a/internal/testgraphql/snapshotter.go
+++ b/internal/testgraphql/snapshotter.go
@@ -43,7 +43,12 @@ func (s *Snapshotter) SnapshotQuery(name, query string, opts ...Option) {
 	opt := applyOpts(opts)
 
 	q := graphql.MustParse(query, nil)
-	require.NoError(s.t, graphql.PrepareQuery(s.schema.Query, q.SelectionSet))
+	err := graphql.PrepareQuery(s.schema.Query, q.SelectionSet)
+	if err != nil && opt.recordError {
+		s.Snapshot(name, struct{ Error string }{err.Error()})
+		return
+	}
+	require.NoError(s.t, err)
 	output, err := s.executor.Execute(context.Background(), s.schema.Query, nil, q)
 
 	if err != nil && opt.recordError {


### PR DESCRIPTION
Summary: Updates the GraphQL package so that if we encounter a type when
parsing the graph that implements the encoding.TextMarshaler/TextUnmarshaler 
interfaces we will automatically convert that type to and from a string in the 
graphql input and output types.