### PR TITLE
go graphql: Add support for using batch.Index as key for all batchFieldFuncs

### DIFF
--- a/batch/index.go
+++ b/batch/index.go
@@ -1,0 +1,5 @@
+package batch
+
+// Index is an alias for the int type, it should be used in all batch field
+// funcs.
+type Index int

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/internal"
 	"github.com/stretchr/testify/assert"
@@ -836,7 +837,25 @@ func TestBatchFieldFuncValidation(t *testing.T) {
 		{
 			name:                 "batch to many response fields",
 			resolverFunc:         func(ctx context.Context, o map[int]Object) (map[int]string, error, bool) { return nil, nil, false },
-			resolverFallbackFunc: func(ctx context.Context, o Object) (string, error) { return "", nil },
+			resolverFallbackFunc: func(ctx context.Context, o Object) (*string, error) { return nil, nil },
+			wantError:            true,
+		},
+		{
+			name:                 "batch.Index usage",
+			resolverFunc:         func(ctx context.Context, o map[batch.Index]Object) (map[batch.Index]string, error) { return nil, nil },
+			resolverFallbackFunc: func(ctx context.Context, o Object) (*string, error) { return nil, nil },
+			wantError:            false,
+		},
+		{
+			name:                 "batch.Index only on params",
+			resolverFunc:         func(ctx context.Context, o map[batch.Index]Object) (map[int]*string, error) { return nil, nil },
+			resolverFallbackFunc: func(ctx context.Context, o Object) (*string, error) { return nil, nil },
+			wantError:            true,
+		},
+		{
+			name:                 "batch.Index only on response",
+			resolverFunc:         func(ctx context.Context, o map[int]Object) (map[batch.Index]*string, error) { return nil, nil },
+			resolverFallbackFunc: func(ctx context.Context, o Object) (*string, error) { return nil, nil },
 			wantError:            true,
 		},
 	}


### PR DESCRIPTION
Summary: Introduces a batch.Index type that we can optionally use in
batchFieldFuncs.  This is to make it obvious that we're using an index
and not necessarily a key or Id.