### PR TITLE
go graphql: Add BatchExecutor for controlled concurrency and Batching Capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 
 ## [Unreleased]
 
+### Added
+
+#### `graphql`
+
+- Introduced new executor for running GraphQL queries.  Includes WorkScheduler interface to control how work is scheduled/executed.
+
 ### Changed
+
+#### `graphql`
+
+- `*SelectionSet` is now properly passed into FieldFuncs.
+- `Union` type `__typename` attributes are now the typename of the subtype (not the union type).
+- Fixed race condition in pagination FieldFuncs.
+
+#### `reactive`
+
+- Always invalidate entire reactive cache when query fails.
 
 #### `sqlgen`
 - Implemented a basic `(*sqlgen.DB).Count` receiver that wraps `SELECT COUNT(*)` functionality in SQL databases. ([#230](https://github.com/samsarahq/thunder/pull/230))

--- a/graphql/batch_executor.go
+++ b/graphql/batch_executor.go
@@ -1,0 +1,396 @@
+package graphql
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/samsarahq/thunder/reactive"
+)
+
+// WorkUnit is a set of execution work that will be done when running
+// a graphql query.  For every source there is an equivalent destination
+// OutputNode that is used to record the result of running a section of the
+// graphql query.
+type WorkUnit struct {
+	ctx          context.Context
+	field        *Field
+	selection    *Selection
+	sources      []interface{}
+	destinations []*outputNode
+}
+
+// UnitResolver is a function that executes a function and returns a set of
+// new work units that need to be run.
+type UnitResolver func(*WorkUnit) []*WorkUnit
+
+// WorkScheduler is an interface that can be provided to the BatchExecutor
+// to control how we traverse the Execution graph.  Examples would include using
+// a bounded goroutine pool, or using unbounded goroutine generation for each
+// work unit.
+type WorkScheduler interface {
+	Run(resolver UnitResolver, startingUnits ...*WorkUnit)
+}
+
+func NewBatchExecutor(scheduler WorkScheduler) *BatchExecutor {
+	return &BatchExecutor{
+		scheduler: scheduler,
+	}
+}
+
+// BatchExecutor is a GraphQL executor.  Given a query it can run through the
+// execution of the request.
+type BatchExecutor struct {
+	scheduler WorkScheduler
+}
+
+// Execute executes a query by traversing the GraphQL query graph and resolving
+// or executing fields.  Any work that needs to be done is passed off to the
+// scheduler to handle managing concurrency of the request.
+// It must return a JSON marshallable response (or an error).
+func (e *BatchExecutor) Execute(ctx context.Context, typ Type, source interface{}, query *Query) (interface{}, error) {
+	queryObject, ok := typ.(*Object)
+	if !ok {
+		return nil, fmt.Errorf("expected query or mutation object for execution, got: %s", typ.String())
+	}
+
+	topLevelSelections := Flatten(query.SelectionSet)
+	topLevelRespWriter := newTopLevelOutputNode(query.Name)
+	initialSelectionWorkUnits := make([]*WorkUnit, 0, len(topLevelSelections))
+	writers := make(map[string]*outputNode)
+	for _, selection := range topLevelSelections {
+		field, ok := queryObject.Fields[selection.Name]
+		if !ok {
+			return nil, fmt.Errorf("invalid top-level selection %q", selection.Name)
+		}
+
+		writer := newOutputNode(topLevelRespWriter, selection.Alias)
+		writers[selection.Alias] = writer
+
+		initialSelectionWorkUnits = append(
+			initialSelectionWorkUnits,
+			&WorkUnit{
+				ctx:          ctx,
+				sources:      []interface{}{source},
+				field:        field,
+				destinations: []*outputNode{writer},
+				selection:    selection,
+			},
+		)
+	}
+
+	e.scheduler.Run(resolveWorkUnit, initialSelectionWorkUnits...)
+
+	if topLevelRespWriter.errRecorder.err != nil {
+		return nil, topLevelRespWriter.errRecorder.err
+	}
+	return writers, nil
+}
+
+// resolveWorkUnit executes/resolves a work unit and checks the
+// selections of the unit to determine if it needs to schedule more work (which
+// will be returned as new work units that will need to get scheduled.
+func resolveWorkUnit(unit *WorkUnit) []*WorkUnit {
+	// TODO Insert Batching code execution here if field is "Batch"
+
+	var units []*WorkUnit
+	for idx, src := range unit.sources {
+		if !unit.field.Expensive {
+			units = append(units, resolveNonBatchUnit(unit.ctx, src, unit.destinations[idx], unit)...)
+			continue
+		}
+		units = append(units, resolveNonBatchUnitWithCaching(src, unit.destinations[idx], unit)...)
+	}
+	return units
+}
+
+// resolveNonBatchUnitWithCaching wraps a resolve request in a reactive cache
+// call.
+// This function makes two assumptions:
+// - We assume that all the reactive cache will get cleared if there is an error.
+// - We assume that there is no "error-catching" mechanism that will stop an
+//   error from propagating all the way to the top of the request stack.
+func resolveNonBatchUnitWithCaching(src interface{}, dest *outputNode, unit *WorkUnit) []*WorkUnit {
+	var workUnits []*WorkUnit
+	subDestRes, err := reactive.Cache(unit.ctx, getWorkCacheKey(src, unit.field, unit.selection), func(ctx context.Context) (interface{}, error) {
+		subDest := newOutputNode(dest, "")
+		workUnits = resolveNonBatchUnit(ctx, src, subDest, unit)
+		return subDest.res, nil
+	})
+	if err != nil {
+		dest.Fail(err)
+	}
+	dest.Fill(subDestRes)
+	return workUnits
+}
+
+// getWorkCacheKey gets the work cache key for the provided source.
+func getWorkCacheKey(src interface{}, field *Field, selection *Selection) resolveAndExecuteCacheKey {
+	value := reflect.ValueOf(src)
+	// cache the body of resolve and execute so that if the source doesn't change, we
+	// don't need to recompute
+	key := resolveAndExecuteCacheKey{field: field, source: src, selection: selection}
+	// some types can't be put in a map; for those, use a always different value
+	// as source
+	if value.IsValid() && !value.Type().Comparable() {
+		// TODO: Warn, or somehow prevent using type-system?
+		key.source = new(byte)
+	}
+	return key
+}
+
+// resolveNonBatchUnit resolves a non-batch field in our graphql response graph.
+func resolveNonBatchUnit(ctx context.Context, src interface{}, dest *outputNode, unit *WorkUnit) []*WorkUnit {
+	fieldResult, err := safeResolve(ctx, unit.field, src, unit.selection.Args, unit.selection.SelectionSet)
+	if err != nil {
+		dest.Fail(err)
+		return nil
+	}
+	subFieldWorkUnits, err := resolveBatch(ctx, []interface{}{fieldResult}, unit.field.Type, unit.selection.SelectionSet, []*outputNode{dest})
+	if err != nil {
+		dest.Fail(err)
+		return nil
+	}
+	return subFieldWorkUnits
+}
+
+// resolveBatch traverses the provided sources and fills in result data and
+// returns new work units that are required to resolve the rest of the
+// query result.
+func resolveBatch(ctx context.Context, sources []interface{}, typ Type, selectionSet *SelectionSet, destinations []*outputNode) ([]*WorkUnit, error) {
+	switch typ := typ.(type) {
+	case *Scalar:
+		return nil, resolveScalarBatch(sources, typ, destinations)
+	case *Enum:
+		return nil, resolveEnumBatch(sources, typ, destinations)
+	case *List:
+		return resolveListBatch(ctx, sources, typ, selectionSet, destinations)
+	case *Union:
+		return resolveUnionBatch(ctx, sources, typ, selectionSet, destinations)
+	case *Object:
+		return resolveObjectBatch(ctx, sources, typ, selectionSet, destinations)
+	case *NonNull:
+		return resolveBatch(ctx, sources, typ.Type, selectionSet, destinations)
+	default:
+		panic(typ)
+	}
+}
+
+// Resolves the scalar type value for all the provided sources.
+func resolveScalarBatch(sources []interface{}, typ *Scalar, destinations []*outputNode) error {
+	for i, source := range sources {
+		if typ.Unwrapper == nil {
+			destinations[i].Fill(unwrap(source))
+			continue
+		}
+		res, err := typ.Unwrapper(source)
+		if err != nil {
+			return err
+		}
+		destinations[i].Fill(res)
+	}
+	return nil
+}
+
+// Resolves the enum type value for all the provided sources.
+func resolveEnumBatch(sources []interface{}, typ *Enum, destinations []*outputNode) error {
+	for i, source := range sources {
+		val := unwrap(source)
+		if mapVal, ok := typ.ReverseMap[val]; !ok {
+			err := errors.New("enum is not valid")
+			destinations[i].Fail(err)
+			return err
+		} else {
+			destinations[i].Fill(mapVal)
+		}
+	}
+	return nil
+}
+
+// Flattens the sources for the list type and calls into an unwrapper method for
+// the list's subtype.
+func resolveListBatch(ctx context.Context, sources []interface{}, typ *List, selectionSet *SelectionSet, destinations []*outputNode) ([]*WorkUnit, error) {
+	reflectedSources := make([]reflect.Value, len(sources))
+	numFlattenedSources := 0
+	for idx, source := range sources {
+		reflectedSources[idx] = reflect.ValueOf(source)
+		numFlattenedSources += reflectedSources[idx].Len()
+	}
+
+	flattenedResps := make([]*outputNode, 0, numFlattenedSources)
+	flattenedSources := make([]interface{}, 0, numFlattenedSources)
+	for idx, slice := range reflectedSources {
+		respList := make([]interface{}, slice.Len())
+		for i := 0; i < slice.Len(); i++ {
+			writer := newOutputNode(destinations[idx], strconv.Itoa(idx))
+			respList[i] = writer
+			flattenedResps = append(flattenedResps, writer)
+			flattenedSources = append(flattenedSources, slice.Index(i).Interface())
+		}
+		destinations[idx].Fill(respList)
+	}
+	return resolveBatch(ctx, flattenedSources, typ.Type, selectionSet, flattenedResps)
+}
+
+// Traverses the Union type and resolves or creates work units to resolve
+// all of the sub-objects for all the provided sources.
+func resolveUnionBatch(ctx context.Context, sources []interface{}, typ *Union, selectionSet *SelectionSet, destinations []*outputNode) ([]*WorkUnit, error) {
+	sourcesByType := make(map[string][]interface{}, len(typ.Types))
+	destinationsByType := make(map[string][]*outputNode, len(typ.Types))
+	for idx, src := range sources {
+		union := reflect.ValueOf(src)
+		if union.Kind() == reflect.Ptr && union.IsNil() {
+			// Don't create a destination for any nil Unions types
+			destinations[idx].Fill(nil)
+			continue
+		}
+
+		srcType := ""
+		if union.Kind() == reflect.Ptr && union.Elem().Kind() == reflect.Struct {
+			union = union.Elem()
+		}
+		for typString := range typ.Types {
+			inner := union.FieldByName(typString)
+			if inner.IsNil() {
+				continue
+			}
+			if srcType != "" {
+				return nil, fmt.Errorf("union type field should only return one value, but received: %s %s", srcType, typString)
+			}
+			srcType = typString
+			sourcesByType[srcType] = append(sourcesByType[srcType], inner.Interface())
+			destinationsByType[srcType] = append(destinationsByType[srcType], destinations[idx])
+		}
+	}
+
+	var workUnits []*WorkUnit
+	for srcType, sources := range sourcesByType {
+		gqlType := typ.Types[srcType]
+		for _, fragment := range selectionSet.Fragments {
+			if fragment.On != srcType {
+				continue
+			}
+			units, err := resolveObjectBatch(ctx, sources, gqlType, fragment.SelectionSet, destinationsByType[srcType])
+			if err != nil {
+				return nil, err
+			}
+			workUnits = append(workUnits, units...)
+		}
+
+	}
+	return workUnits, nil
+}
+
+// Traverses the object selections and resolves or creates work units to resolve
+// all of the object fields for every source passed in.
+func resolveObjectBatch(ctx context.Context, sources []interface{}, typ *Object, selectionSet *SelectionSet, destinations []*outputNode) ([]*WorkUnit, error) {
+	selections := Flatten(selectionSet)
+	numExpensive := 0
+	numNonExpensive := 0
+	for _, selection := range selections {
+		if field, ok := typ.Fields[selection.Name]; ok && field.Expensive {
+			numExpensive++
+		} else if ok && field.External {
+			numNonExpensive++
+		}
+	}
+
+	// For every object, create a "destination" map that we can fill with our
+	// result values.  Filter out invalid/nil objects.
+	nonNilSources := make([]interface{}, 0, len(sources))
+	nonNilDestinations := make([]map[string]interface{}, 0, len(destinations))
+	originDestinations := make([]*outputNode, 0, len(destinations))
+	for idx, source := range sources {
+		value := reflect.ValueOf(source)
+		if value.Kind() == reflect.Ptr && value.IsNil() {
+			destinations[idx].Fill(nil)
+			continue
+		}
+		nonNilSources = append(nonNilSources, source)
+		destMap := make(map[string]interface{}, len(selections))
+		destinations[idx].Fill(destMap)
+		nonNilDestinations = append(nonNilDestinations, destMap)
+		originDestinations = append(originDestinations, destinations[idx])
+	}
+
+	// Number of Work Units = (NumExpensiveFields x NumSources) + NumNonExpensiveFields
+	workUnits := make([]*WorkUnit, 0, numNonExpensive+(numExpensive*len(nonNilSources)))
+
+	// for every selection, resolve the value or schedule an work unit for the field
+	for _, selection := range selections {
+		if selection.Name == "__typename" {
+			for idx := range nonNilDestinations {
+				nonNilDestinations[idx][selection.Alias] = typ.Name
+			}
+			continue
+		}
+
+		destForSelection := make([]*outputNode, 0, len(nonNilDestinations))
+		for idx, destMap := range nonNilDestinations {
+			filler := newOutputNode(originDestinations[idx], selection.Alias)
+			destForSelection = append(destForSelection, filler)
+			destMap[selection.Alias] = filler
+		}
+
+		field := typ.Fields[selection.Name]
+		if field.Expensive {
+			// Expensive fields should be executed as multiple "Units".  The scheduler
+			// controls how the units are executed
+			for idx, source := range nonNilSources {
+				workUnits = append(workUnits, &WorkUnit{
+					ctx:          ctx,
+					field:        field,
+					sources:      []interface{}{source},
+					destinations: []*outputNode{destForSelection[idx]},
+					selection:    selection,
+				})
+			}
+			continue
+		}
+		unit := &WorkUnit{
+			ctx:          ctx,
+			field:        field,
+			sources:      nonNilSources,
+			destinations: destForSelection,
+			selection:    selection,
+		}
+		if field.External {
+			// External non-Expensive fields should be fast (so we can run them at the
+			// same time), but, since they are still external functions we don't want
+			// to run them where they could potentially block.
+			// So we create an work unit with all the fields to execute
+			// asynchronously.
+			workUnits = append(workUnits, unit)
+			continue
+		}
+		// If the fields are not expensive or external the work time should be
+		// bounded, so we can resolve them immediately.
+		workUnits = append(
+			workUnits,
+			resolveWorkUnit(unit)...,
+		)
+	}
+
+	if typ.KeyField != nil {
+		destForSelection := make([]*outputNode, 0, len(nonNilDestinations))
+		for idx, destMap := range nonNilDestinations {
+			filler := newOutputNode(originDestinations[idx], "__key")
+			destForSelection = append(destForSelection, filler)
+			destMap["__key"] = filler
+		}
+		workUnits = append(
+			workUnits,
+			resolveWorkUnit(&WorkUnit{
+				ctx:          ctx,
+				field:        typ.KeyField,
+				sources:      nonNilSources,
+				destinations: destForSelection,
+				selection:    &Selection{},
+			})...,
+		)
+	}
+
+	return workUnits, nil
+}

--- a/graphql/batch_scheduler.go
+++ b/graphql/batch_scheduler.go
@@ -1,0 +1,32 @@
+package graphql
+
+import (
+	"sync"
+)
+
+// NewImmediateGoroutineScheduler creates a new batch execution scheduler that
+// executes all Units immediately in their own goroutine.
+func NewImmediateGoroutineScheduler() WorkScheduler {
+	return &immediateGoroutineScheduler{}
+}
+
+type immediateGoroutineScheduler struct {
+	wg sync.WaitGroup
+}
+
+func (q *immediateGoroutineScheduler) Run(resolver UnitResolver, initialUnits ...*WorkUnit) {
+	q.runEnqueue(resolver, initialUnits...)
+
+	q.wg.Wait()
+}
+
+func (q *immediateGoroutineScheduler) runEnqueue(resolver UnitResolver, units ...*WorkUnit) {
+	for _, unit := range units {
+		q.wg.Add(1)
+		go func(u *WorkUnit) {
+			defer q.wg.Done()
+			units := resolver(u)
+			q.runEnqueue(resolver, units...)
+		}(unit)
+	}
+}

--- a/graphql/connection_test.go
+++ b/graphql/connection_test.go
@@ -694,7 +694,7 @@ func TestEmbeddedArgs(t *testing.T) {
 	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
-	e := graphql.Executor{}
+	e := testgraphql.NewExecutorWrapper(t)
 	val, err := e.Execute(context.Background(), builtSchema.Query, nil, q)
 	assert.Nil(t, err)
 

--- a/graphql/connection_test.go
+++ b/graphql/connection_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/graphql/schemabuilder"
+	"github.com/samsarahq/thunder/internal"
 	"github.com/samsarahq/thunder/internal/testgraphql"
 	"github.com/samsarahq/thunder/reactive"
 	"github.com/stretchr/testify/assert"
@@ -700,40 +701,40 @@ func TestEmbeddedArgs(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{
 		"inner": map[string]interface{}{
 			"innerConnection": map[string]interface{}{
-				"totalCount": int64(5),
+				"totalCount": float64(5),
 				"edges": []interface{}{
 					map[string]interface{}{
 						"node": map[string]interface{}{
-							"__key": int64(1),
-							"id":    int64(1),
+							"__key": float64(1),
+							"id":    float64(1),
 						},
 						"cursor": "MQ==",
 					},
 					map[string]interface{}{
 						"node": map[string]interface{}{
-							"__key": int64(2),
-							"id":    int64(2),
+							"__key": float64(2),
+							"id":    float64(2),
 						},
 						"cursor": "Mg==",
 					},
 					map[string]interface{}{
 						"node": map[string]interface{}{
-							"__key": int64(3),
-							"id":    int64(3),
+							"__key": float64(3),
+							"id":    float64(3),
 						},
 						"cursor": "Mw==",
 					},
 					map[string]interface{}{
 						"node": map[string]interface{}{
-							"__key": int64(4),
-							"id":    int64(4),
+							"__key": float64(4),
+							"id":    float64(4),
 						},
 						"cursor": "NA==",
 					},
 					map[string]interface{}{
 						"node": map[string]interface{}{
-							"__key": int64(5),
-							"id":    int64(5),
+							"__key": float64(5),
+							"id":    float64(5),
 						},
 						"cursor": "NQ==",
 					},
@@ -746,7 +747,7 @@ func TestEmbeddedArgs(t *testing.T) {
 				},
 			},
 		},
-	}, val)
+	}, internal.AsJSON(val))
 
 	schema = schemabuilder.NewSchema()
 

--- a/graphql/end_to_end_test.go
+++ b/graphql/end_to_end_test.go
@@ -150,7 +150,7 @@ func TestEnum(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]interface{}{
 		"inner": "firstField",
-	}, val)
+	}, internal.AsJSON(val))
 
 	q = graphql.MustParse(`
 		{
@@ -166,7 +166,7 @@ func TestEnum(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]interface{}{
 		"inner2": "this",
-	}, val)
+	}, internal.AsJSON(val))
 
 	q = graphql.MustParse(`
 		{
@@ -191,7 +191,7 @@ func TestEnum(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]interface{}{
 		"optional": "firstField",
-	}, val)
+	}, internal.AsJSON(val))
 
 	q = graphql.MustParse(`
 		{
@@ -206,8 +206,8 @@ func TestEnum(t *testing.T) {
 	val, err = e.Execute(context.Background(), builtSchema.Query, nil, q)
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]interface{}{
-		"pointerret": enumType(1),
-	}, val)
+		"pointerret": float64(1),
+	}, internal.AsJSON(val))
 
 }
 

--- a/graphql/end_to_end_test.go
+++ b/graphql/end_to_end_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/graphql/schemabuilder"
 	"github.com/samsarahq/thunder/internal"
+	"github.com/samsarahq/thunder/internal/testgraphql"
 	"github.com/samsarahq/thunder/reactive"
 	"github.com/stretchr/testify/assert"
 )
@@ -62,7 +63,7 @@ func TestPathError(t *testing.T) {
 		t.Error(err)
 	}
 
-	e := graphql.Executor{}
+	e := testgraphql.NewExecutorWrapper(t)
 	_, err := e.Execute(context.Background(), builtSchema.Query, nil, q)
 	if err == nil || err.Error() != "inner.inners.0.expensive.expensives.0.err: no good, bad" {
 		t.Errorf("bad error: %v", err)
@@ -77,7 +78,7 @@ func TestPathError(t *testing.T) {
 		t.Error(err)
 	}
 
-	e = graphql.Executor{}
+	e = testgraphql.NewExecutorWrapper(t)
 	_, err = e.Execute(context.Background(), builtSchema.Query, nil, q)
 	if err == nil || err.Error() != "safe safe" {
 		t.Errorf("bad error: %v", err)
@@ -145,7 +146,7 @@ func TestEnum(t *testing.T) {
 		t.Error(err)
 	}
 
-	e := graphql.Executor{}
+	e := testgraphql.NewExecutorWrapper(t)
 	val, err := e.Execute(context.Background(), builtSchema.Query, nil, q)
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]interface{}{
@@ -161,7 +162,7 @@ func TestEnum(t *testing.T) {
 		t.Error(err)
 	}
 
-	e = graphql.Executor{}
+	e = testgraphql.NewExecutorWrapper(t)
 	val, err = e.Execute(context.Background(), builtSchema.Query, nil, q)
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]interface{}{
@@ -186,7 +187,7 @@ func TestEnum(t *testing.T) {
 		t.Error(err)
 	}
 
-	e = graphql.Executor{}
+	e = testgraphql.NewExecutorWrapper(t)
 	val, err = e.Execute(context.Background(), builtSchema.Query, nil, q)
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]interface{}{
@@ -202,7 +203,7 @@ func TestEnum(t *testing.T) {
 		t.Error(err)
 	}
 
-	e = graphql.Executor{}
+	e = testgraphql.NewExecutorWrapper(t)
 	val, err = e.Execute(context.Background(), builtSchema.Query, nil, q)
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]interface{}{
@@ -270,7 +271,7 @@ func TestEndToEndAwaitAndCache(t *testing.T) {
 
 	start := time.Now()
 	rerunner := reactive.NewRerunner(context.Background(), func(ctx context.Context) (interface{}, error) {
-		e := graphql.Executor{}
+		e := testgraphql.NewExecutorWrapper(t)
 		result, err := e.Execute(ctx, builtSchema.Query, nil, q)
 		if err != nil {
 			t.Error(err)
@@ -325,7 +326,7 @@ func verifyArgumentOption(t *testing.T, query graphql.Type, queryString string, 
 		t.Error(err)
 	}
 
-	e := graphql.Executor{}
+	e := testgraphql.NewExecutorWrapper(t)
 	result, err := e.Execute(context.Background(), query, nil, q)
 	if err != nil {
 		t.Error(err)
@@ -431,7 +432,7 @@ func TestConcurrencyLimiterDeadlock(t *testing.T) {
 	wg.Add(1)
 	rerunner := reactive.NewRerunner(context.Background(), func(ctx context.Context) (interface{}, error) {
 		defer wg.Done()
-		e := graphql.Executor{}
+		e := testgraphql.NewExecutorWrapper(t)
 		ctx = concurrencylimiter.With(ctx, 100)
 
 		_, err := e.Execute(ctx, builtSchema.Query, nil, q)

--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -323,8 +323,8 @@ func (e *Executor) executeObject(ctx context.Context, typ *Object, source interf
 		fields[selection.Alias] = resolved
 	}
 
-	if typ.Key != nil {
-		value, err := e.resolveAndExecute(ctx, &Field{Type: &Scalar{Type: "string"}, Resolve: typ.Key}, source, &Selection{})
+	if typ.KeyField != nil {
+		value, err := e.resolveAndExecute(ctx, typ.KeyField, source, &Selection{})
 		if err != nil {
 			return nil, nestPathError("__key", err)
 		}

--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -19,6 +19,25 @@ type pathError struct {
 	path  []string
 }
 
+func nestPathErrorMulti(path []string, err error) error {
+	// Don't nest SanitzedError's, as they are intended for human consumption.
+	if se, ok := err.(SanitizedError); ok {
+		return se
+	}
+
+	if pe, ok := err.(*pathError); ok {
+		return &pathError{
+			inner: pe.inner,
+			path:  append(pe.path, path...),
+		}
+	}
+
+	return &pathError{
+		inner: err,
+		path:  path,
+	}
+}
+
 func nestPathError(key string, err error) error {
 	// Don't nest SanitzedError's, as they are intended for human consumption.
 	if se, ok := err.(SanitizedError); ok {

--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -113,6 +113,9 @@ func PrepareQuery(typ Type, selectionSet *SelectionSet) error {
 				if selection.SelectionSet != nil {
 					return NewClientError(`scalar field "__typename" must have no selection`)
 				}
+				for _, fragment := range selectionSet.Fragments {
+					fragment.SelectionSet.Selections = append(fragment.SelectionSet.Selections, selection)
+				}
 				continue
 			}
 			return NewClientError(`unknown field "%s"`, selection.Name)

--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -411,6 +411,10 @@ func (e *Executor) execute(ctx context.Context, typ Type, source interface{}, se
 	}
 }
 
+type ExecutorRunner interface {
+	Execute(ctx context.Context, typ Type, source interface{}, query *Query) (interface{}, error)
+}
+
 type Executor struct {
 	mu sync.Mutex
 }

--- a/graphql/executor_test.go
+++ b/graphql/executor_test.go
@@ -135,10 +135,10 @@ func TestBasic(t *testing.T) {
 	}
 
 	// assert that result["as"][1]["valuePtr"] == 1 (and not a pointer to 1)
-	root, _ := result.(map[string]interface{})
+	root, _ := internal.AsJSON(result).(map[string]interface{})
 	as, _ := root["as"].([]interface{})
 	asObject, _ := as[1].(map[string]interface{})
-	if asObject["valuePtr"] != 1 {
+	if int(asObject["valuePtr"].(float64)) != 1 {
 		t.Error("Expected valuePtr to be 1, was", asObject["valuePtr"])
 	}
 

--- a/graphql/executor_test.go
+++ b/graphql/executor_test.go
@@ -1,4 +1,4 @@
-package graphql
+package graphql_test
 
 import (
 	"context"
@@ -8,103 +8,105 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/internal"
+	"github.com/samsarahq/thunder/internal/testgraphql"
 )
 
-func makeQuery(onArgParse *func()) *Object {
+func makeQuery(onArgParse *func()) *graphql.Object {
 	noArguments := func(json interface{}) (interface{}, error) {
 		return nil, nil
 	}
 
-	query := &Object{
+	query := &graphql.Object{
 		Name:   "Query",
-		Fields: make(map[string]*Field),
+		Fields: make(map[string]*graphql.Field),
 	}
 
-	a := &Object{
+	a := &graphql.Object{
 		Name: "A",
-		KeyField: &Field{
-			Resolve: func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error) {
+		KeyField: &graphql.Field{
+			Resolve: func(ctx context.Context, source, args interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 				return source, nil
 			},
-			Type: &Scalar{Type: "string"},
+			Type: &graphql.Scalar{Type: "string"},
 		},
-		Fields: make(map[string]*Field),
+		Fields: make(map[string]*graphql.Field),
 	}
 
-	query.Fields["a"] = &Field{
-		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error) {
+	query.Fields["a"] = &graphql.Field{
+		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			return 0, nil
 		},
 		Type:           a,
 		ParseArguments: noArguments,
 	}
 
-	query.Fields["as"] = &Field{
-		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error) {
+	query.Fields["as"] = &graphql.Field{
+		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			return []int{0, 1, 2, 3}, nil
 		},
-		Type:           &List{Type: a},
+		Type:           &graphql.List{Type: a},
 		ParseArguments: noArguments,
 	}
 
-	query.Fields["static"] = &Field{
-		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error) {
+	query.Fields["static"] = &graphql.Field{
+		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			return "static", nil
 		},
-		Type:           &Scalar{Type: "string"},
+		Type:           &graphql.Scalar{Type: "string"},
 		ParseArguments: noArguments,
 	}
 
-	query.Fields["error"] = &Field{
-		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error) {
+	query.Fields["error"] = &graphql.Field{
+		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			return nil, errors.New("test error")
 		},
-		Type:           &Scalar{Type: "string"},
+		Type:           &graphql.Scalar{Type: "string"},
 		ParseArguments: noArguments,
 	}
 
-	query.Fields["panic"] = &Field{
-		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error) {
+	query.Fields["panic"] = &graphql.Field{
+		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			panic("test panic")
 		},
-		Type:           &Scalar{Type: "string"},
+		Type:           &graphql.Scalar{Type: "string"},
 		ParseArguments: noArguments,
 	}
 
-	a.Fields["value"] = &Field{
-		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error) {
+	a.Fields["value"] = &graphql.Field{
+		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			return source.(int), nil
 		},
-		Type:           &Scalar{Type: "int"},
+		Type:           &graphql.Scalar{Type: "int"},
 		ParseArguments: noArguments,
 	}
 
-	a.Fields["valuePtr"] = &Field{
-		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error) {
+	a.Fields["valuePtr"] = &graphql.Field{
+		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			temp := source.(int)
 			if temp%2 == 0 {
 				return nil, nil
 			}
 			return &temp, nil
 		},
-		Type:           &Scalar{Type: "int"},
+		Type:           &graphql.Scalar{Type: "int"},
 		ParseArguments: noArguments,
 	}
 
-	a.Fields["nested"] = &Field{
-		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error) {
+	a.Fields["nested"] = &graphql.Field{
+		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			return source.(int) + 1, nil
 		},
 		Type:           a,
 		ParseArguments: noArguments,
 	}
 
-	a.Fields["fieldWithArgs"] = &Field{
-		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error) {
+	a.Fields["fieldWithArgs"] = &graphql.Field{
+		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			return 1, nil
 		},
-		Type: &Scalar{Type: "int"},
+		Type: &graphql.Scalar{Type: "int"},
 		ParseArguments: func(json interface{}) (interface{}, error) {
 			if onArgParse != nil {
 				(*onArgParse)()
@@ -119,16 +121,16 @@ func makeQuery(onArgParse *func()) *Object {
 func TestBasic(t *testing.T) {
 	query := makeQuery(nil)
 
-	q := MustParse(`{
+	q := graphql.MustParse(`{
 		static
 		a { value nested { value } }
 		as { value valuePtr }
 	}`, nil)
 
-	if err := PrepareQuery(query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
-	e := Executor{}
+	e := testgraphql.NewExecutorWrapper(t)
 	result, err := e.Execute(context.Background(), query, nil, q)
 	if err != nil {
 		t.Error(err)
@@ -143,23 +145,23 @@ func TestBasic(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(internal.AsJSON(result), internal.ParseJSON(`
-		{
-			"static": "static",
-			"a": {
-				"value": 0,
-				"__key": 0,
-				"nested": {
-					"value": 1,
-					"__key": 1
-				}
-			},
-			"as": [
-			        {"value": 0, "valuePtr": null, "__key": 0},
-				{"value": 1, "valuePtr": 1, "__key": 1},
-				{"value": 2, "valuePtr": null, "__key": 2},
-				{"value": 3, "valuePtr": 3, "__key": 3}
-			]
-		}`)) {
+{
+	"static": "static",
+	"a": {
+		"value": 0,
+		"__key": 0,
+		"nested": {
+			"value": 1,
+			"__key": 1
+		}
+	},
+	"as": [
+		{"value": 0, "valuePtr": null, "__key": 0},
+		{"value": 1, "valuePtr": 1, "__key": 1},
+		{"value": 2, "valuePtr": null, "__key": 2},
+		{"value": 3, "valuePtr": 3, "__key": 3}
+	]
+}`)) {
 		t.Error("bad value", spew.Sdump(internal.AsJSON(result)))
 	}
 }
@@ -171,7 +173,7 @@ func TestRepeatedFragment(t *testing.T) {
 	}
 	query := makeQuery(&countArgParse)
 
-	q := MustParse(`{
+	q := graphql.MustParse(`{
 		static
 		a { value nested { value ...frag } ...frag }
 		as { value }
@@ -181,10 +183,10 @@ func TestRepeatedFragment(t *testing.T) {
 	}
 	`, nil)
 
-	if err := PrepareQuery(query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
-	e := Executor{}
+	e := testgraphql.NewExecutorWrapper(t)
 	_, err := e.Execute(context.Background(), query, nil, q)
 	if err != nil {
 		t.Error(err)
@@ -248,17 +250,17 @@ func TestBadArgs(t *testing.T) {
 func TestError(t *testing.T) {
 	query := makeQuery(nil)
 
-	q := MustParse(`
+	q := graphql.MustParse(`
 		query foo {
 			error
 		}
 	`, map[string]interface{}{})
 
-	if err := PrepareQuery(query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
-	e := Executor{}
+	e := testgraphql.NewExecutorWrapper(t)
 	_, err := e.Execute(context.Background(), query, nil, q)
 	if err == nil || err.Error() != "foo.error: test error" {
 		t.Error("expected test error")
@@ -270,18 +272,17 @@ func TestError(t *testing.T) {
 func TestPanic(t *testing.T) {
 	query := makeQuery(nil)
 
-	q := MustParse(`
+	q := graphql.MustParse(`
 		{
 			panic
 		}
 	`, nil)
 
-	if err := PrepareQuery(query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
-	e := Executor{}
-
+	e := testgraphql.NewExecutorWrapperWithoutExactErrorMatch(t)
 	_, err := e.Execute(context.Background(), query, nil, q)
 	if err == nil || !strings.Contains(err.Error(), "test panic") {
 		t.Error("expected test panic")

--- a/graphql/executor_test.go
+++ b/graphql/executor_test.go
@@ -23,8 +23,11 @@ func makeQuery(onArgParse *func()) *Object {
 
 	a := &Object{
 		Name: "A",
-		Key: func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error) {
-			return source, nil
+		KeyField: &Field{
+			Resolve: func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error) {
+				return source, nil
+			},
+			Type: &Scalar{Type: "string"},
 		},
 		Fields: make(map[string]*Field),
 	}

--- a/graphql/reactive_test.go
+++ b/graphql/reactive_test.go
@@ -1,0 +1,144 @@
+package graphql_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/samsarahq/thunder/graphql"
+	"github.com/samsarahq/thunder/graphql/schemabuilder"
+	"github.com/samsarahq/thunder/reactive"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReactiveCacheResetsOnError(t *testing.T) {
+	users := []*User{
+		{Name: "Alice", Age: 5, resource: reactive.NewResource()},
+		{Name: "Bob", Age: 6, resource: reactive.NewResource()},
+		{Name: "Charlie", Age: 7, resource: reactive.NewResource()},
+	}
+
+	var mu sync.Mutex
+	calls := 0
+
+	schema := schemabuilder.NewSchema()
+
+	query := schema.Query()
+	query.FieldFunc("users", func(ctx context.Context) []*User {
+		return users
+	})
+	query.FieldFunc("uncachedError", func() (string, error) {
+		return "", errors.New("this is not cached")
+	})
+	_ = schema.Mutation()
+
+	user := schema.Object("User", User{})
+	user.FieldFunc("slow", func(ctx context.Context, u *User) *Slow {
+		reactive.AddDependency(ctx, u.resource, nil)
+		return new(Slow)
+	})
+
+	slow := schema.Object("Slow", Slow{})
+	slow.FieldFunc("count", func() bool {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return true
+	})
+
+	builtSchema := schema.MustBuild()
+
+	q := graphql.MustParse(`
+		{
+			users {
+				name
+				slow { count }
+			}
+			uncachedError
+		}`, nil)
+
+	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+		t.Error(err)
+	}
+
+	runGrabber := newConcurrencyManager(t, 1)
+	runGrabber.Inc()
+
+	runFinish := newConcurrencyManager(t, 1)
+
+	rerunner := reactive.NewRerunner(context.Background(), func(ctx context.Context) (interface{}, error) {
+		if !runGrabber.Dec() {
+			return nil, nil
+		}
+		e := graphql.NewBatchExecutor(graphql.NewImmediateGoroutineScheduler())
+		_, err := e.Execute(ctx, builtSchema.Query, nil, q)
+		require.Error(t, err)
+
+		require.True(t, runFinish.Inc(), "could not push finish channel")
+
+		return nil, reactive.RetrySentinelError
+	}, 0, false)
+	defer rerunner.Stop()
+
+	require.True(t, runFinish.Dec(), "error waiting for run to finish")
+	if calls != 3 {
+		t.Errorf("expected 3 calls to slow, got %d", calls)
+	}
+
+	runGrabber.Inc()
+
+	require.True(t, runFinish.Dec(), "error waiting for run to finish")
+	if calls != 6 {
+		t.Errorf("expected 6 total calls to slow, got %d", calls)
+	}
+	runFinish.Close()
+	runGrabber.Close()
+}
+
+func newConcurrencyManager(t *testing.T, size int) *concurrencyManager {
+	return &concurrencyManager{
+		t:           t,
+		done:        make(chan struct{}),
+		counterChan: make(chan struct{}, size),
+	}
+}
+
+type concurrencyManager struct {
+	t           *testing.T
+	done        chan struct{}
+	counterChan chan struct{}
+}
+
+func (c *concurrencyManager) Inc() (ok bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		require.Fail(c.t, "test timed out", ctx.Err())
+		return false
+	case <-c.done:
+		return false
+	case c.counterChan <- struct{}{}:
+		return true
+	}
+}
+
+func (c *concurrencyManager) Dec() (ok bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		require.Fail(c.t, "test timed out", ctx.Err().Error())
+		return false
+	case <-c.done:
+		return false
+	case <-c.counterChan:
+		return true
+	}
+}
+
+func (c *concurrencyManager) Close() {
+	close(c.done)
+}

--- a/graphql/schemabuilder/function.go
+++ b/graphql/schemabuilder/function.go
@@ -59,7 +59,7 @@ func (sb *schemaBuilder) buildFunction(typ reflect.Type, m *method) (*graphql.Fi
 	return &graphql.Field{
 		Resolve: func(ctx context.Context, source, funcRawArgs interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			// Set up function arguments.
-			funcInputArgs := funcCtx.prepareResolveArgs(source, funcRawArgs, ctx, selectionSet)
+			funcInputArgs := funcCtx.prepareResolveArgs(source, funcCtx.hasArgs, funcRawArgs, ctx, selectionSet)
 
 			// Call the function.
 			funcOutputArgs := callableFunc.Call(funcInputArgs)
@@ -238,7 +238,7 @@ func (funcCtx *funcContext) argsTypeMap(argType graphql.Type) (map[string]graphq
 
 // prepareResolveArgs converts the provided source, args and context into the
 // required list of reflect.Value types that the function needs to be called.
-func (funcCtx *funcContext) prepareResolveArgs(source interface{}, args interface{}, ctx context.Context, selectionSet *graphql.SelectionSet) []reflect.Value {
+func (funcCtx *funcContext) prepareResolveArgs(source interface{}, hasArgs bool, args interface{}, ctx context.Context, selectionSet *graphql.SelectionSet) []reflect.Value {
 	in := make([]reflect.Value, 0, funcCtx.funcType.NumIn())
 	if funcCtx.hasContext {
 		in = append(in, reflect.ValueOf(ctx))
@@ -261,7 +261,7 @@ func (funcCtx *funcContext) prepareResolveArgs(source interface{}, args interfac
 	}
 
 	// Set up other arguments.
-	if funcCtx.hasArgs {
+	if hasArgs {
 		in = append(in, reflect.ValueOf(args))
 	}
 	if funcCtx.hasSelectionSet {

--- a/graphql/schemabuilder/function.go
+++ b/graphql/schemabuilder/function.go
@@ -59,7 +59,7 @@ func (sb *schemaBuilder) buildFunction(typ reflect.Type, m *method) (*graphql.Fi
 	return &graphql.Field{
 		Resolve: func(ctx context.Context, source, funcRawArgs interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			// Set up function arguments.
-			funcInputArgs := funcCtx.prepareResolveArgs(source, funcRawArgs, ctx)
+			funcInputArgs := funcCtx.prepareResolveArgs(source, funcRawArgs, ctx, selectionSet)
 
 			// Call the function.
 			funcOutputArgs := callableFunc.Call(funcInputArgs)
@@ -83,10 +83,9 @@ type funcContext struct {
 	hasRet          bool
 	hasError        bool
 
-	funcType     reflect.Type
-	isPtrFunc    bool
-	typ          reflect.Type
-	selectionSet *graphql.SelectionSet
+	funcType  reflect.Type
+	isPtrFunc bool
+	typ       reflect.Type
 }
 
 // getFuncVal returns a reflect.Value of an executable function.
@@ -238,7 +237,7 @@ func (funcCtx *funcContext) argsTypeMap(argType graphql.Type) (map[string]graphq
 
 // prepareResolveArgs converts the provided source, args and context into the
 // required list of reflect.Value types that the function needs to be called.
-func (funcCtx *funcContext) prepareResolveArgs(source interface{}, args interface{}, ctx context.Context) []reflect.Value {
+func (funcCtx *funcContext) prepareResolveArgs(source interface{}, args interface{}, ctx context.Context, selectionSet *graphql.SelectionSet) []reflect.Value {
 	in := make([]reflect.Value, 0, funcCtx.funcType.NumIn())
 	if funcCtx.hasContext {
 		in = append(in, reflect.ValueOf(ctx))
@@ -265,7 +264,7 @@ func (funcCtx *funcContext) prepareResolveArgs(source interface{}, args interfac
 		in = append(in, reflect.ValueOf(args))
 	}
 	if funcCtx.hasSelectionSet {
-		in = append(in, reflect.ValueOf(funcCtx.selectionSet))
+		in = append(in, reflect.ValueOf(selectionSet))
 	}
 
 	return in

--- a/graphql/schemabuilder/function.go
+++ b/graphql/schemabuilder/function.go
@@ -71,6 +71,7 @@ func (sb *schemaBuilder) buildFunction(typ reflect.Type, m *method) (*graphql.Fi
 		Type:           retType,
 		ParseArguments: argParser.Parse,
 		Expensive:      funcCtx.hasContext,
+		External:       true,
 	}, nil
 }
 

--- a/graphql/schemabuilder/output.go
+++ b/graphql/schemabuilder/output.go
@@ -71,13 +71,13 @@ func (sb *schemaBuilder) buildStruct(typ reflect.Type) error {
 		}
 		object.Fields[fieldInfo.Name] = built
 		if fieldInfo.KeyField {
-			if object.Key != nil {
+			if object.KeyField != nil {
 				return fmt.Errorf("bad type %s: multiple key fields", typ)
 			}
 			if !isScalarType(built.Type) {
 				return fmt.Errorf("bad type %s: key type must be scalar, got %T", typ, built.Type)
 			}
-			object.Key = built.Resolve
+			object.KeyField = built
 		}
 	}
 
@@ -115,7 +115,7 @@ func (sb *schemaBuilder) buildStruct(typ reflect.Type) error {
 		if !isScalarType(keyPtr.Type) {
 			return fmt.Errorf("bad type %s: key type must be scalar, got %s", typ, keyPtr.Type.String())
 		}
-		object.Key = keyPtr.Resolve
+		object.KeyField = keyPtr
 	}
 
 	return nil

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -907,6 +907,7 @@ func (sb *schemaBuilder) buildPaginatedField(typ reflect.Type, m *method) (*grap
 		Type:           retType,
 		ParseArguments: argParser.Parse,
 		Expensive:      c.hasContext,
+		External:       true,
 	}
 
 	return ret, nil

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -884,18 +884,18 @@ func (sb *schemaBuilder) buildPaginatedField(typ reflect.Type, m *method) (*grap
 	ret := &graphql.Field{
 		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			argsVal := args
+			hasArgs := true
 			if !c.IsExternallyManaged() {
 				val, ok := args.(ConnectionArgs)
 				if !ok {
 					return nil, fmt.Errorf("arguments should implement ConnectionArgs")
 				}
-				c.hasArgs = val.Args != nil
-				if c.hasArgs {
+				hasArgs = val.Args != nil
+				if hasArgs {
 					argsVal = reflect.ValueOf(val.Args).Elem().Interface()
 				}
 			}
-
-			in := c.prepareResolveArgs(source, argsVal, ctx, selectionSet)
+			in := c.prepareResolveArgs(source, hasArgs, argsVal, ctx, selectionSet)
 
 			// Call the function.
 			out := fun.Call(in)

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -895,7 +895,7 @@ func (sb *schemaBuilder) buildPaginatedField(typ reflect.Type, m *method) (*grap
 				}
 			}
 
-			in := c.prepareResolveArgs(source, argsVal, ctx)
+			in := c.prepareResolveArgs(source, argsVal, ctx, selectionSet)
 
 			// Call the function.
 			out := fun.Call(in)

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/internal"
+	"github.com/samsarahq/thunder/internal/testgraphql"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -166,7 +167,7 @@ func TestExecuteGood(t *testing.T) {
 		t.Error(err)
 	}
 
-	e := graphql.Executor{}
+	e := testgraphql.NewExecutorWrapper(t)
 
 	result, err := e.Execute(ctx, builtSchema.Query, nil, q)
 	if err != nil {
@@ -305,7 +306,7 @@ func TestExecuteErrorNullReturn(t *testing.T) {
 		t.Error(err)
 	}
 
-	e := graphql.Executor{}
+	e := testgraphql.NewExecutorWrapper(t)
 	_, err := e.Execute(context.Background(), builtSchema.Query, nil, q)
 	if err == nil {
 		t.Error("expected error, but received nil")
@@ -335,7 +336,7 @@ func TestExecuteErrorBasic(t *testing.T) {
 		t.Error(err)
 	}
 
-	e := graphql.Executor{}
+	e := testgraphql.NewExecutorWrapper(t)
 	_, err := e.Execute(context.Background(), builtSchema.Query, nil, q)
 	if err == nil {
 		t.Error("expected error, but received nil")

--- a/graphql/testdata/TestConnection.snapshots.json
+++ b/graphql/testdata/TestConnection.snapshots.json
@@ -27,7 +27,73 @@
     ]
   },
   {
+    "Name": "batchExecutor:Pagination, first + after",
+    "Values": [
+      {
+        "inner": {
+          "innerConnection": {
+            "edges": [
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "id": 1
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "MQ==",
+              "hasNextPage": true,
+              "hasPrevPage": false,
+              "startCursor": "MQ=="
+            },
+            "totalCount": 5
+          }
+        }
+      }
+    ]
+  },
+  {
     "Name": "Pagination, last + before",
+    "Values": [
+      {
+        "inner": {
+          "innerConnection": {
+            "edges": [
+              {
+                "cursor": "NA==",
+                "node": {
+                  "__key": 4,
+                  "id": 4
+                }
+              },
+              {
+                "cursor": "NQ==",
+                "node": {
+                  "__key": 5,
+                  "id": 5
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "NQ==",
+              "hasNextPage": false,
+              "hasPrevPage": true,
+              "pages": [
+                "",
+                "Mg==",
+                "NA=="
+              ],
+              "startCursor": "NA=="
+            },
+            "totalCount": 5
+          }
+        }
+      }
+    ]
+  },
+  {
+    "Name": "batchExecutor:Pagination, last + before",
     "Values": [
       {
         "inner": {
@@ -124,7 +190,92 @@
     ]
   },
   {
+    "Name": "batchExecutor:Pagination, no args given",
+    "Values": [
+      {
+        "inner": {
+          "innerConnection": {
+            "edges": [
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "id": 1
+                }
+              },
+              {
+                "cursor": "Mg==",
+                "node": {
+                  "__key": 2,
+                  "id": 2
+                }
+              },
+              {
+                "cursor": "Mw==",
+                "node": {
+                  "__key": 3,
+                  "id": 3
+                }
+              },
+              {
+                "cursor": "NA==",
+                "node": {
+                  "__key": 4,
+                  "id": 4
+                }
+              },
+              {
+                "cursor": "NQ==",
+                "node": {
+                  "__key": 5,
+                  "id": 5
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "NQ==",
+              "hasNextPage": false,
+              "hasPrevPage": false,
+              "pages": [
+                ""
+              ],
+              "startCursor": "MQ=="
+            },
+            "totalCount": 5
+          }
+        }
+      }
+    ]
+  },
+  {
     "Name": "Pagination, nil args",
+    "Values": [
+      {
+        "inner": {
+          "innerConnectionNilArg": {
+            "edges": [
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "id": 1
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "MQ==",
+              "hasNextPage": true,
+              "hasPrevPage": false,
+              "startCursor": "MQ=="
+            },
+            "totalCount": 5
+          }
+        }
+      }
+    ]
+  },
+  {
+    "Name": "batchExecutor:Pagination, nil args",
     "Values": [
       {
         "inner": {
@@ -178,6 +329,33 @@
     ]
   },
   {
+    "Name": "batchExecutor:Pagination, with ctx and error",
+    "Values": [
+      {
+        "inner": {
+          "innerConnectionWithCtxAndError": {
+            "edges": [
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "id": 1
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "MQ==",
+              "hasNextPage": true,
+              "hasPrevPage": false,
+              "startCursor": "MQ=="
+            },
+            "totalCount": 5
+          }
+        }
+      }
+    ]
+  },
+  {
     "Name": "Pagination, with ctx and error",
     "Values": [
       {
@@ -186,7 +364,7 @@
     ]
   },
   {
-    "Name": "Pagination, with error",
+    "Name": "batchExecutor:Pagination, with ctx and error",
     "Values": [
       {
         "Error": "this is an error"
@@ -195,6 +373,30 @@
   },
   {
     "Name": "Pagination, with error",
+    "Values": [
+      {
+        "Error": "this is an error"
+      }
+    ]
+  },
+  {
+    "Name": "batchExecutor:Pagination, with error",
+    "Values": [
+      {
+        "Error": "this is an error"
+      }
+    ]
+  },
+  {
+    "Name": "Pagination, with error",
+    "Values": [
+      {
+        "Error": "first/last cannot be a negative integer"
+      }
+    ]
+  },
+  {
+    "Name": "batchExecutor:Pagination, with error",
     "Values": [
       {
         "Error": "first/last cannot be a negative integer"
@@ -271,7 +473,409 @@
     ]
   },
   {
+    "Name": "batchExecutor:Pagination, filter",
+    "Values": [
+      {
+        "inner": {
+          "filterByBan": {
+            "edges": [
+              {
+                "cursor": "NA==",
+                "node": {
+                  "__key": 4,
+                  "filterText": "soban",
+                  "id": 4
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "NA==",
+              "hasNextPage": false,
+              "hasPrevPage": false,
+              "pages": [
+                ""
+              ],
+              "startCursor": "NA=="
+            },
+            "totalCount": 1
+          },
+          "filterByCan": {
+            "edges": [
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "filterText": "can",
+                  "id": 1
+                }
+              },
+              {
+                "cursor": "Mw==",
+                "node": {
+                  "__key": 3,
+                  "filterText": "cannot",
+                  "id": 3
+                }
+              },
+              {
+                "cursor": "NQ==",
+                "node": {
+                  "__key": 5,
+                  "filterText": "socan",
+                  "id": 5
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "NQ==",
+              "hasNextPage": false,
+              "hasPrevPage": false,
+              "pages": [
+                ""
+              ],
+              "startCursor": "MQ=="
+            },
+            "totalCount": 3
+          }
+        }
+      }
+    ]
+  },
+  {
     "Name": "Pagination, sorts",
+    "Values": [
+      {
+        "inner": {
+          "floatsAsc": {
+            "edges": [
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "float": 1,
+                  "id": 1
+                }
+              },
+              {
+                "cursor": "NA==",
+                "node": {
+                  "__key": 4,
+                  "float": 2,
+                  "id": 4
+                }
+              },
+              {
+                "cursor": "Mg==",
+                "node": {
+                  "__key": 2,
+                  "float": 3,
+                  "id": 2
+                }
+              },
+              {
+                "cursor": "NQ==",
+                "node": {
+                  "__key": 5,
+                  "float": 4,
+                  "id": 5
+                }
+              },
+              {
+                "cursor": "Mw==",
+                "node": {
+                  "__key": 3,
+                  "float": 5,
+                  "id": 3
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "Mw==",
+              "hasNextPage": false,
+              "hasPrevPage": false,
+              "pages": [
+                ""
+              ],
+              "startCursor": "MQ=="
+            },
+            "totalCount": 5
+          },
+          "floatsDesc": {
+            "edges": [
+              {
+                "cursor": "Mw==",
+                "node": {
+                  "__key": 3,
+                  "float": 5,
+                  "id": 3
+                }
+              },
+              {
+                "cursor": "NQ==",
+                "node": {
+                  "__key": 5,
+                  "float": 4,
+                  "id": 5
+                }
+              },
+              {
+                "cursor": "Mg==",
+                "node": {
+                  "__key": 2,
+                  "float": 3,
+                  "id": 2
+                }
+              },
+              {
+                "cursor": "NA==",
+                "node": {
+                  "__key": 4,
+                  "float": 2,
+                  "id": 4
+                }
+              },
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "float": 1,
+                  "id": 1
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "MQ==",
+              "hasNextPage": false,
+              "hasPrevPage": false,
+              "pages": [
+                ""
+              ],
+              "startCursor": "Mw=="
+            },
+            "totalCount": 5
+          },
+          "numbersAsc": {
+            "edges": [
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "id": 1,
+                  "number": 1
+                }
+              },
+              {
+                "cursor": "NA==",
+                "node": {
+                  "__key": 4,
+                  "id": 4,
+                  "number": 2
+                }
+              },
+              {
+                "cursor": "Mg==",
+                "node": {
+                  "__key": 2,
+                  "id": 2,
+                  "number": 3
+                }
+              },
+              {
+                "cursor": "NQ==",
+                "node": {
+                  "__key": 5,
+                  "id": 5,
+                  "number": 4
+                }
+              },
+              {
+                "cursor": "Mw==",
+                "node": {
+                  "__key": 3,
+                  "id": 3,
+                  "number": 5
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "Mw==",
+              "hasNextPage": false,
+              "hasPrevPage": false,
+              "pages": [
+                ""
+              ],
+              "startCursor": "MQ=="
+            },
+            "totalCount": 5
+          },
+          "numbersDesc": {
+            "edges": [
+              {
+                "cursor": "Mw==",
+                "node": {
+                  "__key": 3,
+                  "id": 3,
+                  "number": 5
+                }
+              },
+              {
+                "cursor": "NQ==",
+                "node": {
+                  "__key": 5,
+                  "id": 5,
+                  "number": 4
+                }
+              },
+              {
+                "cursor": "Mg==",
+                "node": {
+                  "__key": 2,
+                  "id": 2,
+                  "number": 3
+                }
+              },
+              {
+                "cursor": "NA==",
+                "node": {
+                  "__key": 4,
+                  "id": 4,
+                  "number": 2
+                }
+              },
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "id": 1,
+                  "number": 1
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "MQ==",
+              "hasNextPage": false,
+              "hasPrevPage": false,
+              "pages": [
+                ""
+              ],
+              "startCursor": "Mw=="
+            },
+            "totalCount": 5
+          },
+          "stringsAsc": {
+            "edges": [
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "id": 1,
+                  "string": "1"
+                }
+              },
+              {
+                "cursor": "NA==",
+                "node": {
+                  "__key": 4,
+                  "id": 4,
+                  "string": "2"
+                }
+              },
+              {
+                "cursor": "Mg==",
+                "node": {
+                  "__key": 2,
+                  "id": 2,
+                  "string": "3"
+                }
+              },
+              {
+                "cursor": "NQ==",
+                "node": {
+                  "__key": 5,
+                  "id": 5,
+                  "string": "4"
+                }
+              },
+              {
+                "cursor": "Mw==",
+                "node": {
+                  "__key": 3,
+                  "id": 3,
+                  "string": "5"
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "Mw==",
+              "hasNextPage": false,
+              "hasPrevPage": false,
+              "pages": [
+                ""
+              ],
+              "startCursor": "MQ=="
+            },
+            "totalCount": 5
+          },
+          "stringsDesc": {
+            "edges": [
+              {
+                "cursor": "Mw==",
+                "node": {
+                  "__key": 3,
+                  "id": 3,
+                  "string": "5"
+                }
+              },
+              {
+                "cursor": "NQ==",
+                "node": {
+                  "__key": 5,
+                  "id": 5,
+                  "string": "4"
+                }
+              },
+              {
+                "cursor": "Mg==",
+                "node": {
+                  "__key": 2,
+                  "id": 2,
+                  "string": "3"
+                }
+              },
+              {
+                "cursor": "NA==",
+                "node": {
+                  "__key": 4,
+                  "id": 4,
+                  "string": "2"
+                }
+              },
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "id": 1,
+                  "string": "1"
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "MQ==",
+              "hasNextPage": false,
+              "hasPrevPage": false,
+              "pages": [
+                ""
+              ],
+              "startCursor": "Mw=="
+            },
+            "totalCount": 5
+          }
+        }
+      }
+    ]
+  },
+  {
+    "Name": "batchExecutor:Pagination, sorts",
     "Values": [
       {
         "inner": {

--- a/graphql/testdata/TestDefaultArgs.snapshots.json
+++ b/graphql/testdata/TestDefaultArgs.snapshots.json
@@ -11,6 +11,17 @@
     ]
   },
   {
+    "Name": "batchExecutor:happy path all provided",
+    "Values": [
+      {
+        "inner": {
+          "optionalValue": "teeeeeeeest",
+          "requiredValue": "requiredInput!"
+        }
+      }
+    ]
+  },
+  {
     "Name": "missing required parameter",
     "Values": [
       {
@@ -20,6 +31,17 @@
   },
   {
     "Name": "missing optional parameter does not error",
+    "Values": [
+      {
+        "inner": {
+          "optionalValue": "",
+          "requiredValue": "teeeeeeeest"
+        }
+      }
+    ]
+  },
+  {
+    "Name": "batchExecutor:missing optional parameter does not error",
     "Values": [
       {
         "inner": {

--- a/graphql/testdata/TestTextMarshaling.snapshots.json
+++ b/graphql/testdata/TestTextMarshaling.snapshots.json
@@ -32,6 +32,38 @@
     ]
   },
   {
+    "Name": "batchExecutor:happy path all inputs and outputs",
+    "Values": [
+      {
+        "inner": {
+          "ptrUuid": "74771078-5edb-4733-88f2-000000000000",
+          "ptrUuidSlice": [
+            "00000000-0000-0000-0000-000000000000",
+            "",
+            "00000000-0000-0000-0000-000000000001"
+          ],
+          "ptrUuidSliceFunc": [
+            "00000000-0000-0000-0000-000000000000",
+            "",
+            "00000000-0000-0000-0000-000000000001"
+          ],
+          "uuid": "74771078-5edb-4733-88f2-111111111111",
+          "uuidFunc": "74771078-5edb-4733-88f2-111111111111",
+          "uuidSlice": [
+            "74771078-5edb-4733-88f2-222222222222",
+            "74771078-5edb-4733-88f2-333333333333",
+            "74771078-5edb-4733-88f2-444444444444"
+          ],
+          "uuidSliceFunc": [
+            "74771078-5edb-4733-88f2-222222222222",
+            "74771078-5edb-4733-88f2-333333333333",
+            "74771078-5edb-4733-88f2-444444444444"
+          ]
+        }
+      }
+    ]
+  },
+  {
     "Name": "invalid ptr uuid input",
     "Values": [
       {
@@ -57,6 +89,14 @@
   },
   {
     "Name": "invalid uuid func response",
+    "Values": [
+      {
+        "Error": "inner.invalidUuidFunc: invalidUUID"
+      }
+    ]
+  },
+  {
+    "Name": "batchExecutor:invalid uuid func response",
     "Values": [
       {
         "Error": "inner.invalidUuidFunc: invalidUUID"

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -49,7 +49,7 @@ func (e *Enum) enumValues() []string {
 type Object struct {
 	Name        string
 	Description string
-	Key         Resolver
+	KeyField    *Field
 	Fields      map[string]*Field
 }
 

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -126,6 +126,7 @@ type Field struct {
 	Args           map[string]Type
 	ParseArguments func(json interface{}) (interface{}, error)
 
+	External  bool
 	Expensive bool
 }
 

--- a/graphql/union_test.go
+++ b/graphql/union_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/graphql/schemabuilder"
 	"github.com/samsarahq/thunder/internal"
+	"github.com/samsarahq/thunder/internal/testgraphql"
 )
 
 type GatewayType int
@@ -70,7 +71,7 @@ func TestUnionType(t *testing.T) {
 		t.Error(err)
 	}
 
-	e := graphql.Executor{}
+	e := testgraphql.NewExecutorWrapper(t)
 
 	result, err := e.Execute(ctx, builtSchema.Query, nil, q)
 	if err != nil {
@@ -204,14 +205,18 @@ func TestBadUnionNonOneHot(t *testing.T) {
 		t.Error(err)
 	}
 
-	e := graphql.Executor{}
-	_, err := e.Execute(ctx, builtSchema.Query, nil, q)
-	if err == nil {
-		t.Error("expected err, received nil")
-	}
+	for _, execWithName := range testgraphql.GetExecutors() {
+		t.Run(execWithName.Name, func(t *testing.T) {
+			e := execWithName.Executor
+			_, err := e.Execute(ctx, builtSchema.Query, nil, q)
+			if err == nil {
+				t.Error("expected err, received nil")
+			}
 
-	if !strings.Contains(err.Error(), "union type field should only return one value") {
-		t.Errorf("expected err, received %s", err.Error())
+			if !strings.Contains(err.Error(), "union type field should only return one value") {
+				t.Errorf("expected err, received %s", err.Error())
+			}
+		})
 	}
 }
 
@@ -241,7 +246,7 @@ func TestUnionList(t *testing.T) {
 		t.Error(err)
 	}
 
-	e := graphql.Executor{}
+	e := testgraphql.NewExecutorWrapper(t)
 	result, err := e.Execute(ctx, builtSchema.Query, nil, q)
 	if err != nil {
 		t.Errorf("expected no error, received %s", err.Error())
@@ -284,7 +289,7 @@ func TestUnionStruct(t *testing.T) {
 		t.Error(err)
 	}
 
-	e := graphql.Executor{}
+	e := testgraphql.NewExecutorWrapper(t)
 	result, err := e.Execute(ctx, builtSchema.Query, nil, q)
 	if err != nil {
 		t.Errorf("expected no error, received %s", err.Error())

--- a/graphql/union_test.go
+++ b/graphql/union_test.go
@@ -62,7 +62,7 @@ func TestUnionType(t *testing.T) {
 	q := graphql.MustParse(`
 		{
 			asset: gateway(type: "asset") { __typename ... on Asset { name batteryLevel } ... on Vehicle { name speed } }
-			vehicle: gateway(type: "vehicle") { ... on Asset { name batteryLevel } ... on Vehicle { name speed } }
+			vehicle: gateway(type: "vehicle") { __typename ... on Asset { name batteryLevel } ... on Vehicle { name speed } }
 		}
 	`, map[string]interface{}{"var": float64(3)})
 
@@ -78,7 +78,7 @@ func TestUnionType(t *testing.T) {
 	}
 
 	if d := pretty.Compare(internal.AsJSON(result), internal.ParseJSON(`
-		{"vehicle": { "name": "a", "speed": 50 }, "asset": { "name": "b", "batteryLevel": 5, "__typename": "Gateway" }}`)); d != "" {
+		{"vehicle": { "name": "a", "speed": 50, "__typename": "Vehicle" }, "asset": { "name": "b", "batteryLevel": 5, "__typename": "Asset" }}`)); d != "" {
 		t.Errorf("expected did not match result: %s", d)
 	}
 }

--- a/graphql/writer.go
+++ b/graphql/writer.go
@@ -1,0 +1,109 @@
+package graphql
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+// errorRecorder is a concurrency-safe way where we can record the first error
+// we get from executing the graphql query.
+type errorRecorder struct {
+	sync.Once
+	err error
+}
+
+func (e *errorRecorder) record(err error) {
+	if err == nil {
+		return
+	}
+	e.Do(func() {
+		e.err = err
+	})
+}
+
+// newTopLevelOutputNode creates a top-level object writer, this should be
+// the object writer that starts the graphql query.
+func newTopLevelOutputNode(path string) *outputNode {
+	return &outputNode{
+		parent:      nil,
+		path:        path,
+		errRecorder: &errorRecorder{},
+	}
+}
+
+// newOutputNode creates an object writer as a part of a chain of objects.
+// It keeps track of the path and current parent so we can properly propagate
+// error information up the stack.
+func newOutputNode(parent *outputNode, path string) *outputNode {
+	return &outputNode{
+		parent:      parent,
+		path:        path,
+		errRecorder: parent.errRecorder,
+	}
+}
+
+type outputNode struct {
+	parent      *outputNode
+	path        string
+	res         interface{}
+	errRecorder *errorRecorder
+}
+
+func (o *outputNode) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.res)
+}
+
+func (o *outputNode) Fill(res interface{}) {
+	o.res = res
+}
+
+func (o *outputNode) Fail(err error) {
+	path := o.getPath()
+	err = nestPathErrorMulti(path, err)
+	o.errRecorder.record(err)
+}
+
+// getPath traverses the parent list to get the current execution path.
+func (o *outputNode) getPath() []string {
+	path := make([]string, 0)
+	cur := o
+	for cur != nil {
+		if cur.path != "" {
+			path = append(path, cur.path)
+		}
+		cur = cur.parent
+	}
+	return path
+}
+
+// Unwraps the object writer JSON map to a "regular" JSON comparable type.
+func outputNodeToJSON(src interface{}) interface{} {
+	switch src := src.(type) {
+	case map[string]*outputNode:
+		newMap := make(map[string]interface{}, len(src))
+		for key, val := range src {
+			newMap[key] = outputNodeToJSON(val)
+		}
+		return newMap
+	case []*outputNode:
+		newList := make([]interface{}, len(src))
+		for idx, val := range src {
+			newList[idx] = outputNodeToJSON(val)
+		}
+		return newList
+	case *outputNode:
+		return outputNodeToJSON(src.res)
+	case []interface{}:
+		for idx := range src {
+			src[idx] = outputNodeToJSON(src[idx])
+		}
+		return src
+	case map[string]interface{}:
+		for key := range src {
+			src[key] = outputNodeToJSON(src[key])
+		}
+		return src
+	default:
+		return src
+	}
+}

--- a/internal/testgraphql/executor.go
+++ b/internal/testgraphql/executor.go
@@ -1,0 +1,77 @@
+package testgraphql
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/samsarahq/thunder/graphql"
+	"github.com/samsarahq/thunder/internal"
+	"github.com/stretchr/testify/require"
+)
+
+type ExecutorAndName struct {
+	Name     string
+	Executor graphql.ExecutorRunner
+}
+
+func GetExecutors() []ExecutorAndName {
+	return []ExecutorAndName{
+		{
+			Name:     "",
+			Executor: &graphql.Executor{},
+		},
+		{
+			Name:     "batchExecutor:",
+			Executor: graphql.NewBatchExecutor(graphql.NewImmediateGoroutineScheduler()),
+		},
+	}
+}
+
+func NewExecutorWrapper(t *testing.T) *ExecutorWrapper {
+	return &ExecutorWrapper{
+		t:          t,
+		exactError: true,
+	}
+}
+
+func NewExecutorWrapperWithoutExactErrorMatch(t *testing.T) *ExecutorWrapper {
+	return &ExecutorWrapper{
+		t:          t,
+		exactError: false,
+	}
+}
+
+type ExecutorWrapper struct {
+	t          *testing.T
+	exactError bool
+}
+
+func (e *ExecutorWrapper) Execute(ctx context.Context, typ graphql.Type, source interface{}, query *graphql.Query) (interface{}, error) {
+	var lastOutput interface{}
+	var lastErr error
+	runOnce := false
+	for _, executorAndName := range GetExecutors() {
+		output, err := executorAndName.Executor.Execute(ctx, typ, source, query)
+		if !runOnce {
+			lastOutput = output
+			lastErr = err
+			runOnce = true
+			continue
+		}
+		if err != nil {
+			require.NotNil(e.t, lastErr)
+			if e.exactError {
+				require.Equal(e.t, lastErr.Error(), err.Error())
+			}
+			continue
+		}
+		require.Nil(e.t, lastErr)
+		require.True(
+			e.t,
+			reflect.DeepEqual(internal.AsJSON(lastOutput), internal.AsJSON(output)),
+			"queries for %q do no match between different executors", query.Name,
+		)
+	}
+	return lastOutput, lastErr
+}

--- a/internal/testgraphql/snapshotter.go
+++ b/internal/testgraphql/snapshotter.go
@@ -2,18 +2,20 @@ package testgraphql
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/samsarahq/go/snapshotter"
 	"github.com/samsarahq/thunder/graphql"
+	"github.com/samsarahq/thunder/internal"
 	"github.com/stretchr/testify/require"
 )
 
 type Snapshotter struct {
 	*snapshotter.Snapshotter
-	t        *testing.T
-	executor graphql.Executor
-	schema   *graphql.Schema
+	t      *testing.T
+	schema *graphql.Schema
 }
 
 func NewSnapshotter(t *testing.T, schema *graphql.Schema) *Snapshotter {
@@ -49,12 +51,35 @@ func (s *Snapshotter) SnapshotQuery(name, query string, opts ...Option) {
 		return
 	}
 	require.NoError(s.t, err)
-	output, err := s.executor.Execute(context.Background(), s.schema.Query, nil, q)
 
-	if err != nil && opt.recordError {
-		s.Snapshot(name, struct{ Error string }{err.Error()})
-	} else {
-		require.NoError(s.t, err)
-		s.Snapshot(name, output)
+	var lastOutput interface{}
+	var lastErr error
+	runOnce := false
+	for _, executorAndName := range GetExecutors() {
+		output, err := executorAndName.Executor.Execute(context.Background(), s.schema.Query, nil, q)
+
+		if err != nil && opt.recordError {
+			s.Snapshot(fmt.Sprintf("%s%s", executorAndName.Name, name), struct{ Error string }{err.Error()})
+		} else {
+			require.NoError(s.t, err)
+			s.Snapshot(fmt.Sprintf("%s%s", executorAndName.Name, name), output)
+		}
+		if !runOnce {
+			lastOutput = output
+			lastErr = err
+			runOnce = true
+			continue
+		}
+		if err != nil {
+			require.NotNil(s.t, lastErr)
+			require.Equal(s.t, lastErr.Error(), err.Error())
+			continue
+		}
+		require.Nil(s.t, lastErr)
+		require.True(
+			s.t,
+			reflect.DeepEqual(internal.AsJSON(lastOutput), internal.AsJSON(output)),
+			"Snapshots for %q do no match between different executors", name,
+		)
 	}
 }

--- a/reactive/ctxmutex_test.go
+++ b/reactive/ctxmutex_test.go
@@ -66,6 +66,9 @@ func TestMutexLockTimeout(t *testing.T) {
 
 func TestMutexLockCanceled(t *testing.T) {
 	var m ctxMutex
+	_ = m.Lock(context.Background()) // Grab the lock
+	defer m.Unlock()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	require.Equal(t, m.Lock(ctx), context.Canceled)

--- a/reactive/graph.go
+++ b/reactive/graph.go
@@ -71,7 +71,7 @@ func (n *node) strobe() {
 	}
 }
 
-// invalidate invalidates noode if it has not yet been invalidated
+// invalidate invalidates node if it has not yet been invalidated
 func (n *node) invalidate() {
 	// check if we should invalidate, and figure out who we should invalidate
 	n.mu.Lock()

--- a/reactive/rerunner_test.go
+++ b/reactive/rerunner_test.go
@@ -207,8 +207,8 @@ func TestErrorRetry(t *testing.T) {
 
 	shouldSentinel = false
 	run.Expect(t, "expected rerun after sentinel")
-	if innerRuns != 1 {
-		t.Errorf("expected 1 run, but got %d", innerRuns)
+	if innerRuns != 2 {
+		t.Errorf("expected 2 runs (first run and one after failed run), but got %d", innerRuns)
 	}
 }
 


### PR DESCRIPTION
Summary: Adds a new Executor option for Graphql execution to thunder.  This new
entrypoint has the ability to control the concurrency of requests through a 
"Scheduler" interface which owns how "ExecutionUnits" are executed on the graphql
graph.  In addition the new executor treats batches as a top-level concern, this 
makes it much easier to slot in graphQL batchFieldFuncs in a subsequent PR.

In the process of adding this new feature, there were a couple changes/fixes
that needed to go in to help with the migration:
- Fix passing SelectionSet into functions
- Change Object.Key from a Function to a fully-formed graphql.Field
- Add "External" flag on graphql.Field to control external concurrency.
- Clear reactive cache computations when a request errors.
- Fix Union type __typename fields so they are the type name of the sub-type (not the union)
- Fix a concurrency race condition that exists in pagination right now.