### PR TITLE
go graphql/schemabuilder: add Expensive field func option

### DIFF
--- a/graphql/batch_executor_test.go
+++ b/graphql/batch_executor_test.go
@@ -99,7 +99,7 @@ func TestNonExpensiveExecution(t *testing.T) {
 				obj := schema.Object("Object", Object{})
 				obj.FieldFunc("value", func(ctx context.Context, object *Object) *Object {
 					return object
-				})
+				}, schemabuilder.Expensive)
 				return nil
 			},
 			query: `
@@ -157,7 +157,7 @@ func TestNonExpensiveExecution(t *testing.T) {
 				obj := schema.Object("Object", Object{})
 				obj.FieldFunc("value", func(ctx context.Context, object *Object) *Object {
 					return object
-				})
+				}, schemabuilder.Expensive)
 				return nil
 			},
 			query: `

--- a/graphql/end_to_end_test.go
+++ b/graphql/end_to_end_test.go
@@ -38,7 +38,7 @@ func TestPathError(t *testing.T) {
 	inner := schema.Object("inner", Inner{})
 	inner.FieldFunc("expensive", func(ctx context.Context) Expensive {
 		return Expensive{}
-	})
+	}, schemabuilder.Expensive)
 	inner.FieldFunc("inners", func(ctx context.Context) []Inner {
 		return []Inner{Inner{}}
 	})
@@ -234,7 +234,7 @@ func TestEndToEndAwaitAndCache(t *testing.T) {
 	query := schema.Query()
 	query.FieldFunc("users", func(ctx context.Context) []*User {
 		return users
-	})
+	}, schemabuilder.Expensive)
 
 	_ = schema.Mutation()
 
@@ -243,7 +243,7 @@ func TestEndToEndAwaitAndCache(t *testing.T) {
 		reactive.AddDependency(ctx, u.resource, nil)
 		time.Sleep(100 * time.Millisecond)
 		return new(Slow)
-	})
+	}, schemabuilder.Expensive)
 
 	slow := schema.Object("Slow", Slow{})
 	slow.FieldFunc("count", func() bool {

--- a/graphql/schemabuilder/batch.go
+++ b/graphql/schemabuilder/batch.go
@@ -123,7 +123,7 @@ func (sb *schemaBuilder) buildBatchFunctionAndFuncCtx(typ reflect.Type, m *metho
 		Args:           args,
 		Type:           retType,
 		ParseArguments: argParser.Parse,
-		Expensive:      funcCtx.hasContext,
+		Expensive:      m.Expensive,
 	}, funcCtx, nil
 }
 

--- a/graphql/schemabuilder/function.go
+++ b/graphql/schemabuilder/function.go
@@ -75,7 +75,7 @@ func (sb *schemaBuilder) buildFunctionAndFuncCtx(typ reflect.Type, m *method) (*
 		Args:           args,
 		Type:           retType,
 		ParseArguments: argParser.Parse,
-		Expensive:      funcCtx.hasContext,
+		Expensive:      m.Expensive,
 		External:       true,
 	}, funcCtx, nil
 }

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -980,7 +980,7 @@ func (sb *schemaBuilder) buildPaginatedField(typ reflect.Type, m *method) (*grap
 		Args:           args,
 		Type:           retType,
 		ParseArguments: argParser.Parse,
-		Expensive:      c.hasContext,
+		Expensive:      m.Expensive,
 		External:       true,
 	}
 

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/internal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type alias int64
@@ -194,6 +195,69 @@ func TestExecuteGood(t *testing.T) {
 		"weirdKey": {"key": -1, "__key": -1}
 		}`)) {
 		t.Error("bad value")
+	}
+}
+
+func TestExpensiveField(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		hasContext           bool
+		hasExpensiveOption   bool
+		expectExpensive      bool
+	}{
+		{
+			name:                 "no context, no expensive option",
+			hasContext:           false,
+			hasExpensiveOption:   false,
+			expectExpensive:      false,
+		},
+		{
+			name:                 "no context, expensive option",
+			hasContext:           false,
+			hasExpensiveOption:   true,
+			expectExpensive:      true,
+		},
+		{
+			name:                 "has context, no expensive option",
+			hasContext:           true,
+			hasExpensiveOption:   false,
+			expectExpensive:      false,
+		},
+		{
+			name:                 "has context and expensive option",
+			hasContext:           true,
+			hasExpensiveOption: true,
+			expectExpensive:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema := NewSchema()
+			query := schema.Query()
+
+			var options []FieldFuncOption
+			if tc.hasExpensiveOption {
+				options = append(options, Expensive)
+			}
+
+			if tc.hasContext {
+				testFieldFunc := func(context.Context) int { return 0 }
+				query.FieldFunc("testField", testFieldFunc, options...)
+			} else {
+				testFieldFunc := func() int { return 0 }
+				query.FieldFunc("testField", testFieldFunc, options...)
+			}
+
+			_ = schema.Mutation()
+
+			builtSchema := schema.MustBuild()
+			builtObject, ok := (builtSchema.Query).(*graphql.Object)
+			require.True(t, ok)
+
+			builtField := builtObject.Fields["testField"]
+			assert.Equal(t, tc.expectExpensive, builtField.Expensive)
+		})
 	}
 }
 

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -44,6 +44,12 @@ var Paginated fieldFuncOptionFunc = func(m *method) {
 	m.Paginated = true
 }
 
+// Expensive is an option that can be passed to a FieldFunc to indicate that
+// the function is expensive to execute, so it should be parallelized.
+var Expensive fieldFuncOptionFunc = func(m *method) {
+	m.Expensive = true
+}
+
 type Filter struct {
 	Name            string
 	FilterFunc      interface{}
@@ -204,6 +210,9 @@ type method struct {
 
 	// Whether or not the FieldFunc is paginated.
 	Paginated bool
+
+	// Whether or not the FieldFunc has been marked as expensive.
+	Expensive bool
 
 	// Text filter methods
 	TextFilterFuncs map[string]Filter


### PR DESCRIPTION
Add a field func option to mark a field func as "expensive".

Previously, Thunder would assume that any field func accepting a "context" parameter must be expensive and so should be executed concurrently.

The new behavior is to assume that a field func is inexpensive unless the Expensive option is set explicitly.