### PR TITLE
go graphql: Short-Circuit execution if no sources

### DIFF
--- a/graphql/batch_executor.go
+++ b/graphql/batch_executor.go
@@ -195,6 +195,9 @@ func executeNonBatchWorkUnit(ctx context.Context, src interface{}, dest *outputN
 // returns new work units that are required to resolve the rest of the
 // query result.
 func resolveBatch(ctx context.Context, sources []interface{}, typ Type, selectionSet *SelectionSet, destinations []*outputNode) ([]*WorkUnit, error) {
+	if len(sources) == 0 {
+		return nil, nil
+	}
 	switch typ := typ.(type) {
 	case *Scalar:
 		return nil, resolveScalarBatch(sources, typ, destinations)

--- a/graphql/batch_test.go
+++ b/graphql/batch_test.go
@@ -714,6 +714,28 @@ func TestBatchFieldFuncExecution(t *testing.T) {
 			]}
 			`,
 		},
+		{
+			name:       "zero len list does not execute BatchFieldFunc",
+			objectFunc: func(ctx context.Context) []Object { return []Object{} },
+			resolverFunc: func(o map[int]Object) (map[int]string, error) {
+				require.Fail(t, "fieldFunc should not have been called")
+				return nil, nil
+			},
+			resolverFallbackFunc: func(o Object) (*string, error) {
+				require.Fail(t, "fieldFunc should not have been called")
+				return nil, nil
+			},
+			query: `
+			{
+				objects {
+					key
+					value
+				}
+			}`,
+			wantResultJSON: `
+			{"objects": []}
+			`,
+		},
 	}
 
 	const (


### PR DESCRIPTION
Summary: There was an edge-case where we'd schedule another round of
useless work for empty list responses.  This fixes the problem by
stopping the unwrapping if we have no sources/destinations to use.