### PR TITLE
go graphql: Properly index paths for list errors in batch executor

### DIFF
--- a/graphql/batch_executor.go
+++ b/graphql/batch_executor.go
@@ -259,7 +259,7 @@ func resolveListBatch(ctx context.Context, sources []interface{}, typ *List, sel
 	for idx, slice := range reflectedSources {
 		respList := make([]interface{}, slice.Len())
 		for i := 0; i < slice.Len(); i++ {
-			writer := newOutputNode(destinations[idx], strconv.Itoa(idx))
+			writer := newOutputNode(destinations[idx], strconv.Itoa(i))
 			respList[i] = writer
 			flattenedResps = append(flattenedResps, writer)
 			flattenedSources = append(flattenedSources, slice.Index(i).Interface())


### PR DESCRIPTION
Summary: Accidentally wasn't using the proper index for list error paths.
Caught this error when running through all our production
snapshots.  Wrote a test that fails before the executor change and
passes after the change.