### PR TITLE
Revert "go schemabuilder: Make expensive option a noop"

### DIFF
--- a/graphql/schemabuilder/batch.go
+++ b/graphql/schemabuilder/batch.go
@@ -127,7 +127,7 @@ func (sb *schemaBuilder) buildBatchFunctionAndFuncCtx(typ reflect.Type, m *metho
 		Args:           args,
 		Type:           retType,
 		ParseArguments: argParser.Parse,
-		Expensive:      funcCtx.hasContext,
+		Expensive:      m.Expensive,
 	}, funcCtx, nil
 }
 

--- a/graphql/schemabuilder/function.go
+++ b/graphql/schemabuilder/function.go
@@ -75,7 +75,7 @@ func (sb *schemaBuilder) buildFunctionAndFuncCtx(typ reflect.Type, m *method) (*
 		Args:           args,
 		Type:           retType,
 		ParseArguments: argParser.Parse,
-		Expensive:      funcCtx.hasContext,
+		Expensive:      m.Expensive,
 		External:       true,
 	}, funcCtx, nil
 }

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -1099,7 +1099,7 @@ func (sb *schemaBuilder) buildPaginatedField(typ reflect.Type, m *method) (*grap
 		Args:           args,
 		Type:           retType,
 		ParseArguments: argParser.Parse,
-		Expensive:      c.hasContext,
+		Expensive:      m.Expensive,
 		External:       true,
 	}
 

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -199,7 +199,6 @@ func TestExecuteGood(t *testing.T) {
 }
 
 func TestExpensiveField(t *testing.T) {
-	t.Skip()
 	testCases := []struct {
 		name               string
 		hasContext         bool


### PR DESCRIPTION
This reverts commit 34dfd659753f186b319821cc0669f51a3e513bcc.

I believe all the field funcs are now marked with the
Expensive option, so we can re-enable this functionality.