### PR TITLE
go graphql: Fix bug with passing back nils/empty results for batchFuncs

### DIFF
--- a/graphql/batch_executor.go
+++ b/graphql/batch_executor.go
@@ -350,7 +350,7 @@ func resolveObjectBatch(ctx context.Context, sources []interface{}, typ *Object,
 	originDestinations := make([]*outputNode, 0, len(destinations))
 	for idx, source := range sources {
 		value := reflect.ValueOf(source)
-		if value.Kind() == reflect.Ptr && value.IsNil() {
+		if !value.IsValid() || (value.Kind() == reflect.Ptr && value.IsNil()) {
 			destinations[idx].Fill(nil)
 			continue
 		}


### PR DESCRIPTION
Summary: Fixes a bug that would occur when a batchFieldFunc would return
less objects than were passed in.  Adds a test which failed before and
passes afterwards.