### PR TITLE
go reactive: Reset reactive cache on every run.

### DIFF
--- a/reactive/rerunner_test.go
+++ b/reactive/rerunner_test.go
@@ -207,8 +207,8 @@ func TestErrorRetry(t *testing.T) {
 
 	shouldSentinel = false
 	run.Expect(t, "expected rerun after sentinel")
-	if innerRuns != 1 {
-		t.Errorf("expected 1 runs (first run), but got %d", innerRuns)
+	if innerRuns != 2 {
+		t.Errorf("expected 2 runs (first run, then retry run), but got %d", innerRuns)
 	}
 }
 


### PR DESCRIPTION
Summary: Whenever we get a retry sentinel error we want to throw away
the current calculations we have to get a clean slate for the next run.

This is required to rollout the new graphql Executor which has a
possibility of caching promises that stored an error (instead of the
result we want).