### PR TITLE
FilterTextOptions to Select Filters

### DIFF
--- a/graphql/connection_test.go
+++ b/graphql/connection_test.go
@@ -280,7 +280,7 @@ func TestConnection(t *testing.T) {
 
 	snap.SnapshotQuery("Pagination, filter", `{
 		inner {
-			filterByCan: innerConnectionWithFilter(filterText: "can", first: 5, after: "") {
+			filterByCan: innerConnectionWithFilter(filterText: "can", filterTextFields: ["foo","wug"], first: 5, after: "") {
 				totalCount
 				edges {
 					node {

--- a/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
+++ b/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
@@ -439,6 +439,24 @@
                     {
                       "defaultValue": null,
                       "description": "",
+                      "name": "filterTextFields",
+                      "type": {
+                        "kind": "LIST",
+                        "name": "",
+                        "ofType": {
+                          "kind": "NON_NULL",
+                          "name": "",
+                          "ofType": {
+                            "kind": "SCALAR",
+                            "name": "string",
+                            "ofType": null
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "defaultValue": null,
+                      "description": "",
                       "name": "first",
                       "type": {
                         "kind": "SCALAR",
@@ -521,6 +539,24 @@
                         "kind": "SCALAR",
                         "name": "string",
                         "ofType": null
+                      }
+                    },
+                    {
+                      "defaultValue": null,
+                      "description": "",
+                      "name": "filterTextFields",
+                      "type": {
+                        "kind": "LIST",
+                        "name": "",
+                        "ofType": {
+                          "kind": "NON_NULL",
+                          "name": "",
+                          "ofType": {
+                            "kind": "SCALAR",
+                            "name": "string",
+                            "ofType": null
+                          }
+                        }
                       }
                     },
                     {


### PR DESCRIPTION
FilterText allows us to query specific fields when we make paginated requests. However, we run the filterText against all the filters. FilterTextOptions allow us to specify which filters to run it against. The api now would look something like

```
filterByCan: innerConnectionWithFilter(filterText: "can", filterTextField:["foo","wug"],first: 5, after: "") 
```