### PR TITLE
sqlgen: WithShardLimit bug when filter is part of pk

### DIFF
--- a/sqlgen/db.go
+++ b/sqlgen/db.go
@@ -311,7 +311,9 @@ func (db *DB) UpdateRow(ctx context.Context, row interface{}) error {
 		return err
 	}
 
-	if err := db.checkColumnValuesAgainstShardLimit(query.Columns, query.Values); err != nil {
+	if err := db.checkColumnValuesAgainstShardLimit(
+		append(query.Where.Columns, query.Columns...),
+		append(query.Where.Values, query.Values...)); err != nil {
 		return err
 	}
 

--- a/sqlgen/integration_test.go
+++ b/sqlgen/integration_test.go
@@ -344,6 +344,20 @@ func TestLimit(t *testing.T) {
 		t.Error(err)
 	}
 
+	// Check aliceDb can update alice if pk is part of the shard limit clause
+	aliceDb, err = db.WithShardLimit(Filter{
+		"name": alice.Name,
+		"id":   alice.Id, // Shard part of PK
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check aliceDb can update alice.
+	if err := aliceDb.UpdateRow(ctx, alice); err != nil {
+		t.Error(err)
+	}
+
 	// Check aliceDb can't update bob.
 	if err := aliceDb.UpdateRow(ctx, bob); err == nil || !strings.Contains(err.Error(), "name = Alice") {
 		t.Error("could update bob on aliceDb")


### PR DESCRIPTION
When we use UpdateRow, we fail to check if the shard filter is in the
where columns. If the shard is part of PK, the column and value is
added to as part of the columns in the where component of the query.
As a result, we should check both the where and the regular columns
for the shard filter when we update a row.