### PR TITLE
go graphql: Use flattening function for new executor results

### DIFF
--- a/graphql/batch_executor.go
+++ b/graphql/batch_executor.go
@@ -101,7 +101,7 @@ func (e *BatchExecutor) Execute(ctx context.Context, typ Type, source interface{
 	if topLevelRespWriter.errRecorder.err != nil {
 		return nil, topLevelRespWriter.errRecorder.err
 	}
-	return writers, nil
+	return outputNodeToJSON(writers), nil
 }
 
 // executeWorkUnit executes/resolves a work unit and checks the


### PR DESCRIPTION
Summary: I wrote a graphql tree flattening function that would convert
an output node into a JSON tree of map[string]interface{},
[]interface{}, etc.  We didn't use it because we thought we wouldn't
necessarily need it (we could do JSON marshal/unmarshaling).  Since 
the thunder/diff package heavily depends on the map[string]interface{}
type structure to function properly this commit unwraps the new executor's
graphql result.