### PR TITLE
go graphql: Add support for Default/ZeroValue parameter defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### `graphql`
 
+- Added support for marking input parameters as `graphql:",optional"` for graphql functions. These fields will be guaranteed to not error if they are not provided by callers.
 - Added automatic support for encoding.TextMarshaler/Unmarshaler types to be exposed as string fields.
 - Object key must now be scalar. ([#190](https://github.com/samsarahq/thunder/pull/190))
 - `ErrorCause` is a new exported function that can be used to unwrap pathErrors returned from middlleware. ([#191](https://github.com/samsarahq/thunder/pull/191))

--- a/graphql/defaultargs_test.go
+++ b/graphql/defaultargs_test.go
@@ -1,0 +1,63 @@
+package graphql_test
+
+import (
+	"testing"
+
+	"github.com/samsarahq/thunder/graphql/schemabuilder"
+	"github.com/samsarahq/thunder/internal/testgraphql"
+)
+
+func TestDefaultArgs(t *testing.T) {
+	schema := schemabuilder.NewSchema()
+
+	type Inner struct {
+		OptionalValue string
+		RequiredValue string
+	}
+
+	query := schema.Query()
+	query.FieldFunc("inner", func(input struct {
+		OptionalInput string `graphql:",optional"`
+		RequiredInput string
+	}) Inner {
+		return Inner{
+			OptionalValue: input.OptionalInput,
+			RequiredValue: input.RequiredInput,
+		}
+	})
+
+	_ = schema.Mutation()
+
+	builtSchema := schema.MustBuild()
+
+	snap := testgraphql.NewSnapshotter(t, builtSchema)
+	defer snap.Verify()
+
+	snap.SnapshotQuery("happy path all provided", `{
+		inner(
+			optionalInput: "teeeeeeeest", 
+			requiredInput: "requiredInput!", 
+		) { 
+			optionalValue
+			requiredValue
+		}
+	}`)
+
+	snap.SnapshotQuery("missing required parameter", `{
+		inner(
+			optionalInput: "teeeeeeeest", 
+		) { 
+			optionalValue
+			requiredValue
+		}
+	}`, testgraphql.RecordError)
+
+	snap.SnapshotQuery("missing optional parameter does not error", `{
+		inner(
+			requiredInput: "teeeeeeeest", 
+		) { 
+			optionalValue
+			requiredValue
+		}
+	}`)
+}

--- a/graphql/schemabuilder/reflect.go
+++ b/graphql/schemabuilder/reflect.go
@@ -49,6 +49,10 @@ type graphQLFieldInfo struct {
 
 	// KeyField indicates that this field should be treated as a Object Key field.
 	KeyField bool
+
+	// OptionalInputField indicates that this field should be treated as an optional
+	// field on graphQL input args.
+	OptionalInputField bool
 }
 
 // parseGraphQLFieldInfo parses a struct field and returns a struct with the
@@ -70,16 +74,20 @@ func parseGraphQLFieldInfo(field reflect.StructField) (*graphQLFieldInfo, error)
 	}
 
 	var key bool
+	var optional bool
 
 	if len(tags) > 1 {
 		for _, tag := range tags[1:] {
-			if tag != "key" || key {
+			if tag == "key" && !key {
+				key = true
+			} else if tag == "optional" && !optional {
+				optional = true
+			} else {
 				return nil, fmt.Errorf("field %s has unexpected tag %s", name, tag)
 			}
-			key = true
 		}
 	}
-	return &graphQLFieldInfo{Name: name, KeyField: key}, nil
+	return &graphQLFieldInfo{Name: name, KeyField: key, OptionalInputField: optional}, nil
 }
 
 // Common Types that we will need to perform type assertions against.

--- a/graphql/testdata/TestDefaultArgs.snapshots.json
+++ b/graphql/testdata/TestDefaultArgs.snapshots.json
@@ -1,0 +1,32 @@
+[
+  {
+    "Name": "happy path all provided",
+    "Values": [
+      {
+        "inner": {
+          "optionalValue": "teeeeeeeest",
+          "requiredValue": "requiredInput!"
+        }
+      }
+    ]
+  },
+  {
+    "Name": "missing required parameter",
+    "Values": [
+      {
+        "Error": "error parsing args for \"inner\": requiredInput: not a string"
+      }
+    ]
+  },
+  {
+    "Name": "missing optional parameter does not error",
+    "Values": [
+      {
+        "inner": {
+          "optionalValue": "",
+          "requiredValue": "teeeeeeeest"
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Summary: Adds support for graphql parameter fields to be noop fields.
Previously if you wanted to add a non-pointer field as a new input arg
to one of your functions this would break all existing callers (since 
they would not have the proper field).  Now if you have an existing
input struct like:
```
type Input struct {
  Arg1 string
  Arg2 string
}
```

You can safely add a new type like so:
```
type Input struct {
  Arg1 string
  Arg2 string
  Arg3 string `graphql:",optional"`
}
```
And the Arg3 string will get filled with "" if no args are provided.