### PR TITLE
Add human message that describes failed operation of decoding request body

### DIFF
--- a/graphql/http.go
+++ b/graphql/http.go
@@ -64,8 +64,8 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var params httpPostBody
-	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
-		writeResponse(nil, err)
+	if json.NewDecoder(r.Body).Decode(&params) != nil {
+		writeResponse(nil, errors.New("request must has a body with valid JSON structure"))
 		return
 	}
 


### PR DESCRIPTION
I would like to change error message, that occurs when decoding of request body is failed. It returns not useful message and it is not clearly enough to the client what happened. It's not a big problem, but I think we should have a general message here, that clearly says provided request data is not correct.
Examples, how it looks now:
- `{"data":null,"errors":["EOF"]}`
- `{"data":null,"errors":["json: cannot unmarshal object into Go struct field httpPostBody.query of type string"]}`
- `{"data":null,"errors":["invalid character 'v' after object key:value pair"]}`

How it would be after merging the PR:
- `{"data":null,"errors":["request must has a body with valid JSON structure"]}`

My main reason, why it should be done: correct error message will directly point clients to look on their request, instead of contacting GraphQL developers because "their stuff does not work as expected".