### PR TITLE
go diff: Fix long-standing diffing bug 

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -138,7 +138,7 @@ func diffMap(old map[string]interface{}, newAny interface{}) interface{} {
 	// Verify the type of new.
 	new, ok := newAny.(map[string]interface{})
 	if !ok {
-		return markReplaced(new)
+		return markReplaced(newAny)
 	}
 
 	// Check if two map are identical by comparing their pointers, and
@@ -261,7 +261,7 @@ func diffArray(old []interface{}, newAny interface{}) interface{} {
 	// Verify the type of new.
 	new, ok := newAny.([]interface{})
 	if !ok {
-		return markReplaced(new)
+		return markReplaced(newAny)
 	}
 
 	// Check if two arrays are identical by comparing their pointers and length,

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -281,3 +281,36 @@ func TestKitchenSink(t *testing.T) {
 		t.Error("bad kitchen sink")
 	}
 }
+
+func TestDiffToNil(t *testing.T) {
+	d := diff.Diff(map[string]interface{}{
+		"__key": "a",
+		"users": []interface{}{
+			map[string]interface{}{
+				"__key": "alice",
+				"age":   30,
+				"address": map[string]interface{}{
+					"__key": "10",
+					"city":  "berkeley",
+				},
+			},
+		},
+	}, map[string]interface{}{
+		"__key": "a",
+		"users": []interface{}{
+			map[string]interface{}{
+				"__key":   "alice",
+				"age":     30,
+				"address": nil,
+			},
+		},
+	})
+
+	if !reflect.DeepEqual(internal.AsJSON(d), internal.ParseJSON(`
+		{"users": {
+			"0": {"address": [null]}
+		}}
+	`)) {
+		t.Error("bad diff")
+	}
+}


### PR DESCRIPTION
Summary: Noticed and brought up by Edwin last week. This bug has existed
for a long time.  The way it would manifest, is that when a field would
get replaced with a "Nil" value in the execution graph, instead of
diffing the value and returning "nil" as the new value, we were using
the result of a failed cast `newVal, ok :=
val.(map[string]interface{})`.
The `newVal` would be an empty map (instead of the "nil" value we really
wanted).  This would lead to weird behavior, where, on an update,
instead of returning a nil value for something like current driver, we'd
return an empty object instead.