### PR TITLE
Batching Pagination Filters

### DIFF
--- a/graphql/benchmark_test.go
+++ b/graphql/benchmark_test.go
@@ -1,0 +1,115 @@
+package graphql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samsarahq/thunder/batch"
+	"github.com/samsarahq/thunder/graphql"
+	"github.com/samsarahq/thunder/graphql/schemabuilder"
+	"github.com/stretchr/testify/require"
+)
+
+func pagintedQueryWithFilterBenchmark(b *testing.B, n int, batchFunc bool) {
+	schema := schemabuilder.NewSchema()
+	type Inner struct {
+	}
+	query := schema.Query()
+	query.FieldFunc("inner", func() Inner {
+		return Inner{}
+	})
+	inner := schema.Object("inner", Inner{})
+	item := schema.Object("item", Item{})
+	item.Key("id")
+	filterTexts := [5]string{"can", "man", "cannot", "soban", "socan"}
+	items := make([]Item, n, n)
+	for i := 0; i < n; i++ {
+		items[i] = Item{Id: int64(i), FilterText: filterTexts[i%5], String: "a"}
+	}
+	if !batchFunc {
+		inner.FieldFunc("innerConnectionWithFilter", func() []Item {
+			return items
+		}, schemabuilder.Paginated,
+			schemabuilder.FilterField("foo",
+				func(ctx context.Context, i Item) string {
+					return i.FilterText
+				},
+			),
+			schemabuilder.FilterField("bar",
+				func(ctx context.Context, i Item) string {
+					return i.String
+				},
+			),
+		)
+	} else {
+		inner.FieldFunc("innerConnectionWithFilter", func() []Item {
+			return items
+		}, schemabuilder.Paginated,
+			schemabuilder.BatchFilterField("foo",
+				func(ctx context.Context, items map[batch.Index]Item) (map[batch.Index]string, error) {
+					myMap := make(map[batch.Index]string, len(items))
+					for i, item := range items {
+						myMap[i] = item.FilterText
+					}
+					return myMap, nil
+				},
+			),
+			schemabuilder.BatchFilterField("bar",
+				func(ctx context.Context, items map[batch.Index]Item) (map[batch.Index]string, error) {
+					myMap := make(map[batch.Index]string, len(items))
+					for i, item := range items {
+						myMap[i] = item.String
+					}
+					return myMap, nil
+				},
+			),
+		)
+	}
+	builtSchema := schema.MustBuild()
+	q := graphql.MustParse(`
+		{
+			inner {
+				innerConnectionWithFilter(filterText: "can",first: 4, after: "") {
+					totalCount
+					edges {
+						node {
+							id
+						}
+						cursor
+					}
+				}
+			}
+		}`, nil)
+	graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet)
+	exeuctor := graphql.NewExecutor(graphql.NewImmediateGoroutineScheduler())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := exeuctor.Execute(context.Background(), builtSchema.Query, nil, q)
+		require.NoError(b, err)
+	}
+
+}
+
+func BenchmarkFiltersBatched10Items(b *testing.B) {
+	pagintedQueryWithFilterBenchmark(b, 10, true)
+}
+
+func BenchmarkFiltersNotBatched10Items(b *testing.B) {
+	pagintedQueryWithFilterBenchmark(b, 10, false)
+}
+
+func BenchmarkFiltersBatched100Items(b *testing.B) {
+	pagintedQueryWithFilterBenchmark(b, 100, true)
+}
+
+func BenchmarkFiltersNotBatched100Items(b *testing.B) {
+	pagintedQueryWithFilterBenchmark(b, 100, false)
+}
+
+func BenchmarkFiltersBatched1000Items(b *testing.B) {
+	pagintedQueryWithFilterBenchmark(b, 1000, true)
+}
+
+func BenchmarkFiltersNotBatched1000Items(b *testing.B) {
+	pagintedQueryWithFilterBenchmark(b, 1000, false)
+}

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"sync"
 
+	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/internal/filter"
 	"golang.org/x/sync/errgroup"
@@ -21,6 +23,7 @@ type Connection struct {
 }
 
 var typeOfString = reflect.TypeOf("")
+var typeofMap = reflect.TypeOf(map[batch.Index]string{})
 
 // paginateManually applies the pagination arguments to the edges in memory and sets hasNextPage +
 // hasPrevPage. The behavior is expected to conform to the Relay Cursor spec:
@@ -393,39 +396,33 @@ func (c *connectionContext) pagesFromEdges(edges []Edge, limit int) (pages []str
 	return pages
 }
 
-func (c *connectionContext) applyTextFilter(ctx context.Context, nodes []interface{}, args PaginationArgs) ([]interface{}, error) {
-	if args.FilterText == nil || *args.FilterText == "" {
-		return nodes, nil
-	}
+type SafeBatchNodesToKeep struct {
+	nodesToKeep []bool
+	mux         sync.Mutex
+}
 
-	nodesToKeep := make([]bool, len(nodes))
-
+func (c *connectionContext) applyBatchTextFilter(ctx context.Context, nodes []interface{}, matchStrings []string, batchedFields map[string]*graphql.Field) ([]bool, error) {
 	g, ctx := errgroup.WithContext(ctx)
-	for unscopedI, unscopedNode := range nodes {
-		i, node := unscopedI, unscopedNode
+	nodesToKeep := make([]bool, len(nodes))
+	m := &sync.Mutex{}
+	for unscopeName, unscopedFilterField := range batchedFields {
+		name, filterField := unscopeName, unscopedFilterField
 		g.Go(func() error {
-			keep := false
-			for name, filterField := range c.FilterTextFields {
-				// Resolve the graphql.Field made for sorting.
-				text, err := filterField.Resolve(ctx, node, nil, nil)
-				if err != nil {
-					return err
-				}
-
-				// Only strings are allowed for FilterText fields.
+			texts, err := filterField.BatchResolver(ctx, nodes, nil, nil)
+			if err != nil {
+				return err
+			}
+			for i, text := range texts {
 				textString, ok := text.(string)
 				if !ok {
 					return fmt.Errorf("filter %s returned %T, must be a string", name, text)
 				}
-
-				if filter.Match(textString, *args.FilterText) {
-					keep = true
-					break
+				if filter.MatchText(textString, matchStrings) {
+					m.Lock()
+					nodesToKeep[i] = true
+					m.Unlock()
 				}
 			}
-
-			nodesToKeep[i] = keep
-
 			return nil
 		})
 	}
@@ -433,15 +430,71 @@ func (c *connectionContext) applyTextFilter(ctx context.Context, nodes []interfa
 	if err := g.Wait(); err != nil {
 		return nil, err
 	}
+	return nodesToKeep, nil
+}
 
-	var filteredNodes []interface{}
+func (c *connectionContext) applyTextFilter(ctx context.Context, nodes []interface{}, args PaginationArgs) ([]interface{}, error) {
+	if args.FilterText == nil || *args.FilterText == "" {
+		return nodes, nil
+	}
 
-	for i, keep := range nodesToKeep {
-		if keep {
-			filteredNodes = append(filteredNodes, nodes[i])
+	nodesToKeep := make([]bool, len(nodes))
+
+	filterTextFieldsNotBatched := make(map[string]*graphql.Field)
+	filterTextFieldsBatched := make(map[string]*graphql.Field)
+
+	for name, filterField := range c.FilterTextFields {
+		if filterField.Batch && filterField.UseBatchFunc(ctx) {
+			filterTextFieldsBatched[name] = filterField
+		} else {
+			filterTextFieldsNotBatched[name] = filterField
 		}
 	}
 
+	g, ctx := errgroup.WithContext(ctx)
+	matchStrings := filter.GetMatchStrings(*args.FilterText)
+	if len(filterTextFieldsNotBatched) > 0 {
+		for unscopedI, unscopedNode := range nodes {
+			i, node := unscopedI, unscopedNode
+			g.Go(func() error {
+				keep := false
+				for name, filterField := range filterTextFieldsNotBatched {
+					// Resolve the graphql.Field made for sorting.
+					text, err := filterField.Resolve(ctx, node, nil, nil)
+					if err != nil {
+						return err
+					}
+					// Only strings are allowed for FilterText fields.
+					textString, ok := text.(string)
+					if !ok {
+						return fmt.Errorf("filter %s returned %T, must be a string", name, text)
+					}
+					if filter.MatchText(textString, matchStrings) {
+						keep = true
+						break
+					}
+				}
+				nodesToKeep[i] = keep
+				return nil
+			})
+		}
+
+	}
+
+	batchedNodesToKeep, err := c.applyBatchTextFilter(ctx, nodes, matchStrings, filterTextFieldsBatched)
+
+	if err != nil {
+		return nil, err
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	var filteredNodes []interface{}
+	for i := range nodesToKeep {
+		if nodesToKeep[i] || batchedNodesToKeep[i] {
+			filteredNodes = append(filteredNodes, nodes[i])
+		}
+	}
 	return filteredNodes, nil
 }
 
@@ -702,14 +755,36 @@ func (c *connectionContext) consumeTextFilters(sb *schemaBuilder, m *method, typ
 	c.FilterTextFields = make(map[string]*graphql.Field)
 
 	for name, fn := range m.TextFilterFuncs {
-		funcTyp := getFuncReturnType(fn)
-
-		if funcTyp != typeOfString {
-			return fmt.Errorf("invalid text filter field %s: unsupported return type %v, must be a string", name, funcTyp)
+		if fn.BatchFilterFunc != nil {
+			batchFuncTyp := getFuncReturnType(fn.BatchFilterFunc)
+			if batchFuncTyp != typeofMap {
+				return fmt.Errorf("invalid text filter field %s: unsupported return type %v, must be a map[batch.Index]string", name, batchFuncTyp)
+			}
+		}
+		if fn.FilterFunc != nil {
+			funcTyp := getFuncReturnType(fn.FilterFunc)
+			if funcTyp != typeOfString {
+				return fmt.Errorf("invalid text filter field %s: unsupported return type %v, must be a string", name, funcTyp)
+			}
 		}
 
-		// Build a GraphQL field for the function.
-		field, err := sb.buildFunction(typ, &method{Fn: fn})
+		var field *graphql.Field = nil
+		var err error = nil
+
+		if fn.BatchFilterFunc != nil && fn.FilterFunc != nil {
+			field, err = sb.buildBatchFunction(typ,
+				&method{
+					Fn: fn.BatchFilterFunc,
+					BatchArgs: batchArgs{
+						FallbackFunc:          fn.FilterFunc,
+						ShouldUseFallbackFunc: fn.FallbackFlag,
+					}, Batch: true})
+		} else if fn.BatchFilterFunc != nil {
+			field, err = sb.buildBatchFunction(typ, &method{Fn: fn.BatchFilterFunc, Batch: true})
+		} else {
+			field, err = sb.buildFunction(typ, &method{Fn: fn.FilterFunc, Batch: false})
+		}
+
 		if err != nil {
 			return err
 		}
@@ -718,7 +793,6 @@ func (c *connectionContext) consumeTextFilters(sb *schemaBuilder, m *method, typ
 		}
 		c.FilterTextFields[name] = field
 	}
-
 	return nil
 }
 

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -7,30 +7,35 @@ import (
 
 var matchGroups = regexp.MustCompile(`(?:([^\s"]+)|"([^"]*)"?)+`)
 
-// Split terms by spaces, except for spaces within quotes.
-// Like http://stackoverflow.com/questions/16261635/javascript-split-string-by-space-but-ignore-space-in-quotes-notice-not-to-spli
-// except:
-// - Treat the query ["san fran] as having the single term ["san fran"] instead of ["san", "fran"]
-// - Removes the delimiting quotes.
-func Match(str, query string) bool {
+func GetMatchStrings(query string) []string {
 	if query == "" {
-		return true
+		return nil
 	}
-
 	matches := matchGroups.FindAllStringSubmatch(query, -1)
+	matchStrings := make([]string, 0, len(matches))
 	for _, match := range matches {
 		// Empty quotes can count as a match, ignore them.
 		if match[1] == "" && match[2] == "" {
+			matchStrings = append(matchStrings, "")
 			continue
 		}
-		// Get relevant match (one of these has to be a non-empty string, otherwise this wouldn't be
-		// a match).
+		// Get relevant match (one of these has to be a non-empty string, otherwise this wouldn't be a match).
 		matchString := match[1]
 		if matchString == "" {
 			matchString = match[2]
 		}
+		// matchStrings[i] = matchString
+		matchStrings = append(matchStrings, matchString)
+	}
+	return matchStrings
+}
 
-		if strings.Contains(strings.ToLower(str), strings.ToLower(matchString)) {
+func MatchText(str string, matchStrings []string) bool {
+	if len(matchStrings) == 0 {
+		return true
+	}
+	for _, matchString := range matchStrings {
+		if strings.Contains(strings.ToLower(str), strings.ToLower(matchString)) && matchString != "" {
 			return true
 		}
 	}

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -24,9 +24,10 @@ func TestMatch(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		matchStrings := filter.GetMatchStrings(tc.Query)
 		assert.Equal(t,
 			tc.Matches,
-			filter.Match(tc.String, tc.Query),
+			filter.MatchText(tc.String, matchStrings),
 			"expected Match(`%s`, `%s`) to be %v", tc.String, tc.Query, tc.Matches,
 		)
 	}


### PR DESCRIPTION
Added batch filtering and fallback methods for filtering during pagination

To run the tests, use `GOMAXPROCS=1 /Users/arshiamalkani/co/backend/opt/go1.11.5/bin/go test -benchmem -run=^$ github.com/samsarahq/thunder/graphql -bench=.`

Benchmark Test results
```
BenchmarkFiltersBatched10Items             30000             40715 ns/op           16149 B/op        247 allocs/op
BenchmarkFiltersNotBatched10Items          30000             58969 ns/op           15419 B/op        245 allocs/op
BenchmarkFiltersBatched100Items            10000            120814 ns/op           69603 B/op        930 allocs/op
BenchmarkFiltersNotBatched100Items          3000            436085 ns/op           68804 B/op       1064 allocs/op
BenchmarkFiltersBatched1000Items            2000           1114082 ns/op          752992 B/op       7599 allocs/op
BenchmarkFiltersNotBatched1000Items          300           5026686 ns/op          641897 B/op       9165 allocs/op
```