### PR TITLE
graphql: add Unwrap support

### DIFF
--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -45,6 +45,10 @@ func ErrorCause(err error) error {
 	return err
 }
 
+func (pe *pathError) Unwrap() error {
+	return pe.inner
+}
+
 func (pe *pathError) Error() string {
 	var buffer bytes.Buffer
 	for i := len(pe.path) - 1; i >= 0; i-- {


### PR DESCRIPTION
This PR adds Unwrap support to the pathError type, following the design from https://go.googlesource.com/proposal/+/master/design/29934-error-values.md