### PR TITLE
Work Scheduler for pagination

### DIFF
--- a/graphql/batch_executor_test.go
+++ b/graphql/batch_executor_test.go
@@ -275,15 +275,16 @@ func TestNonExpensiveExecution(t *testing.T) {
 }
 
 type counterGoroutineScheduler struct {
-	wg sync.WaitGroup
-
+	wg    sync.WaitGroup
 	count int64
 }
 
 func (q *counterGoroutineScheduler) Run(resolver graphql.UnitResolver, initialUnits ...*graphql.WorkUnit) {
 	q.runEnqueue(resolver, initialUnits...)
-
 	q.wg.Wait()
+}
+
+func (q *counterGoroutineScheduler) RunAll(ctx context.Context, executionUnits []*graphql.ExecutionUnit) {
 }
 
 func (q *counterGoroutineScheduler) runEnqueue(resolver graphql.UnitResolver, units ...*graphql.WorkUnit) {

--- a/graphql/batch_scheduler.go
+++ b/graphql/batch_scheduler.go
@@ -1,7 +1,9 @@
 package graphql
 
 import (
+	"context"
 	"sync"
+	"sync/atomic"
 )
 
 // NewImmediateGoroutineScheduler creates a new batch execution scheduler that
@@ -10,13 +12,31 @@ func NewImmediateGoroutineScheduler() WorkScheduler {
 	return &immediateGoroutineScheduler{}
 }
 
-type immediateGoroutineScheduler struct{}
+type immediateGoroutineScheduler struct {
+	wg    sync.WaitGroup
+	count int64
+}
 
 func (q *immediateGoroutineScheduler) Run(resolver UnitResolver, initialUnits ...*WorkUnit) {
 	r := &immediateGoroutineSchedulerRunner{}
 	r.runEnqueue(resolver, initialUnits...)
-
 	r.wg.Wait()
+}
+
+func (q *immediateGoroutineScheduler) RunAll(ctx context.Context, executionUnits []*ExecutionUnit) {
+	q.runEnqueue(executionUnits)
+	q.wg.Wait()
+}
+
+func (q *immediateGoroutineScheduler) runEnqueue(executionUnits []*ExecutionUnit) {
+	atomic.AddInt64(&q.count, int64(len(executionUnits)))
+	for _, unit := range executionUnits {
+		q.wg.Add(1)
+		go func(u *ExecutionUnit) {
+			defer q.wg.Done()
+			u.ExeucteFunction(u.Context)
+		}(unit)
+	}
 }
 
 type immediateGoroutineSchedulerRunner struct {


### PR DESCRIPTION
All goroutines spawned by filters and sorts now use the work scheduler, which allows us to track the goroutines spawned. This also exposes the context, which can be used for xray traces. 