### PR TITLE
Error Handling for Batched Pagination Filters

### DIFF
--- a/graphql/batch_executor.go
+++ b/graphql/batch_executor.go
@@ -129,7 +129,7 @@ func executeWorkUnit(unit *WorkUnit) []*WorkUnit {
 }
 
 func executeBatchWorkUnit(unit *WorkUnit) []*WorkUnit {
-	results, err := safeExecuteBatchResolver(unit.ctx, unit.field, unit.sources, unit.selection.Args, unit.selection.SelectionSet)
+	results, err := SafeExecuteBatchResolver(unit.ctx, unit.field, unit.sources, unit.selection.Args, unit.selection.SelectionSet)
 	if err != nil {
 		for _, dest := range unit.destinations {
 			dest.Fail(err)
@@ -149,7 +149,7 @@ func executeBatchWorkUnit(unit *WorkUnit) []*WorkUnit {
 func executeNonExpensiveWorkUnit(unit *WorkUnit) []*WorkUnit {
 	results := make([]interface{}, 0, len(unit.sources))
 	for idx, src := range unit.sources {
-		fieldResult, err := safeExecuteResolver(unit.ctx, unit.field, src, unit.selection.Args, unit.selection.SelectionSet)
+		fieldResult, err := SafeExecuteResolver(unit.ctx, unit.field, src, unit.selection.Args, unit.selection.SelectionSet)
 		if err != nil {
 			// Fail the unit and exit.
 			unit.destinations[idx].Fail(err)
@@ -204,7 +204,7 @@ func getWorkCacheKey(src interface{}, field *Field, selection *Selection) resolv
 
 // executeNonBatchWorkUnit resolves a non-batch field in our graphql response graph.
 func executeNonBatchWorkUnit(ctx context.Context, src interface{}, dest *outputNode, unit *WorkUnit) []*WorkUnit {
-	fieldResult, err := safeExecuteResolver(ctx, unit.field, src, unit.selection.Args, unit.selection.SelectionSet)
+	fieldResult, err := SafeExecuteResolver(ctx, unit.field, src, unit.selection.Args, unit.selection.SelectionSet)
 	if err != nil {
 		dest.Fail(err)
 		return nil

--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -190,7 +190,7 @@ func PrepareQuery(ctx context.Context, typ Type, selectionSet *SelectionSet) err
 	}
 }
 
-func safeExecuteBatchResolver(ctx context.Context, field *Field, sources []interface{}, args interface{}, selectionSet *SelectionSet) (results []interface{}, err error) {
+func SafeExecuteBatchResolver(ctx context.Context, field *Field, sources []interface{}, args interface{}, selectionSet *SelectionSet) (results []interface{}, err error) {
 	defer func() {
 		if panicErr := recover(); panicErr != nil {
 			const size = 64 << 10
@@ -202,7 +202,7 @@ func safeExecuteBatchResolver(ctx context.Context, field *Field, sources []inter
 	return field.BatchResolver(ctx, sources, args, selectionSet)
 }
 
-func safeExecuteResolver(ctx context.Context, field *Field, source, args interface{}, selectionSet *SelectionSet) (result interface{}, err error) {
+func SafeExecuteResolver(ctx context.Context, field *Field, source, args interface{}, selectionSet *SelectionSet) (result interface{}, err error) {
 	defer func() {
 		if panicErr := recover(); panicErr != nil {
 			const size = 64 << 10

--- a/graphql/schemabuilder/batch.go
+++ b/graphql/schemabuilder/batch.go
@@ -20,7 +20,6 @@ func (sb *schemaBuilder) buildBatchFunctionWithFallback(typ reflect.Type, m *met
 	if err != nil {
 		return nil, err
 	}
-
 	if fallbackFuncCtx.hasContext != batchFuncCtx.hasContext ||
 		!fallbackFuncCtx.hasSource || // Batch func always has a source.
 		fallbackFuncCtx.hasArgs != batchFuncCtx.hasArgs ||
@@ -29,6 +28,7 @@ func (sb *schemaBuilder) buildBatchFunctionWithFallback(typ reflect.Type, m *met
 		fallbackFuncCtx.hasRet != batchFuncCtx.hasRet {
 		return nil, fmt.Errorf("batch and fallback function signatures did not match")
 	}
+
 	if fallbackField.Type.String() != batchField.Type.String() {
 		return nil, fmt.Errorf("batch and fallback graphql return types did not match: Batch(%v) Fallback(%v)", batchField.Type, fallbackField.Type)
 	}

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -49,12 +49,14 @@ type Filter struct {
 	FilterFunc      interface{}
 	BatchFilterFunc interface{}
 	FallbackFlag    func(context.Context) bool
+	Options         []FieldFuncOption
 }
 
-func FilterField(name string, filter interface{}) FieldFuncOption {
+func FilterField(name string, filter interface{}, options ...FieldFuncOption) FieldFuncOption {
 	var filterStruct = Filter{
 		Name:       name,
 		FilterFunc: filter,
+		Options:    options,
 	}
 	var fieldFuncTextFilterFields fieldFuncOptionFunc = func(m *method) {
 		if m.TextFilterFuncs == nil {
@@ -68,10 +70,11 @@ func FilterField(name string, filter interface{}) FieldFuncOption {
 	return fieldFuncTextFilterFields
 }
 
-func BatchFilterField(name string, batchFilter interface{}) FieldFuncOption {
+func BatchFilterField(name string, batchFilter interface{}, options ...FieldFuncOption) FieldFuncOption {
 	var filterStruct = Filter{
 		Name:            name,
 		BatchFilterFunc: batchFilter,
+		Options:         options,
 	}
 	var fieldFuncTextFilterFields fieldFuncOptionFunc = func(m *method) {
 		if m.TextFilterFuncs == nil {
@@ -85,12 +88,13 @@ func BatchFilterField(name string, batchFilter interface{}) FieldFuncOption {
 	return fieldFuncTextFilterFields
 }
 
-func BatchFilterFieldWithFallback(name string, batchFilter interface{}, filter interface{}, flag func(context.Context) bool) FieldFuncOption {
+func BatchFilterFieldWithFallback(name string, batchFilter interface{}, filter interface{}, flag func(context.Context) bool, options ...FieldFuncOption) FieldFuncOption {
 	var filterStruct = Filter{
 		Name:            name,
 		FilterFunc:      filter,
 		BatchFilterFunc: batchFilter,
 		FallbackFlag:    flag,
+		Options:         options,
 	}
 	var fieldFuncTextFilterFields fieldFuncOptionFunc = func(m *method) {
 		if m.TextFilterFuncs == nil {


### PR DESCRIPTION
(1) Builds the batch function with fallbacks correctly for paginated filters. This also means setting it to be nonullable in all cases
(2) Uses the SafeExecuteBatchResolver and SafeExecuteResolver for pagination to handle panics better 
(3) Allows you to pass in optional arguments for options when working on a filter. This is useful for the BatchFilterFieldWithFallback where you can set it to Expensive