### PR TITLE
go schemabuilder: Make expensive option a noop

### DIFF
--- a/graphql/schemabuilder/batch.go
+++ b/graphql/schemabuilder/batch.go
@@ -123,7 +123,7 @@ func (sb *schemaBuilder) buildBatchFunctionAndFuncCtx(typ reflect.Type, m *metho
 		Args:           args,
 		Type:           retType,
 		ParseArguments: argParser.Parse,
-		Expensive:      m.Expensive,
+		Expensive:      funcCtx.hasContext,
 	}, funcCtx, nil
 }
 

--- a/graphql/schemabuilder/function.go
+++ b/graphql/schemabuilder/function.go
@@ -75,7 +75,7 @@ func (sb *schemaBuilder) buildFunctionAndFuncCtx(typ reflect.Type, m *method) (*
 		Args:           args,
 		Type:           retType,
 		ParseArguments: argParser.Parse,
-		Expensive:      m.Expensive,
+		Expensive:      funcCtx.hasContext,
 		External:       true,
 	}, funcCtx, nil
 }

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -1099,7 +1099,7 @@ func (sb *schemaBuilder) buildPaginatedField(typ reflect.Type, m *method) (*grap
 		Args:           args,
 		Type:           retType,
 		ParseArguments: argParser.Parse,
-		Expensive:      m.Expensive,
+		Expensive:      c.hasContext,
 		External:       true,
 	}
 

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -199,6 +199,7 @@ func TestExecuteGood(t *testing.T) {
 }
 
 func TestExpensiveField(t *testing.T) {
+	t.Skip()
 	testCases := []struct {
 		name               string
 		hasContext         bool


### PR DESCRIPTION
Summary: We think this caused some issues (we just had an outage that's hard to pinpoint, this change is the most suspicious), we're making it a noop for now while we investigate further.