### PR TITLE
Add support of setting proper Content-Type header, small optimisation

### DIFF
--- a/graphql/http.go
+++ b/graphql/http.go
@@ -47,8 +47,10 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-
-		http.Error(w, string(responseJSON), http.StatusOK)
+		if w.Header().Get("Content-Type") == "" {
+			w.Header().Set("Content-Type", "application/json")
+		}
+		w.Write(responseJSON)
 	}
 
 	if r.Method != "POST" {

--- a/graphql/http_test.go
+++ b/graphql/http_test.go
@@ -41,7 +41,7 @@ func TestHTTPMustPost(t *testing.T) {
 		t.Errorf("expected 200, but received %d", rr.Code)
 	}
 
-	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"request must be a POST\"]}\n"); diff != "" {
+	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"request must be a POST\"]}"); diff != "" {
 		t.Errorf("expected response to match, but received %s", diff)
 	}
 }
@@ -58,7 +58,7 @@ func TestHTTPParseQuery(t *testing.T) {
 		t.Errorf("expected 200, but received %d", rr.Code)
 	}
 
-	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"request must include a query\"]}\n"); diff != "" {
+	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"request must include a query\"]}"); diff != "" {
 		t.Errorf("expected response to match, but received %s", diff)
 	}
 }
@@ -75,7 +75,7 @@ func TestHTTPMustHaveQuery(t *testing.T) {
 		t.Errorf("expected 200, but received %d", rr.Code)
 	}
 
-	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"must have a single query\"]}\n"); diff != "" {
+	if diff := pretty.Compare(rr.Body.String(), "{\"data\":null,\"errors\":[\"must have a single query\"]}"); diff != "" {
 		t.Errorf("expected response to match, but received %s", diff)
 	}
 }
@@ -92,7 +92,24 @@ func TestHTTPSuccess(t *testing.T) {
 		t.Errorf("expected 200, but received %d", rr.Code)
 	}
 
-	if diff := pretty.Compare(rr.Body.String(), "{\"data\":{\"mirror\":-1},\"errors\":null}\n"); diff != "" {
+	if diff := pretty.Compare(rr.Body.String(), "{\"data\":{\"mirror\":-1},\"errors\":null}"); diff != "" {
+		t.Errorf("expected response to match, but received %s", diff)
+	}
+}
+
+func TestHTTPContentType(t *testing.T) {
+	req, err := http.NewRequest("POST", "/graphql", strings.NewReader(`{"query": "query TestQuery($value: int64) { mirror(value: $value) }", "variables": { "value": 1 }}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := testHTTPRequest(req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, but received %d", rr.Code)
+	}
+
+	if diff := pretty.Compare(rr.HeaderMap.Get("Content-Type"), "application/json"); diff != "" {
 		t.Errorf("expected response to match, but received %s", diff)
 	}
 }


### PR DESCRIPTION
I would like to add support of setting more relevant than `text/plain` Content-Type header for GraphQL. Regarding [specification](https://graphql.org/learn/serving-over-http/), response should has JSON format, so, the more suitable Content-Type is `application/json`.

This PR replaces using `http.Error` with `w.Write` for sending output to the client.

Why I think it is important.

Overriding Content-Type header inside `http.Error` is not only one thing, made me do this PR. In order to pass JSON to `http.Error`, you have to convert it to string. This is totally redundant operation for this case. Moreover, `http.Error` adds additional `\n` (because of `fmt.Fprintln()`) to each response of service, based on this framework. Though there is not any conventions in specifications of [HTTP/2](https://http2.github.io/http2-spec/) and [HTTP/1.1](https://tools.ietf.org/html/rfc2616#section-4.4) about setting `\n` in the end of message-body, but other huge GraphQL APIs, such as github, facebook and others do not set `\n` in the end of JSON response. I also do believe that `\n` in the end on JSON  response is useless and should be reworked.

This PR also removes default irrelevant for GraphQL setting `X-Content-Type-Options` header with `nosniff` value. However, you still able to set it (if needed) before starting processing `GraphQL.HTTPHandler`.

Because of `http.Write()` there is no need to send `http.StatusOk` with `w.WriteHeader()`. It will be don automatically.

In summary, after merging this PR, by default, response of GraphQL API based on this framework will use `Content-Type` header as `application/json`, will not has additional `\n` in the end of payload, will not has `X-Content-Type-Options` header, and will stop doing conversion bytes array to string on each response.

I would like to add an example, how still possible to set necessary for your application headers. For example, if you're using http router in the top of GraphQL API, you are able to do the next (sample with [go-chi](https://github.com/go-chi/chi) http router):

    ...
    r := chi.NewRouter()
    r.Group(func(router chi.Router) {
        router.Mount("/graphql", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
            w.Header().Set("X-Content-Type-Options", "nosniff")
            ...
            graphql.HTTPHandler(schema, func(input *graphql.ComputationInput, next graphql.MiddlewareNextFunc) *graphql.ComputationOutput {
                ...
            }).ServeHTTP(w, r)
        }))
    })
    ...
