### PR TITLE
go schemabuilder: Add BatchFieldFunc entry point (no fallback)

### DIFF
--- a/graphql/schemabuilder/batch.go
+++ b/graphql/schemabuilder/batch.go
@@ -51,6 +51,17 @@ func (sb *schemaBuilder) buildBatchFunctionWithFallback(typ reflect.Type, m *met
 	return batchField, nil
 }
 
+func (sb *schemaBuilder) buildBatchFunction(typ reflect.Type, m *method) (*graphql.Field, error) {
+	batchField, _, err := sb.buildBatchFunctionAndFuncCtx(typ, m)
+	if err != nil {
+		return nil, err
+	}
+	batchField.UseBatchFunc = func(context.Context) bool {
+		return true
+	}
+	return batchField, nil
+}
+
 // buildBatchFunction corresponds to buildFunction for a batchFieldFunc
 func (sb *schemaBuilder) buildBatchFunctionAndFuncCtx(typ reflect.Type, m *method) (*graphql.Field, *batchFuncContext, error) {
 	funcCtx := &batchFuncContext{parentTyp: typ}

--- a/graphql/schemabuilder/output.go
+++ b/graphql/schemabuilder/output.go
@@ -91,7 +91,15 @@ func (sb *schemaBuilder) buildStruct(typ reflect.Type) error {
 		method := methods[name]
 
 		if method.Batch {
-			batchField, err := sb.buildBatchFunctionWithFallback(typ, method)
+			if method.BatchArgs.FallbackFunc != nil {
+				batchField, err := sb.buildBatchFunctionWithFallback(typ, method)
+				if err != nil {
+					return err
+				}
+				object.Fields[name] = batchField
+				continue
+			}
+			batchField, err := sb.buildBatchFunction(typ, method)
 			if err != nil {
 				return err
 			}

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -90,6 +90,25 @@ func (s *Object) FieldFunc(name string, f interface{}, options ...FieldFuncOptio
 	s.Methods[name] = m
 }
 
+func (s *Object) BatchFieldFunc(name string, batchFunc interface{}, options ...FieldFuncOption) {
+	if s.Methods == nil {
+		s.Methods = make(Methods)
+	}
+
+	m := &method{
+		Fn:    batchFunc,
+		Batch: true,
+	}
+	for _, opt := range options {
+		opt.apply(m)
+	}
+
+	if _, ok := s.Methods[name]; ok {
+		panic("duplicate method")
+	}
+	s.Methods[name] = m
+}
+
 func (s *Object) BatchFieldFuncWithFallback(name string, batchFunc interface{}, fallbackFunc interface{}, flag UseFallbackFlag, options ...FieldFuncOption) {
 	if s.Methods == nil {
 		s.Methods = make(Methods)


### PR DESCRIPTION
Summary: Adds an entrypoint for batchFieldFuncs that does not require a
"fallback" method to be registered.  This will not work with the old
executor, but, we're in the process of deleting the old executor so it
should be fine.