### PR TITLE
go graphql: Remove selection.UseBatch option

### DIFF
--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -168,10 +168,6 @@ func PrepareQuery(ctx context.Context, typ Type, selectionSet *SelectionSet) err
 				selection.parsed = true
 			}
 
-			if field.Batch && field.UseBatchFunc(ctx) {
-				selection.UseBatch = true
-			}
-
 			if err := PrepareQuery(ctx, field.Type, selection.SelectionSet); err != nil {
 				return err
 			}

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -181,8 +181,6 @@ type Selection struct {
 	Args         interface{}
 	SelectionSet *SelectionSet
 
-	UseBatch bool
-
 	// The parsed flag is used to make sure the args for this Selection are only
 	// parsed once.
 	parsed bool


### PR DESCRIPTION
Summary: There were some issues with passing the information about whether
to batch a function in the selection.UseBatch parameter. Sometimes it just
wouldn't get set for unknown reasons (after the UseBatch func was replaces
with an "Always on" function).  Instead of going through and finding deep
hidden meaning in go structs, this commit just changes the logic for
determining batch execution to call into the usebatchFunc function in the
execution path, and deletes the selection.UseBatch type.

In order to do this we needed to add a "useBatch" option to the WorkUnit so 
we wouldn't accidentally schedule work to be batched, then run it sequentially. 
(if the feature flag changed mid-query).