### PR TITLE
go graphql: Fix Nil List & Union responses in Batches

### DIFF
--- a/graphql/schemabuilder/batch.go
+++ b/graphql/schemabuilder/batch.go
@@ -259,8 +259,11 @@ func (funcCtx *batchFuncContext) consumeReturnValue(m *method, sb *schemaBuilder
 		return nil, nil, err
 	}
 	if nonNull, ok := retType.(*graphql.NonNull); ok {
-		// Batch functions don't support NonNull responses by default
-		retType = nonNull.Type
+		if _, isList := nonNull.Type.(*graphql.List); !isList {
+			// Batch functions don't support NonNull responses by default unless they
+			// are lists we can fill with zero length values.
+			retType = nonNull.Type
+		}
 	}
 	funcCtx.hasRet = true
 	return retType, out, nil


### PR DESCRIPTION
Summary: Added tests to validate that List and Union types worked
properly with batch functions.  Found that there were some odd edge
cases with batches that required a few extra checks.  In addition to the
extra checks we need to be able to support Non-Nil List types to have
1:1 support with the existing list responses (which must be non-nil).
We make an exception to batch list responses to support returning
nil/non-valid values and converting them to a Zero-sized list.

Added tests for List and Union to validate that everything works.

Only grey area type now is enum types which are not fully functional in
batch & non-batch contexts. but solving this might be a bit more trouble
than it is worth.