### PR TITLE
btuan/count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+#### `sqlgen`
+- Implemented a basic `(*sqlgen.DB).Count` receiver that wraps `SELECT COUNT(*)` functionality in SQL databases. ([#230](https://github.com/samsarahq/thunder/pull/230))
+
+
 ## [0.5.0] 2019-01-10
 
 ### Changed

--- a/sqlgen/integration_test.go
+++ b/sqlgen/integration_test.go
@@ -101,6 +101,10 @@ func TestIntegrationBasic(t *testing.T) {
 			Mood: &mood,
 		},
 	}, users)
+
+	numBobs, err := db.Count(context.Background(), &User{}, Filter{"name": "Bob"})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), numBobs)
 }
 
 // TestContextCancelBeforeRowsScan demonstrates we don't

--- a/sqlgen/mysql.go
+++ b/sqlgen/mysql.go
@@ -32,6 +32,28 @@ type SQLQuery interface {
 	ToSQL() (string, []interface{})
 }
 
+type countQuery struct {
+	Table string
+	Where *SimpleWhere
+}
+
+// ToSQL builds a parameterized SELECT COUNT(*) FROM x ... statement
+func (q *countQuery) ToSQL() (string, []interface{}) {
+	var buffer bytes.Buffer
+
+	buffer.WriteString("SELECT COUNT(*)")
+	buffer.WriteString(" FROM ")
+	buffer.WriteString(q.Table)
+
+	where, whereValues := q.Where.ToSQL()
+	if where != "" {
+		buffer.WriteString(" WHERE ")
+		buffer.WriteString(where)
+	}
+
+	return buffer.String(), whereValues
+}
+
 // SelectQuery represents a SELECT query
 type SelectQuery struct {
 	Table   string

--- a/sqlgen/mysql_test.go
+++ b/sqlgen/mysql_test.go
@@ -34,6 +34,24 @@ func TestSimpleWhere(t *testing.T) {
 	}, "foo = ? AND bar = ?", []interface{}{1, 2}, t)
 }
 
+func TestCountQuery(t *testing.T) {
+	testQuery(&countQuery{
+		Table:   "foo",
+		Where: &SimpleWhere{
+			Columns: []string{"bar"},
+			Values:  []interface{}{3},
+		},
+	}, "SELECT COUNT(*) FROM foo WHERE bar = ?", []interface{}{3}, t)
+
+	testQuery(&countQuery{
+		Table:   "foo2",
+		Where: &SimpleWhere{
+			Columns: []string{"baz"},
+			Values:  []interface{}{"xyz"},
+		},
+	}, "SELECT COUNT(*) FROM foo2 WHERE baz = ?", []interface{}{"xyz"}, t)
+}
+
 func TestSelectQuery(t *testing.T) {
 	testQuery(&SelectQuery{
 		Table:   "foo",

--- a/sqlgen/reflect_test.go
+++ b/sqlgen/reflect_test.go
@@ -170,6 +170,47 @@ func TestMakeWhere(t *testing.T) {
 	}
 }
 
+func TestMakeCount(t *testing.T) {
+	s := NewSchema()
+	if err := s.RegisterType("users", AutoIncrement, user{}); err != nil {
+		t.Fatal(err)
+	}
+
+	var usr user
+	query, err := s.makeCount(&usr, Filter{"id": 10})
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(query, &baseCountQuery{
+		Table:  s.ByName["users"],
+		Filter: Filter{"id": 10},
+	}) {
+		t.Error("bad count")
+	}
+
+	query, err = s.makeCount(&usr, Filter{})
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(query, &baseCountQuery{
+		Table:  s.ByName["users"],
+		Filter: Filter{},
+	}) {
+		t.Error("bad count")
+	}
+
+	query, err = s.makeCount(&usr, Filter{"name": "bob", "age": 10})
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(query, &baseCountQuery{
+		Table:  s.ByName["users"],
+		Filter: Filter{"name": "bob", "age": 10},
+	}) {
+		t.Error("bad count")
+	}
+}
+
 func TestMakeSelect(t *testing.T) {
 	s := NewSchema()
 	if err := s.RegisterType("users", AutoIncrement, user{}); err != nil {


### PR DESCRIPTION
Implements a basic `Count` receiver that wraps `SELECT COUNT(*)` functionality in SQL databases.