### PR TITLE
Batching Paginated Sorts

### DIFF
--- a/graphql/benchmark_pagination_test.go
+++ b/graphql/benchmark_pagination_test.go
@@ -141,3 +141,137 @@ func BenchmarkFiltersNotBatched1000Items(b *testing.B) {
 func BenchmarkFiltersNotBatched1000ItemsExpensive(b *testing.B) {
 	pagintedQueryWithFilterBenchmark(b, 1000, false, true)
 }
+
+func pagintedQueryWithSortBenchmark(b *testing.B, n int, batchFunc bool, expensive bool) {
+	schema := schemabuilder.NewSchema()
+	type Inner struct {
+	}
+	query := schema.Query()
+	query.FieldFunc("inner", func() Inner {
+		return Inner{}
+	})
+	inner := schema.Object("inner", Inner{})
+	item := schema.Object("item", Item{})
+	item.Key("id")
+	filterTexts := [5]string{"can", "man", "cannot", "soban", "socan"}
+	items := make([]Item, n, n)
+	for i := 0; i < n; i++ {
+		items[i] = Item{Id: int64(i), FilterText: filterTexts[i%5], String: "a"}
+	}
+	if !batchFunc {
+		if expensive {
+			inner.FieldFunc("innerConnectionWithFilter", func() []Item {
+				return items
+			}, schemabuilder.Paginated,
+				schemabuilder.SortField("foo",
+					func(ctx context.Context, i Item) string {
+						return i.FilterText
+					},
+				),
+				schemabuilder.SortField("bar",
+					func(ctx context.Context, i Item) string {
+						return i.String
+					},
+				),
+			)
+		} else {
+			inner.FieldFunc("innerConnectionWithFilter", func() []Item {
+				return items
+			}, schemabuilder.Paginated,
+				schemabuilder.SortField("foo",
+					func(i Item) string {
+						return i.FilterText
+					},
+				),
+				schemabuilder.SortField("bar",
+					func(i Item) string {
+						return i.String
+					},
+				),
+			)
+		}
+
+	} else {
+		inner.FieldFunc("innerConnectionWithFilter", func() []Item {
+			return items
+		}, schemabuilder.Paginated,
+			schemabuilder.BatchSortField("foo",
+				func(ctx context.Context, items map[batch.Index]Item) (map[batch.Index]string, error) {
+					myMap := make(map[batch.Index]string, len(items))
+					for i, item := range items {
+						myMap[i] = item.FilterText
+					}
+					return myMap, nil
+				},
+			),
+			schemabuilder.BatchSortField("bar",
+				func(ctx context.Context, items map[batch.Index]Item) (map[batch.Index]string, error) {
+					myMap := make(map[batch.Index]string, len(items))
+					for i, item := range items {
+						myMap[i] = item.String
+					}
+					return myMap, nil
+				},
+			),
+		)
+	}
+	builtSchema := schema.MustBuild()
+	q := graphql.MustParse(`
+		{
+			inner {
+				innerConnectionWithFilter(sortBy: "foo",first: 4, after: "") {
+					totalCount
+					edges {
+						node {
+							id
+						}
+						cursor
+					}
+				}
+			}
+		}`, nil)
+	graphql.PrepareQuery(context.Background(), builtSchema.Query, q.SelectionSet)
+	exeuctor := graphql.NewExecutor(graphql.NewImmediateGoroutineScheduler())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := exeuctor.Execute(context.Background(), builtSchema.Query, nil, q)
+		require.NoError(b, err)
+	}
+
+}
+
+func BenchmarkSortsBatched10Items(b *testing.B) {
+	pagintedQueryWithFilterBenchmark(b, 10, true, false)
+}
+
+func BenchmarkSortsNotBatched10Items(b *testing.B) {
+	pagintedQueryWithSortBenchmark(b, 10, false, false)
+}
+
+func BenchmarkSortsNotBatchedExpensive10Items(b *testing.B) {
+	pagintedQueryWithSortBenchmark(b, 10, false, true)
+}
+
+func BenchmarkSortsBatched100Items(b *testing.B) {
+	pagintedQueryWithSortBenchmark(b, 100, true, false)
+}
+
+func BenchmarkSortsNotBatched100Items(b *testing.B) {
+	pagintedQueryWithSortBenchmark(b, 100, false, false)
+}
+
+func BenchmarkSortsNotBatchedExpensive100Items(b *testing.B) {
+	pagintedQueryWithSortBenchmark(b, 100, false, true)
+}
+
+func BenchmarkSortsBatched1000Items(b *testing.B) {
+	pagintedQueryWithSortBenchmark(b, 1000, true, false)
+}
+
+func BenchmarkSortsNotBatched1000Items(b *testing.B) {
+	pagintedQueryWithSortBenchmark(b, 1000, false, false)
+}
+
+func BenchmarkSortsNotBatchedExpensive1000Items(b *testing.B) {
+	pagintedQueryWithSortBenchmark(b, 1000, false, true)
+}


### PR DESCRIPTION
Batches the paginated sorts by 
(1) Run the paginated sorts batched
(2) Run the paginated sorts not batched and executed serially, which is useful if we aren't making expensive operations
(3) Run the  paginated sorts not batched but with an expensive flag to spawn a goroutine per node. It detects if it is expensive if it has a ctx passed in. 

 
```
BenchmarkSortsBatched10Items                       50000             39933 ns/op           15834 B/op        246 allocs/op
BenchmarkSortsNotBatched10Items                    50000             29063 ns/op           12065 B/op        213 allocs/op
BenchmarkSortsNotBatchedExpensive10Items           50000             34620 ns/op           12385 B/op        213 allocs/op
BenchmarkSortsBatched100Items                      10000            116631 ns/op           54667 B/op        852 allocs/op
BenchmarkSortsNotBatched100Items                   10000            114231 ns/op           47156 B/op        939 allocs/op
BenchmarkSortsNotBatchedExpensive100Items          10000            161803 ns/op           50356 B/op        939 allocs/op
BenchmarkSortsBatched1000Items                      2000           1064689 ns/op          505393 B/op       7156 allocs/op
BenchmarkSortsNotBatched1000Items                   2000           1119087 ns/op          379250 B/op       8145 allocs/op
BenchmarkSortsNotBatchedExpensive1000Items          1000           1555780 ns/op          411252 B/op       8145 allocs/op
```

For reference when looking at the stats, the BenchmarkSortsNotBatchedExpensive numbers show the how long it use to take. Ideally everything will move to BenchmarkSortsBatched or BenchmarkSortsNotBatched and BenchmarkSortsNotBatchedExpensive will be deprecated