### PR TITLE
Implements Unwrap for SafeErrors

### DIFF
--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -12,6 +12,7 @@ type SanitizedError interface {
 }
 
 type SafeError struct {
+	inner   error
 	message string
 }
 
@@ -33,12 +34,23 @@ func (e SafeError) SanitizedError() string {
 	return e.message
 }
 
+// Unwrap returns the wrapped error, implementing go's 1.13 error wrapping proposal.
+func (e SafeError) Unwrap() error {
+	return e.inner
+}
+
 func NewClientError(format string, a ...interface{}) error {
 	return ClientError{message: fmt.Sprintf(format, a...)}
 }
 
 func NewSafeError(format string, a ...interface{}) error {
 	return SafeError{message: fmt.Sprintf(format, a...)}
+}
+
+// WrapAsSafeError wraps an error into a "SafeError", and takes in a message.
+// This message can be used like fmt.Sprintf to take in formatting and arguments.
+func WrapAsSafeError(err error, format string, a ...interface{}) error {
+	return SafeError{inner: err, message: fmt.Sprintf(format, a...)}
 }
 
 func sanitizeError(err error) string {

--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -1,0 +1,54 @@
+package graphql
+
+import (
+	"fmt"
+
+	"github.com/gorilla/websocket"
+)
+
+type SanitizedError interface {
+	error
+	SanitizedError() string
+}
+
+type SafeError struct {
+	message string
+}
+
+type ClientError SafeError
+
+func (e ClientError) Error() string {
+	return e.message
+}
+
+func (e ClientError) SanitizedError() string {
+	return e.message
+}
+
+func (e SafeError) Error() string {
+	return e.message
+}
+
+func (e SafeError) SanitizedError() string {
+	return e.message
+}
+
+func NewClientError(format string, a ...interface{}) error {
+	return ClientError{message: fmt.Sprintf(format, a...)}
+}
+
+func NewSafeError(format string, a ...interface{}) error {
+	return SafeError{message: fmt.Sprintf(format, a...)}
+}
+
+func sanitizeError(err error) string {
+	if sanitized, ok := err.(SanitizedError); ok {
+		return sanitized.SanitizedError()
+	}
+	return "Internal server error"
+}
+
+func isCloseError(err error) bool {
+	_, ok := err.(*websocket.CloseError)
+	return ok || err == websocket.ErrCloseSent
+}

--- a/graphql/errors_test.go
+++ b/graphql/errors_test.go
@@ -1,0 +1,28 @@
+package graphql_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/samsarahq/thunder/graphql"
+	"github.com/stretchr/testify/assert"
+)
+
+type Wrapper interface {
+	Unwrap() error
+}
+
+func TestNewSafeError(t *testing.T) {
+	err := graphql.NewSafeError("This is an error.")
+	wrapperError, ok := err.(Wrapper)
+	assert.True(t, ok)
+	assert.Nil(t, wrapperError.Unwrap())
+}
+
+func TestWrapAsSafeError(t *testing.T) {
+	sourceErr := errors.New("I am the source error.")
+	err := graphql.WrapAsSafeError(sourceErr, "This is an error.")
+	wrapperError, ok := err.(Wrapper)
+	assert.True(t, ok)
+	assert.Equal(t, sourceErr, wrapperError.Unwrap())
+}

--- a/graphql/server.go
+++ b/graphql/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log"
 	"net/http"
 	"sync"
@@ -99,53 +98,6 @@ type subscribeMessage struct {
 type mutateMessage struct {
 	Query     string                 `json:"query"`
 	Variables map[string]interface{} `json:"variables"`
-}
-
-type SanitizedError interface {
-	error
-	SanitizedError() string
-}
-
-type SafeError struct {
-	message string
-}
-
-type ClientError SafeError
-
-func (e ClientError) Error() string {
-	return e.message
-}
-
-func (e ClientError) SanitizedError() string {
-	return e.message
-}
-
-func (e SafeError) Error() string {
-	return e.message
-}
-
-func (e SafeError) SanitizedError() string {
-	return e.message
-}
-
-func NewClientError(format string, a ...interface{}) error {
-	return ClientError{message: fmt.Sprintf(format, a...)}
-}
-
-func NewSafeError(format string, a ...interface{}) error {
-	return SafeError{message: fmt.Sprintf(format, a...)}
-}
-
-func sanitizeError(err error) string {
-	if sanitized, ok := err.(SanitizedError); ok {
-		return sanitized.SanitizedError()
-	}
-	return "Internal server error"
-}
-
-func isCloseError(err error) bool {
-	_, ok := err.(*websocket.CloseError)
-	return ok || err == websocket.ErrCloseSent
 }
 
 func (c *conn) writeOrClose(out outEnvelope) {


### PR DESCRIPTION
We want to be able to extract stack traces from safeErrors. To do this, we're adding an `inner` field to the struct, and implementing `Unwrap` to extract this in order to get to an error type that provides a stack trace.

I've also moved errors out to errors.go for cleanliness.