### PR TITLE
go graphql: Add BatchFieldFuncs to new Executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### `graphql`
 
 - Introduced new executor for running GraphQL queries.  Includes WorkScheduler interface to control how work is scheduled/executed.
+- Introduced BatchFieldFuncWithFallback method for the new GraphQL executor (must have fallback until we've deleted the old executor)
 
 ### Changed
 

--- a/graphql/batch_test.go
+++ b/graphql/batch_test.go
@@ -1,0 +1,368 @@
+package graphql_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/samsarahq/thunder/graphql"
+	"github.com/samsarahq/thunder/graphql/schemabuilder"
+	"github.com/samsarahq/thunder/internal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchFieldFuncExecution(t *testing.T) {
+	type Object struct {
+		Key string
+	}
+	tests := []struct {
+		name                 string
+		objectFunc           interface{}
+		resolverFunc         interface{}
+		resolverFallbackFunc interface{}
+		query                string
+		wantResultJSON       string
+		wantError            string
+	}{
+		{
+			name:                 "good run with no value",
+			objectFunc:           func(ctx context.Context) []*Object { return []*Object{&Object{Key: "key1"}} },
+			resolverFunc:         func(ctx context.Context, o map[int]Object) (map[int]string, error) { return nil, nil },
+			resolverFallbackFunc: func(ctx context.Context, o Object) (*string, error) { return nil, nil },
+			query: `
+			{
+				objects {
+					key
+					value
+				}
+			}`,
+			wantResultJSON: `
+			{"objects": [
+			{"key": "key1", "value":null}
+			]}
+			`,
+		},
+		{
+			name:       "good run with response",
+			objectFunc: func(ctx context.Context) []*Object { return []*Object{&Object{Key: "key1"}} },
+			resolverFunc: func(ctx context.Context, o map[int]Object) (map[int]string, error) {
+				myMap := make(map[int]string, len(o))
+				for idx, val := range o {
+					myMap[idx] = "valfor" + val.Key
+				}
+				return myMap, nil
+			},
+			resolverFallbackFunc: func(ctx context.Context, o Object) (*string, error) {
+				str := "valfor" + o.Key
+				return &str, nil
+			},
+			query: `
+			{
+				objects {
+					key
+					value
+				}
+			}`,
+			wantResultJSON: `
+			{"objects": [
+			{"key": "key1", "value": "valforkey1"}
+			]}
+			`,
+		},
+		{
+			name:       "panic run with response",
+			objectFunc: func(ctx context.Context) []*Object { return []*Object{&Object{Key: "key1"}} },
+			resolverFunc: func(ctx context.Context, o map[int]Object) (map[int]string, error) {
+				panic("bad times")
+				return nil, errors.New("my error here")
+			},
+			resolverFallbackFunc: func(ctx context.Context, o Object) (*string, error) {
+				panic("bad times")
+				return nil, errors.New("my error here")
+			},
+			query: `
+			{
+				objects {
+					key
+					value
+				}
+			}`,
+			wantError: "bad times",
+		},
+		{
+			name:       "error run with response",
+			objectFunc: func(ctx context.Context) []*Object { return []*Object{&Object{Key: "key1"}} },
+			resolverFunc: func(ctx context.Context, o map[int]Object) (map[int]string, error) {
+				return nil, errors.New("my error here")
+			},
+			resolverFallbackFunc: func(ctx context.Context, o Object) (*string, error) {
+				return nil, errors.New("my error here")
+			},
+			query: `
+			{
+				objects {
+					key
+					value
+				}
+			}`,
+			wantError: "my error here",
+		},
+		{
+			name:       "good run with pointer args",
+			objectFunc: func(ctx context.Context) []*Object { return []*Object{&Object{Key: "key1"}} },
+			resolverFunc: func(ctx context.Context, o map[int]*Object) (map[int]string, error) {
+				myMap := make(map[int]string, len(o))
+				for idx, val := range o {
+					myMap[idx] = "valfor" + val.Key
+				}
+				return myMap, nil
+			},
+			resolverFallbackFunc: func(ctx context.Context, o Object) (*string, error) {
+				str := "valfor" + o.Key
+				return &str, nil
+			},
+			query: `
+			{
+				objects {
+					key
+					value
+				}
+			}`,
+			wantResultJSON: `
+			{"objects": [
+			{"key": "key1", "value": "valforkey1"}
+			]}
+			`,
+		},
+		{
+			name:       "good run with pointer response type",
+			objectFunc: func(ctx context.Context) []*Object { return []*Object{&Object{Key: "key1"}} },
+			resolverFunc: func(ctx context.Context, o map[int]*Object) (map[int]*string, error) {
+				myMap := make(map[int]*string, len(o))
+				for idx, val := range o {
+					p := "valfor" + val.Key
+					myMap[idx] = &p
+				}
+				return myMap, nil
+			},
+			resolverFallbackFunc: func(ctx context.Context, o Object) (*string, error) {
+				str := "valfor" + o.Key
+				return &str, nil
+			},
+			query: `
+			{
+				objects {
+					key
+					value
+				}
+			}`,
+			wantResultJSON: `
+			{"objects": [
+			{"key": "key1", "value": "valforkey1"}
+			]}
+			`,
+		},
+		{
+			name:       "good run with pointer nil response type",
+			objectFunc: func(ctx context.Context) []*Object { return []*Object{&Object{Key: "key1"}} },
+			resolverFunc: func(ctx context.Context, o map[int]*Object) (map[int]*string, error) {
+				myMap := make(map[int]*string, len(o))
+				for idx, _ := range o {
+					myMap[idx] = nil
+				}
+				return myMap, nil
+			},
+			resolverFallbackFunc: func(ctx context.Context, o Object) (*string, error) {
+				return nil, nil
+			},
+			query: `
+			{
+				objects {
+					key
+					value
+				}
+			}`,
+			wantResultJSON: `
+			{"objects": [
+			{"key": "key1", "value": null}
+			]}
+			`,
+		},
+		{
+			name:       "run with all sub-object and args",
+			objectFunc: func(ctx context.Context) []*Object { return []*Object{&Object{Key: "key1"}} },
+			resolverFunc: func(ctx context.Context, o map[int]*Object, args struct{ Prefix string }) (map[int]*Object, error) {
+				myMap := make(map[int]*Object, len(o))
+				for idx, val := range o {
+					val.Key = args.Prefix + val.Key
+					myMap[idx] = val
+				}
+				return myMap, nil
+			},
+			resolverFallbackFunc: func(ctx context.Context, o Object, args struct{ Prefix string }) (*Object, error) {
+				o.Key = args.Prefix + o.Key
+				return &o, nil
+			},
+			query: `
+			{
+				objects {
+					key
+					value(prefix: "test") {
+						key
+					}
+				}
+			}`,
+			wantResultJSON: `
+			{"objects": [
+			{"key": "key1", "value": {"key": "testkey1"}}
+			]}
+			`,
+		},
+		{
+			name:       "run with all possible parameters",
+			objectFunc: func(ctx context.Context) []*Object { return []*Object{&Object{Key: "key1"}} },
+			resolverFunc: func(ctx context.Context, o map[int]*Object, args struct{ Prefix string }, set *graphql.SelectionSet) (map[int]*Object, error) {
+				if set == nil {
+					return nil, errors.New("Expected to have selectionSet")
+				}
+				myMap := make(map[int]*Object, len(o))
+				for idx, val := range o {
+					val.Key = args.Prefix + val.Key
+					myMap[idx] = val
+				}
+				return myMap, nil
+			},
+			resolverFallbackFunc: func(ctx context.Context, o Object, args struct{ Prefix string }, set *graphql.SelectionSet) (*Object, error) {
+				if set == nil {
+					return nil, errors.New("Expected to have selectionSet")
+				}
+				o.Key = args.Prefix + o.Key
+				return &o, nil
+			},
+			query: `
+			{
+				objects {
+					key
+					value(prefix: "test") {
+						key
+					}
+				}
+			}`,
+			wantResultJSON: `
+			{"objects": [
+			{"key": "key1", "value": {"key": "testkey1"}}
+			]}
+			`,
+		},
+		{
+			name: "run with lots of objects",
+			objectFunc: func(ctx context.Context) []*Object {
+				return []*Object{
+					{Key: "key1"},
+					{Key: "key2"},
+					{Key: "key3"},
+					{Key: "key4"},
+					{Key: "key5"},
+					{Key: "key6"},
+					{Key: "key7"},
+					{Key: "key8"},
+				}
+			},
+			resolverFunc: func(ctx context.Context, o map[int]*Object, args struct{ Prefix string }, set *graphql.SelectionSet) (map[int]*Object, error) {
+				if set == nil {
+					return nil, errors.New("Expected to have selectionSet")
+				}
+				myMap := make(map[int]*Object, len(o))
+				for idx, val := range o {
+					val.Key = args.Prefix + val.Key
+					myMap[idx] = val
+				}
+				return myMap, nil
+			},
+			resolverFallbackFunc: func(ctx context.Context, o Object, args struct{ Prefix string }, set *graphql.SelectionSet) (*Object, error) {
+				if set == nil {
+					return nil, errors.New("Expected to have selectionSet")
+				}
+				o.Key = args.Prefix + o.Key
+				return &o, nil
+			},
+			query: `
+			{
+				objects {
+					key
+					value(prefix: "test") {
+						key
+					}
+				}
+			}`,
+			wantResultJSON: `
+			{"objects": [
+			{"key": "key1", "value": {"key": "testkey1"}},
+			{"key": "key2", "value": {"key": "testkey2"}},
+			{"key": "key3", "value": {"key": "testkey3"}},
+			{"key": "key4", "value": {"key": "testkey4"}},
+			{"key": "key5", "value": {"key": "testkey5"}},
+			{"key": "key6", "value": {"key": "testkey6"}},
+			{"key": "key7", "value": {"key": "testkey7"}},
+			{"key": "key8", "value": {"key": "testkey8"}}
+			]}
+			`,
+		},
+	}
+
+	const (
+		OldExecutor           = "OldExecutor"
+		NewExecutorNoBatching = "NewExecutorNoBatching"
+		NewExecutorBatching   = "NewExecutorBatching"
+	)
+	conditions := []string{OldExecutor, NewExecutorNoBatching, NewExecutorBatching}
+	for _, tt := range tests {
+		for _, cond := range conditions {
+			t.Run(fmt.Sprintf("%s %s", tt.name, cond), func(t *testing.T) {
+				builder := schemabuilder.NewSchema()
+				builder.Query().FieldFunc("objects", tt.objectFunc)
+
+				obj := builder.Object("object", Object{})
+				obj.BatchFieldFunc("value", tt.resolverFunc, tt.resolverFallbackFunc, func() bool {
+					return cond == NewExecutorNoBatching
+				})
+				schema, err := builder.Build()
+				require.NoError(t, err)
+
+				q := graphql.MustParse(tt.query, nil)
+
+				if err := graphql.PrepareQuery(schema.Query, q.SelectionSet); err != nil {
+					t.Error(err)
+				}
+
+				var e graphql.ExecutorRunner
+				e = graphql.NewBatchExecutor(graphql.NewImmediateGoroutineScheduler())
+				if cond == OldExecutor {
+					e = &graphql.Executor{}
+				}
+
+				ctx := context.Background()
+				res, err := e.Execute(ctx, schema.Query, nil, q)
+				if tt.wantError != "" {
+					require.Error(t, err)
+					require.Contains(t, err.Error(), tt.wantError)
+					return
+				}
+				require.NoError(t, err)
+
+				wantParsedJSON := internal.ParseJSON(tt.wantResultJSON)
+				gotJSON := internal.AsJSON(res)
+
+				require.Equal(
+					t,
+					wantParsedJSON,
+					gotJSON,
+					"Mismatch for expected vs actual response.  Want:\n%s\nGot:\n%s",
+					internal.MarshalJSON(wantParsedJSON),
+					internal.MarshalJSON(gotJSON),
+				)
+			})
+		}
+	}
+}

--- a/graphql/batch_test.go
+++ b/graphql/batch_test.go
@@ -332,7 +332,7 @@ func TestBatchFieldFuncExecution(t *testing.T) {
 
 				q := graphql.MustParse(tt.query, nil)
 
-				if err := graphql.PrepareQuery(schema.Query, q.SelectionSet); err != nil {
+				if err := graphql.PrepareQuery(context.Background(), schema.Query, q.SelectionSet); err != nil {
 					t.Error(err)
 				}
 

--- a/graphql/batch_test.go
+++ b/graphql/batch_test.go
@@ -324,7 +324,7 @@ func TestBatchFieldFuncExecution(t *testing.T) {
 				builder.Query().FieldFunc("objects", tt.objectFunc)
 
 				obj := builder.Object("object", Object{})
-				obj.BatchFieldFunc("value", tt.resolverFunc, tt.resolverFallbackFunc, func(ctx context.Context) bool {
+				obj.BatchFieldFuncWithFallback("value", tt.resolverFunc, tt.resolverFallbackFunc, func(ctx context.Context) bool {
 					return cond == NewExecutorNoBatching
 				})
 				schema, err := builder.Build()

--- a/graphql/batch_test.go
+++ b/graphql/batch_test.go
@@ -324,7 +324,7 @@ func TestBatchFieldFuncExecution(t *testing.T) {
 				builder.Query().FieldFunc("objects", tt.objectFunc)
 
 				obj := builder.Object("object", Object{})
-				obj.BatchFieldFunc("value", tt.resolverFunc, tt.resolverFallbackFunc, func() bool {
+				obj.BatchFieldFunc("value", tt.resolverFunc, tt.resolverFallbackFunc, func(ctx context.Context) bool {
 					return cond == NewExecutorNoBatching
 				})
 				schema, err := builder.Build()

--- a/graphql/connection_test.go
+++ b/graphql/connection_test.go
@@ -691,7 +691,7 @@ func TestEmbeddedArgs(t *testing.T) {
 			}
 	    }`, nil)
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 	e := testgraphql.NewExecutorWrapper(t)

--- a/graphql/end_to_end_test.go
+++ b/graphql/end_to_end_test.go
@@ -59,7 +59,7 @@ func TestPathError(t *testing.T) {
 			inner { inners { expensive { expensives { err } } } }
         }`, nil)
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -74,7 +74,7 @@ func TestPathError(t *testing.T) {
 			safe
 		}`, nil)
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -142,7 +142,7 @@ func TestEnum(t *testing.T) {
 			inner(enumField: firstField)
 		}
 		`, nil)
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -158,7 +158,7 @@ func TestEnum(t *testing.T) {
 			inner2(enumField2: this)
 		}
 		`, nil)
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -174,7 +174,7 @@ func TestEnum(t *testing.T) {
 			inner(enumField: wrongField)
 		}
 		`, nil)
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err == nil {
+	if err := graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet); err == nil {
 		t.Error(err)
 	}
 
@@ -183,7 +183,7 @@ func TestEnum(t *testing.T) {
 			optional(enumField: firstField)
 		}
 		`, nil)
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -199,7 +199,7 @@ func TestEnum(t *testing.T) {
 			pointerret(enumField: firstField)
 		}
 		`, nil)
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -263,7 +263,7 @@ func TestEndToEndAwaitAndCache(t *testing.T) {
             }
         }`, nil)
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -322,7 +322,7 @@ func TestEndToEndAwaitAndCache(t *testing.T) {
 func verifyArgumentOption(t *testing.T, query graphql.Type, queryString string, variables map[string]interface{}, expectedResult string) {
 	q := graphql.MustParse(queryString, variables)
 
-	if err := graphql.PrepareQuery(query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -424,7 +424,7 @@ func TestConcurrencyLimiterDeadlock(t *testing.T) {
             }
         }`, nil)
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 

--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -101,7 +101,7 @@ func unwrap(v interface{}) interface{} {
 
 // PrepareQuery checks that the given selectionSet matches the schema typ, and
 // parses the args in selectionSet
-func PrepareQuery(typ Type, selectionSet *SelectionSet) error {
+func PrepareQuery(ctx context.Context, typ Type, selectionSet *SelectionSet) error {
 	switch typ := typ.(type) {
 	case *Scalar:
 		if selectionSet != nil {
@@ -123,7 +123,7 @@ func PrepareQuery(typ Type, selectionSet *SelectionSet) error {
 				if fragment.On != typString {
 					continue
 				}
-				if err := PrepareQuery(graphqlTyp, fragment.SelectionSet); err != nil {
+				if err := PrepareQuery(ctx, graphqlTyp, fragment.SelectionSet); err != nil {
 					return err
 				}
 			}
@@ -178,22 +178,22 @@ func PrepareQuery(typ Type, selectionSet *SelectionSet) error {
 				selection.UseBatch = true
 			}
 
-			if err := PrepareQuery(field.Type, selection.SelectionSet); err != nil {
+			if err := PrepareQuery(ctx, field.Type, selection.SelectionSet); err != nil {
 				return err
 			}
 		}
 		for _, fragment := range selectionSet.Fragments {
-			if err := PrepareQuery(typ, fragment.SelectionSet); err != nil {
+			if err := PrepareQuery(ctx, typ, fragment.SelectionSet); err != nil {
 				return err
 			}
 		}
 		return nil
 
 	case *List:
-		return PrepareQuery(typ.Type, selectionSet)
+		return PrepareQuery(ctx, typ.Type, selectionSet)
 
 	case *NonNull:
-		return PrepareQuery(typ.Type, selectionSet)
+		return PrepareQuery(ctx, typ.Type, selectionSet)
 
 	default:
 		panic("unknown type kind")

--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -174,7 +174,7 @@ func PrepareQuery(ctx context.Context, typ Type, selectionSet *SelectionSet) err
 				selection.parsed = true
 			}
 
-			if field.Batch && field.UseBatchFunc() {
+			if field.Batch && field.UseBatchFunc(ctx) {
 				selection.UseBatch = true
 			}
 

--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -200,7 +200,7 @@ func PrepareQuery(ctx context.Context, typ Type, selectionSet *SelectionSet) err
 	}
 }
 
-func safeResolveBatch(ctx context.Context, field *Field, sources []interface{}, args interface{}, selectionSet *SelectionSet) (results []interface{}, err error) {
+func safeExecuteBatchResolver(ctx context.Context, field *Field, sources []interface{}, args interface{}, selectionSet *SelectionSet) (results []interface{}, err error) {
 	defer func() {
 		if panicErr := recover(); panicErr != nil {
 			const size = 64 << 10
@@ -212,7 +212,7 @@ func safeResolveBatch(ctx context.Context, field *Field, sources []interface{}, 
 	return field.BatchResolver(ctx, sources, args, selectionSet)
 }
 
-func safeResolve(ctx context.Context, field *Field, source, args interface{}, selectionSet *SelectionSet) (result interface{}, err error) {
+func safeExecuteResolver(ctx context.Context, field *Field, source, args interface{}, selectionSet *SelectionSet) (result interface{}, err error) {
 	defer func() {
 		if panicErr := recover(); panicErr != nil {
 			const size = 64 << 10
@@ -251,7 +251,7 @@ func (e *Executor) resolveAndExecute(ctx context.Context, field *Field, source i
 
 			// TODO: Consider cacheing resolve and execute independently
 			resolvedValue, err := reactive.Cache(ctx, key, func(ctx context.Context) (interface{}, error) {
-				value, err := safeResolve(ctx, field, source, selection.Args, selection.SelectionSet)
+				value, err := safeExecuteResolver(ctx, field, source, selection.Args, selection.SelectionSet)
 				if err != nil {
 					return nil, err
 				}
@@ -274,7 +274,7 @@ func (e *Executor) resolveAndExecute(ctx context.Context, field *Field, source i
 		}), nil
 	}
 
-	value, err := safeResolve(ctx, field, source, selection.Args, selection.SelectionSet)
+	value, err := safeExecuteResolver(ctx, field, source, selection.Args, selection.SelectionSet)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/executor_test.go
+++ b/graphql/executor_test.go
@@ -127,7 +127,7 @@ func TestBasic(t *testing.T) {
 		as { value valuePtr }
 	}`, nil)
 
-	if err := graphql.PrepareQuery(query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 	e := testgraphql.NewExecutorWrapper(t)
@@ -183,7 +183,7 @@ func TestRepeatedFragment(t *testing.T) {
 	}
 	`, nil)
 
-	if err := graphql.PrepareQuery(query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 	e := testgraphql.NewExecutorWrapper(t)
@@ -256,7 +256,7 @@ func TestError(t *testing.T) {
 		}
 	`, map[string]interface{}{})
 
-	if err := graphql.PrepareQuery(query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -278,7 +278,7 @@ func TestPanic(t *testing.T) {
 		}
 	`, nil)
 
-	if err := graphql.PrepareQuery(query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 

--- a/graphql/http.go
+++ b/graphql/http.go
@@ -85,7 +85,7 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if query.Kind == "mutation" {
 		schema = h.schema.Mutation
 	}
-	if err := PrepareQuery(schema, query.SelectionSet); err != nil {
+	if err := PrepareQuery(r.Context(), schema, query.SelectionSet); err != nil {
 		writeResponse(nil, err)
 		return
 	}

--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -376,7 +376,7 @@ func ComputeSchemaJSON(schemaBuilderSchema schemabuilder.Schema) ([]byte, error)
 		return nil, err
 	}
 
-	if err := graphql.PrepareQuery(schema.Query, query.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), schema.Query, query.SelectionSet); err != nil {
 		return nil, err
 	}
 

--- a/graphql/reactive_test.go
+++ b/graphql/reactive_test.go
@@ -59,7 +59,7 @@ func TestReactiveCacheResetsOnError(t *testing.T) {
 			uncachedError
 		}`, nil)
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 

--- a/graphql/schemabuilder/batch.go
+++ b/graphql/schemabuilder/batch.go
@@ -1,0 +1,338 @@
+package schemabuilder
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/samsarahq/thunder/graphql"
+)
+
+// buildBatchFunction corresponds to buildFunction for a batchFieldFunc
+func (sb *schemaBuilder) buildBatchFunctionWithFallback(typ reflect.Type, m *method) (*graphql.Field, error) {
+	fallbackField, fallbackFuncCtx, err := sb.buildFunctionAndFuncCtx(typ, &method{Fn: m.BatchArgs.FallbackFunc})
+	if err != nil {
+		return nil, err
+	}
+
+	batchField, batchFuncCtx, err := sb.buildBatchFunctionAndFuncCtx(typ, m)
+	if err != nil {
+		return nil, err
+	}
+
+	if fallbackFuncCtx.hasContext != batchFuncCtx.hasContext ||
+		!fallbackFuncCtx.hasSource || // Batch func always has a source.
+		fallbackFuncCtx.hasArgs != batchFuncCtx.hasArgs ||
+		fallbackFuncCtx.hasSelectionSet != batchFuncCtx.hasSelectionSet ||
+		fallbackFuncCtx.hasError != batchFuncCtx.hasError ||
+		fallbackFuncCtx.hasRet != batchFuncCtx.hasRet {
+		return nil, fmt.Errorf("batch and fallback function signatures did not match")
+	}
+	if fallbackField.Type.String() != batchField.Type.String() {
+		return nil, fmt.Errorf("batch and fallback graphql return types did not match: Batch(%v) Fallback(%v)", batchField.Type, fallbackField.Type)
+	}
+
+	if len(fallbackField.Args) != len(batchField.Args) {
+		return nil, fmt.Errorf("batch and fallback arg type did not match: Batch(%v) Fallback(%v)", batchField.Args, fallbackField.Args)
+	}
+	for key, fallbackTyp := range fallbackField.Args {
+		if batchType, ok := batchField.Args[key]; !ok || fallbackTyp.String() != batchType.String() {
+			return nil, fmt.Errorf("batch and fallback func arg types did not match: Batch(%v) Fallback(%v)", batchType, fallbackTyp)
+		}
+	}
+
+	if m.BatchArgs.ShouldUseFallbackFunc == nil {
+		return nil, fmt.Errorf("batch function requires fallback check function (got nil)")
+	}
+
+	batchField.UseBatchFunc = m.BatchArgs.ShouldUseFallbackFunc
+	batchField.Resolve = fallbackField.Resolve
+	return batchField, nil
+}
+
+// buildBatchFunction corresponds to buildFunction for a batchFieldFunc
+func (sb *schemaBuilder) buildBatchFunctionAndFuncCtx(typ reflect.Type, m *method) (*graphql.Field, *batchFuncContext, error) {
+	funcCtx := &batchFuncContext{parentTyp: typ}
+
+	if typ.Kind() == reflect.Ptr {
+		return nil, nil, fmt.Errorf("source-type of buildBatchFunction cannot be a pointer (got: %v)", typ)
+	}
+
+	callableFunc, err := funcCtx.getFuncVal(m)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	in := funcCtx.getFuncInputTypes()
+	if len(in) == 0 {
+		return nil, nil, fmt.Errorf("batch Field funcs require at least one input field")
+	}
+
+	in = funcCtx.consumeContext(in)
+	in, err = funcCtx.consumeRequiredSourceBatch(in)
+	if err != nil {
+		return nil, nil, err
+	}
+	argParser, args, in, err := funcCtx.consumeArgs(sb, in)
+	if err != nil {
+		return nil, nil, err
+	}
+	in = funcCtx.consumeSelectionSet(in)
+
+	// We have succeeded if no arguments remain.
+	if len(in) != 0 {
+		return nil, nil, fmt.Errorf("%s arguments should be [context,]map[int][*]%s[, args][, selectionSet]", funcCtx.funcType, typ)
+	}
+
+	out := funcCtx.getFuncOutputTypes()
+	retType, out, err := funcCtx.consumeReturnValue(m, sb, out)
+	if err != nil {
+		return nil, nil, err
+	}
+	out = funcCtx.consumeReturnError(out)
+	if len(out) > 0 {
+		return nil, nil, fmt.Errorf("%s return should be [map[int]<Type>][,error]", funcCtx.funcType)
+	}
+
+	batchExecFunc := func(ctx context.Context, sources []interface{}, funcRawArgs interface{}, selectionSet *graphql.SelectionSet) ([]interface{}, error) {
+		// Set up function arguments.
+		funcInputArgs := funcCtx.prepareResolveArgs(sources, funcRawArgs, ctx, selectionSet)
+
+		// Call the function.
+		funcOutputArgs := callableFunc.Call(funcInputArgs)
+
+		return funcCtx.extractResultsAndErr(len(sources), funcOutputArgs, retType)
+	}
+
+	return &graphql.Field{
+		BatchResolver:  batchExecFunc,
+		Batch:          true,
+		External:       true,
+		Args:           args,
+		Type:           retType,
+		ParseArguments: argParser.Parse,
+		Expensive:      funcCtx.hasContext,
+	}, funcCtx, nil
+}
+
+// funcContext is used to parse the function signature in buildFunction.
+type batchFuncContext struct {
+	hasContext      bool
+	hasArgs         bool
+	hasSelectionSet bool
+	hasRet          bool
+	hasError        bool
+
+	funcType     reflect.Type
+	batchMapType reflect.Type
+	isPtrFunc    bool
+	parentTyp    reflect.Type
+}
+
+// getFuncVal returns a reflect.Value of an executable function.
+func (funcCtx *batchFuncContext) getFuncVal(m *method) (reflect.Value, error) {
+	fun := reflect.ValueOf(m.Fn)
+	if fun.Kind() != reflect.Func {
+		return fun, fmt.Errorf("fun must be func, not %s", fun)
+	}
+	funcCtx.funcType = fun.Type()
+	return fun, nil
+}
+
+// getFuncInputTypes returns the input arguments for the function we're
+// representing.
+func (funcCtx *batchFuncContext) getFuncInputTypes() []reflect.Type {
+	in := make([]reflect.Type, 0, funcCtx.funcType.NumIn())
+	for i := 0; i < funcCtx.funcType.NumIn(); i++ {
+		in = append(in, funcCtx.funcType.In(i))
+	}
+	return in
+}
+
+// consumeContext reads in the input parameters for the provided
+// function and determines whether the function has a Context input parameter.
+// It returns the input types without the context parameter if it was there.
+func (funcCtx *batchFuncContext) consumeContext(in []reflect.Type) []reflect.Type {
+	if len(in) > 0 && in[0] == contextType {
+		funcCtx.hasContext = true
+		in = in[1:]
+	}
+	return in
+}
+
+// consumeRequiredSourceBatch reads in the input parameters for the provided
+// function and guarantees that the input parameters include a batch of the
+// parent type (map[int]*ParentObject).  If we don't have the batch we return an
+// error because the function is invalid.
+func (funcCtx *batchFuncContext) consumeRequiredSourceBatch(in []reflect.Type) ([]reflect.Type, error) {
+	if len(in) == 0 {
+		return nil, fmt.Errorf("requires batch source input parameter for func")
+	}
+	inType := in[0]
+	in = in[1:]
+
+	parentPtrType := reflect.PtrTo(funcCtx.parentTyp)
+	if inType.Kind() != reflect.Map ||
+		inType.Key().Kind() != reflect.Int ||
+		(inType.Elem() != parentPtrType && inType.Elem() != funcCtx.parentTyp) {
+		return nil, fmt.Errorf(
+			"invalid source batch type, expected one of map[int]*%s or map[int]%s, but got %s",
+			funcCtx.parentTyp.String(),
+			funcCtx.parentTyp.String(),
+			inType.String(),
+		)
+	}
+
+	funcCtx.isPtrFunc = inType.Elem() == parentPtrType
+	funcCtx.batchMapType = inType
+
+	return in, nil
+}
+
+// consumeArgs reads the args parameter if it is there and returns an argParser,
+// argTypeMap and the filtered input parameters.
+func (funcCtx *batchFuncContext) consumeArgs(sb *schemaBuilder, in []reflect.Type) (*argParser, map[string]graphql.Type, []reflect.Type, error) {
+	if len(in) == 0 || in[0] == selectionSetType {
+		return nil, nil, in, nil
+	}
+	inType := in[0]
+	in = in[1:]
+	argParser, argType, err := sb.makeStructParser(inType)
+	if err != nil {
+		return nil, nil, in, fmt.Errorf("attempted to parse %s as arguments struct, but failed: %s", inType.Name(), err.Error())
+	}
+	inputObject, ok := argType.(*graphql.InputObject)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("%s's args should be an object", funcCtx.funcType)
+	}
+	args := make(map[string]graphql.Type, len(inputObject.InputFields))
+	for name, typ := range inputObject.InputFields {
+		args[name] = typ
+	}
+	funcCtx.hasArgs = true
+	return argParser, args, in, nil
+}
+
+// consumeSelectionSet reads the input parameters and will pop off the
+// selectionSet type if we detect it in the input fields.  Check out
+// graphql.SelectionSet for more infomation about selection sets.
+func (funcCtx *batchFuncContext) consumeSelectionSet(in []reflect.Type) []reflect.Type {
+	if len(in) > 0 && in[0] == selectionSetType {
+		in = in[1:]
+		funcCtx.hasSelectionSet = true
+	}
+	return in
+}
+
+func (funcCtx *batchFuncContext) getFuncOutputTypes() []reflect.Type {
+	out := make([]reflect.Type, 0, funcCtx.funcType.NumOut())
+	for i := 0; i < funcCtx.funcType.NumOut(); i++ {
+		out = append(out, funcCtx.funcType.Out(i))
+	}
+	return out
+}
+
+// consumeReturnValue consumes the function output's response value if it exists
+// and validates that the response is a proper batch type.
+func (funcCtx *batchFuncContext) consumeReturnValue(m *method, sb *schemaBuilder, out []reflect.Type) (graphql.Type, []reflect.Type, error) {
+	if m.MarkedNonNullable {
+		return nil, nil, fmt.Errorf("%s is marked non-nullable, but batch functions must be able to handle nil responses", funcCtx.funcType)
+	}
+	if len(out) == 0 || out[0] == errType {
+		retType, err := sb.getType(reflect.TypeOf(true))
+		if err != nil {
+			return nil, nil, err
+		}
+		return retType, out, nil
+	}
+	outType := out[0]
+	out = out[1:]
+	if outType.Kind() != reflect.Map ||
+		outType.Key().Kind() != reflect.Int {
+		return nil, nil, fmt.Errorf(
+			"invalid response batch type, expected map[int]<Type>, but got %s",
+			outType.String(),
+		)
+	}
+	retType, err := sb.getType(outType.Elem())
+	if err != nil {
+		return nil, nil, err
+	}
+	if nonNull, ok := retType.(*graphql.NonNull); ok {
+		// Batch functions don't support NonNull responses by default
+		retType = nonNull.Type
+	}
+	funcCtx.hasRet = true
+	return retType, out, nil
+}
+
+// consumeReturnValue consumes the function output's error type if it exists.
+func (funcCtx *batchFuncContext) consumeReturnError(out []reflect.Type) []reflect.Type {
+	if len(out) > 0 && out[0] == errType {
+		funcCtx.hasError = true
+		out = out[1:]
+	}
+	return out
+}
+
+// prepareResolveArgs converts the provided source, args and context into the
+// required list of reflect.Value types that the function needs to be called.
+func (funcCtx *batchFuncContext) prepareResolveArgs(sources []interface{}, args interface{}, ctx context.Context, selectionSet *graphql.SelectionSet) []reflect.Value {
+	in := make([]reflect.Value, 0, funcCtx.funcType.NumIn())
+	if funcCtx.hasContext {
+		in = append(in, reflect.ValueOf(ctx))
+	}
+
+	batchMap := reflect.MakeMapWithSize(funcCtx.batchMapType, len(sources))
+	for idx, source := range sources {
+		idxVal := idx
+		sourceValue := reflect.ValueOf(source)
+		ptrSource := sourceValue.Kind() == reflect.Ptr
+		switch {
+		case ptrSource && !funcCtx.isPtrFunc:
+			batchMap.SetMapIndex(reflect.ValueOf(idxVal), sourceValue.Elem())
+		case !ptrSource && funcCtx.isPtrFunc:
+			copyPtr := reflect.New(funcCtx.parentTyp)
+			copyPtr.Elem().Set(sourceValue)
+			batchMap.SetMapIndex(reflect.ValueOf(idxVal), copyPtr)
+		default:
+			batchMap.SetMapIndex(reflect.ValueOf(idxVal), sourceValue)
+		}
+	}
+	in = append(in, batchMap)
+
+	// Set up other arguments.
+	if funcCtx.hasArgs {
+		in = append(in, reflect.ValueOf(args))
+	}
+	if funcCtx.hasSelectionSet {
+		in = append(in, reflect.ValueOf(selectionSet))
+	}
+
+	return in
+}
+
+// extractResultsAndErr converts the response from calling the function into
+// the expected type for the response object (as opposed to a reflect.Value).
+// It also handles reading whether the function ended with errors.
+func (funcCtx *batchFuncContext) extractResultsAndErr(numResps int, out []reflect.Value, retType graphql.Type) ([]interface{}, error) {
+	if funcCtx.hasError {
+		if err := out[len(out)-1]; !err.IsNil() {
+			return nil, err.Interface().(error)
+		}
+	}
+	if !funcCtx.hasRet {
+		res := make([]interface{}, numResps)
+		for i := 0; i < numResps; i++ {
+			res[i] = true
+		}
+		return res, nil
+	}
+	resBatch := out[0]
+
+	res := make([]interface{}, numResps)
+	for _, mapKey := range resBatch.MapKeys() {
+		res[mapKey.Int()] = resBatch.MapIndex(mapKey).Interface()
+	}
+	return res, nil
+}

--- a/graphql/schemabuilder/output.go
+++ b/graphql/schemabuilder/output.go
@@ -90,6 +90,15 @@ func (sb *schemaBuilder) buildStruct(typ reflect.Type) error {
 	for _, name := range names {
 		method := methods[name]
 
+		if method.Batch {
+			batchField, err := sb.buildBatchFunctionWithFallback(typ, method)
+			if err != nil {
+				return err
+			}
+			object.Fields[name] = batchField
+			continue
+		}
+
 		if method.Paginated {
 			typedField, err := sb.buildPaginatedField(typ, method)
 			if err != nil {

--- a/graphql/schemabuilder/perf_test.go
+++ b/graphql/schemabuilder/perf_test.go
@@ -40,7 +40,7 @@ func BenchmarkSimpleExecute(b *testing.B) {
 		}
 	`, nil)
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(ctx, builtSchema.Query, q.SelectionSet); err != nil {
 		b.Error(err)
 	}
 

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -847,7 +847,7 @@ func TestBatchFieldFuncValidation(t *testing.T) {
 
 			obj := builder.Object("object", Object{})
 			obj.Key("key")
-			obj.BatchFieldFunc("keys", tt.resolverFunc, tt.resolverFallbackFunc, func() bool { return true })
+			obj.BatchFieldFunc("keys", tt.resolverFunc, tt.resolverFallbackFunc, func(ctx context.Context) bool { return true })
 			_, err := builder.Build()
 			if tt.wantError {
 				assert.Error(t, err)

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -847,7 +847,7 @@ func TestBatchFieldFuncValidation(t *testing.T) {
 
 			obj := builder.Object("object", Object{})
 			obj.Key("key")
-			obj.BatchFieldFunc("keys", tt.resolverFunc, tt.resolverFallbackFunc, func(ctx context.Context) bool { return true })
+			obj.BatchFieldFuncWithFallback("keys", tt.resolverFunc, tt.resolverFallbackFunc, func(ctx context.Context) bool { return true })
 			_, err := builder.Build()
 			if tt.wantError {
 				assert.Error(t, err)

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -162,7 +162,7 @@ func TestExecuteGood(t *testing.T) {
 		}
 	`, map[string]interface{}{"var": float64(3)})
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(ctx, builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -301,7 +301,7 @@ func TestExecuteErrorNullReturn(t *testing.T) {
 		}
 	`, map[string]interface{}{"var": float64(3)})
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -331,7 +331,7 @@ func TestExecuteErrorBasic(t *testing.T) {
 		}
 	`, map[string]interface{}{"var": float64(3)})
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -90,7 +90,7 @@ func (s *Object) FieldFunc(name string, f interface{}, options ...FieldFuncOptio
 	s.Methods[name] = m
 }
 
-func (s *Object) BatchFieldFunc(name string, batchFunc interface{}, fallbackFunc interface{}, flag UseFallbackFlag) {
+func (s *Object) BatchFieldFuncWithFallback(name string, batchFunc interface{}, fallbackFunc interface{}, flag UseFallbackFlag) {
 	if s.Methods == nil {
 		s.Methods = make(Methods)
 	}

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -1,6 +1,9 @@
 package schemabuilder
 
-import "reflect"
+import (
+	"context"
+	"reflect"
+)
 
 // A Object represents a Go type and set of methods to be converted into an
 // Object in a GraphQL schema.
@@ -136,7 +139,7 @@ type method struct {
 	BatchArgs batchArgs
 }
 
-type UseFallbackFlag func() bool
+type UseFallbackFlag func(context.Context) bool
 
 type batchArgs struct {
 	FallbackFunc          interface{}

--- a/graphql/server.go
+++ b/graphql/server.go
@@ -197,7 +197,7 @@ func (c *conn) handleSubscribe(in *inEnvelope) error {
 		c.logger.Error(c.ctx, err, tags)
 		return err
 	}
-	if err := PrepareQuery(c.schema.Query, query.SelectionSet); err != nil {
+	if err := PrepareQuery(context.Background(), c.schema.Query, query.SelectionSet); err != nil {
 		c.logger.Error(c.ctx, err, tags)
 		return err
 	}
@@ -325,7 +325,7 @@ func (c *conn) handleMutate(in *inEnvelope) error {
 		c.logger.Error(c.ctx, err, tags)
 		return err
 	}
-	if err := PrepareQuery(c.mutationSchema.Mutation, query.SelectionSet); err != nil {
+	if err := PrepareQuery(c.ctx, c.mutationSchema.Mutation, query.SelectionSet); err != nil {
 		c.logger.Error(c.ctx, err, tags)
 		return err
 	}

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -130,7 +130,7 @@ type Field struct {
 	Args           map[string]Type
 	ParseArguments func(json interface{}) (interface{}, error)
 
-	UseBatchFunc func() bool
+	UseBatchFunc func(context.Context) bool
 	Batch        bool
 	External     bool
 	Expensive    bool

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -117,17 +117,23 @@ var _ Type = &Union{}
 // A Resolver calculates the value of a field of an object
 type Resolver func(ctx context.Context, source, args interface{}, selectionSet *SelectionSet) (interface{}, error)
 
+// A BatchResolver calculates the value of a field for a slice of objects.
+type BatchResolver func(ctx context.Context, sources []interface{}, args interface{}, selectionSet *SelectionSet) ([]interface{}, error)
+
 // Field knows how to compute field values of an Object
 //
 // Fields are responsible for computing their value themselves.
 type Field struct {
 	Resolve        Resolver
+	BatchResolver  BatchResolver
 	Type           Type
 	Args           map[string]Type
 	ParseArguments func(json interface{}) (interface{}, error)
 
-	External  bool
-	Expensive bool
+	UseBatchFunc func() bool
+	Batch        bool
+	External     bool
+	Expensive    bool
 }
 
 type Schema struct {
@@ -174,6 +180,8 @@ type Selection struct {
 	Alias        string
 	Args         interface{}
 	SelectionSet *SelectionSet
+
+	UseBatch bool
 
 	// The parsed flag is used to make sure the args for this Selection are only
 	// parsed once.

--- a/graphql/union_test.go
+++ b/graphql/union_test.go
@@ -67,7 +67,7 @@ func TestUnionType(t *testing.T) {
 		}
 	`, map[string]interface{}{"var": float64(3)})
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(ctx, builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -201,7 +201,7 @@ func TestBadUnionNonOneHot(t *testing.T) {
 
 	q := graphql.MustParse(`{ union { __typename } }`, map[string]interface{}{"var": float64(3)})
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(ctx, builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -242,7 +242,7 @@ func TestUnionList(t *testing.T) {
 
 	q := graphql.MustParse(`{ list { ... on UnionPart1 { otherThing } ... on UnionPart2 { thing } } }`, map[string]interface{}{"var": float64(3)})
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(ctx, builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 
@@ -285,7 +285,7 @@ func TestUnionStruct(t *testing.T) {
 
 	q := graphql.MustParse(`{ wrapper { x {... on UnionPart1 { otherThing } ... on UnionPart2 { thing } } } }`, map[string]interface{}{"var": float64(3)})
 
-	if err := graphql.PrepareQuery(builtSchema.Query, q.SelectionSet); err != nil {
+	if err := graphql.PrepareQuery(ctx, builtSchema.Query, q.SelectionSet); err != nil {
 		t.Error(err)
 	}
 

--- a/internal/testgraphql/snapshotter.go
+++ b/internal/testgraphql/snapshotter.go
@@ -45,7 +45,7 @@ func (s *Snapshotter) SnapshotQuery(name, query string, opts ...Option) {
 	opt := applyOpts(opts)
 
 	q := graphql.MustParse(query, nil)
-	err := graphql.PrepareQuery(s.schema.Query, q.SelectionSet)
+	err := graphql.PrepareQuery(context.Background(), s.schema.Query, q.SelectionSet)
 	if err != nil && opt.recordError {
 		s.Snapshot(name, struct{ Error string }{err.Error()})
 		return


### PR DESCRIPTION
Summary: Adds support for running fieldFuncs as a "Batch" instead of one at a time. 
The API surface of this forces passing in a Fallback/Non-batch function that has 
the same signature as the batch function.  This is mostly for the transition period,
eventually we'll go full-batch.