### PR TITLE
go schemabuilder: Allow marking batchFieldFuncs as "NonNullable"

### DIFF
--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -90,7 +90,7 @@ func (s *Object) FieldFunc(name string, f interface{}, options ...FieldFuncOptio
 	s.Methods[name] = m
 }
 
-func (s *Object) BatchFieldFuncWithFallback(name string, batchFunc interface{}, fallbackFunc interface{}, flag UseFallbackFlag) {
+func (s *Object) BatchFieldFuncWithFallback(name string, batchFunc interface{}, fallbackFunc interface{}, flag UseFallbackFlag, options ...FieldFuncOption) {
 	if s.Methods == nil {
 		s.Methods = make(Methods)
 	}
@@ -102,6 +102,9 @@ func (s *Object) BatchFieldFuncWithFallback(name string, batchFunc interface{}, 
 			ShouldUseFallbackFunc: flag,
 		},
 		Batch: true,
+	}
+	for _, opt := range options {
+		opt.apply(m)
 	}
 
 	if _, ok := s.Methods[name]; ok {


### PR DESCRIPTION
Summary: Adds support for marking a BatchFieldFunc as "NonNullable". We
don't have the ability to enforce this explicitly through the function
signature, but we can enforce it by validating that responses are being
passed back properly for every node we passed in.  If we see a mismatch
we fail the entire query.

This allows us to have parity with the current non-nullable fieldFuncs
we have right now.  I've added some tests to validate that we fail if a
nil result is returned, and for the happy cases of having non-nil
strings and enum values.