### PR TITLE
graphql, reactive: add flag to spawn goroutine

### DIFF
--- a/graphql/end_to_end_test.go
+++ b/graphql/end_to_end_test.go
@@ -278,7 +278,7 @@ func TestEndToEndAwaitAndCache(t *testing.T) {
 
 		results <- internal.AsJSON(result)
 		return nil, nil
-	}, 0)
+	}, 0, false)
 	defer rerunner.Stop()
 
 	result := <-results
@@ -441,7 +441,7 @@ func TestConcurrencyLimiterDeadlock(t *testing.T) {
 
 		assert.Equal(t, 2*200, calls)
 		return nil, nil
-	}, 0)
+	}, 0, false)
 
 	wg.Wait()
 	defer rerunner.Stop()

--- a/graphql/http.go
+++ b/graphql/http.go
@@ -120,7 +120,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		writeResponse(current, nil)
 		return nil, nil
-	}, DefaultMinRerunInterval)
+	}, DefaultMinRerunInterval, false)
 
 	wg.Wait()
 	runner.Stop()

--- a/graphql/schemabuilder/perf_test.go
+++ b/graphql/schemabuilder/perf_test.go
@@ -55,7 +55,7 @@ func BenchmarkSimpleExecute(b *testing.B) {
 			close(done)
 
 			return nil, errors.New("stop")
-		}, 0)
+		}, 0, false)
 		<-done
 	}
 }

--- a/livesql/example_test.go
+++ b/livesql/example_test.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/samsarahq/thunder/internal/testfixtures"
 	"github.com/samsarahq/thunder/livesql"
 	"github.com/samsarahq/thunder/reactive"
 	"github.com/samsarahq/thunder/sqlgen"
-	"github.com/samsarahq/thunder/internal/testfixtures"
 )
 
 type Cat struct {
@@ -60,7 +60,7 @@ func Example() {
 		fmt.Println(user.Name)
 		ch <- struct{}{}
 		return nil, nil
-	}, 200*time.Millisecond)
+	}, 200*time.Millisecond, false)
 	defer rerunner.Stop()
 
 	<-ch

--- a/livesql/integration_test.go
+++ b/livesql/integration_test.go
@@ -74,7 +74,7 @@ func TestIntegrationBasic(t *testing.T) {
 		}
 		users <- *user
 		return nil, nil
-	}, 50*time.Millisecond)
+	}, 50*time.Millisecond, false)
 	defer rerunner.Stop()
 
 	// Initial rerunner query matches initial insert.
@@ -160,7 +160,7 @@ func TestIntegrationFilterCustomType(t *testing.T) {
 		}
 		users <- user
 		return nil, nil
-	}, 50*time.Millisecond)
+	}, 50*time.Millisecond, false)
 	defer rerunner.Stop()
 
 	// Initial rerunner query matches initial insert.

--- a/reactive/rerunner_test.go
+++ b/reactive/rerunner_test.go
@@ -52,7 +52,7 @@ func TestRerun(t *testing.T) {
 		AddDependency(ctx, dep, nil)
 		run.Trigger()
 		return nil, nil
-	}, 0)
+	}, 0, false)
 
 	for i := 0; i < 10; i++ {
 		run.Expect(t, "expected (re-)run")
@@ -81,7 +81,7 @@ func TestCache(t *testing.T) {
 
 		run.Trigger()
 		return nil, nil
-	}, 0)
+	}, 0, false)
 
 	run.Expect(t, "expected run")
 	innerRun.Expect(t, "expected inner run")
@@ -106,7 +106,7 @@ func TestRerunCache(t *testing.T) {
 			return nil, nil
 		})
 		return nil, nil
-	}, 0)
+	}, 0, false)
 
 	run.Expect(t, "expected run")
 
@@ -126,7 +126,7 @@ func TestStop(t *testing.T) {
 		AddDependency(ctx, dep, nil)
 		run.Trigger()
 		return nil, nil
-	}, 0)
+	}, 0, false)
 
 	run.Expect(t, "expected run")
 
@@ -145,7 +145,7 @@ func TestError(t *testing.T) {
 		AddDependency(ctx, dep, nil)
 		run.Trigger()
 		return nil, errors.New("error")
-	}, 0)
+	}, 0, false)
 
 	run.Expect(t, "expected run")
 
@@ -179,7 +179,7 @@ func TestErrorRetry(t *testing.T) {
 			run.Trigger()
 		}
 		return nil, nil
-	}, 0)
+	}, 0, false)
 
 	run.Expect(t, "expected run")
 	if innerRuns != 1 {
@@ -230,7 +230,7 @@ func TestErrorRetryDelay(t *testing.T) {
 		oldRun.Trigger()
 
 		return nil, RetrySentinelError
-	}, 100*time.Millisecond)
+	}, 100*time.Millisecond, false)
 
 	run.Expect(t, "expected first run")
 
@@ -273,7 +273,7 @@ func TestCacheLock(t *testing.T) {
 
 		run.Trigger()
 		return nil, nil
-	}, 0)
+	}, 0, false)
 
 	run.Expect(t, "expected run")
 }
@@ -317,7 +317,7 @@ func TestCacheParallel(t *testing.T) {
 
 		run.Trigger()
 		return nil, nil
-	}, 0)
+	}, 0, false)
 
 	run.Expect(t, "expected run")
 }
@@ -343,7 +343,7 @@ func TestMinRerunInterval(t *testing.T) {
 		}
 
 		return nil, nil
-	}, 1*time.Second)
+	}, 1*time.Second, false)
 
 	run.Expect(t, "expected run")
 
@@ -374,7 +374,7 @@ func TestRerunImmediately(t *testing.T) {
 		}
 
 		return nil, nil
-	}, 30*time.Second)
+	}, 30*time.Second, false)
 
 	run.Expect(t, "expected run")
 


### PR DESCRIPTION
Turns out reruns blocked call to Invalidate().