### PR TITLE
go reactive: Don't cleanAll whenever we get an error

### DIFF
--- a/reactive/rerunner.go
+++ b/reactive/rerunner.go
@@ -103,16 +103,6 @@ func (c *cache) cleanInvalidated() {
 	}
 }
 
-func (c *cache) cleanAll() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	for key, computation := range c.computations {
-		computation.node.release()
-		delete(c.computations, key)
-	}
-}
-
 // Resource represents a leaf-level dependency in a computation
 type Resource struct {
 	node
@@ -363,8 +353,6 @@ func (r *Rerunner) run() {
 	computation, err := run(ctx, r.f)
 	r.lastRun = time.Now()
 	if err != nil {
-		// We've hit an error, make sure we clear all existing computations immediately.
-		r.cache.cleanAll()
 		if err == RetrySentinelError {
 
 			r.retryDelay = r.retryDelay * 2

--- a/reactive/rerunner_test.go
+++ b/reactive/rerunner_test.go
@@ -207,8 +207,8 @@ func TestErrorRetry(t *testing.T) {
 
 	shouldSentinel = false
 	run.Expect(t, "expected rerun after sentinel")
-	if innerRuns != 2 {
-		t.Errorf("expected 2 runs (first run and one after failed run), but got %d", innerRuns)
+	if innerRuns != 1 {
+		t.Errorf("expected 1 runs (first run), but got %d", innerRuns)
 	}
 }
 


### PR DESCRIPTION
Summary: Removes a cleanAll func call whenever we get an error.