### PR TITLE
Manual Pagination With Fallback

### DIFF
--- a/graphql/connection_test.go
+++ b/graphql/connection_test.go
@@ -28,6 +28,11 @@ type Args struct {
 	Additional string
 }
 
+type ManualArgs struct {
+	Additional     string
+	PaginationArgs schemabuilder.PaginationArgs
+}
+
 type Item struct {
 	Id         int64
 	FilterText string
@@ -1254,4 +1259,136 @@ func TestPaginatedSorts(t *testing.T) {
 			},
 		}, internal.AsJSON(val))
 	}
+}
+
+func TestConnectionManual(t *testing.T) {
+	schema := schemabuilder.NewSchema()
+	type Inner struct {
+	}
+
+	query := schema.Query()
+	query.FieldFunc("inner", func() Inner {
+		return Inner{}
+	})
+
+	inner := schema.Object("inner", Inner{})
+	item := schema.Object("item", Item{})
+	item.Key("id")
+
+	inner.FieldFunc("innerConnectionWithCtxAndError", func(ctx context.Context, args Args) ([]Item, error) {
+		return []Item{{Id: 1}, {Id: 2}, {Id: 3}, {Id: 4}, {Id: 5}}, nil
+	}, schemabuilder.Paginated)
+
+	inner.FieldFunc("innerConnectionWithCtxAndErrorManual", func(ctx context.Context, args ManualArgs) ([]Item, schemabuilder.PaginationInfo, error) {
+		var info schemabuilder.PaginationInfo
+		info.TotalCountFunc = func() int64 { return 5 }
+		info.HasNextPage = true
+		info.HasPrevPage = false
+		return []Item{{Id: 1}, {Id: 2}, {Id: 3}}, info, nil
+	}, schemabuilder.Paginated)
+
+	shouldUseFallback := true
+	inner.ManualPaginationWithFallback("innerConnectionWithCtxAndErrorManualAndFallback",
+		func(ctx context.Context, args ManualArgs) ([]Item, schemabuilder.PaginationInfo, error) {
+			var info schemabuilder.PaginationInfo
+			info.TotalCountFunc = func() int64 { return 5 }
+			info.HasNextPage = true
+			info.HasPrevPage = false
+			return []Item{{Id: 1}, {Id: 2}, {Id: 3}}, info, nil
+		},
+		func(ctx context.Context, args Args) ([]Item, error) {
+			return []Item{{Id: 1}, {Id: 2}, {Id: 3}, {Id: 4}, {Id: 5}}, nil
+		},
+		func(ctx context.Context) bool {
+			return shouldUseFallback
+		},
+		schemabuilder.Paginated)
+
+	builtSchema := schema.MustBuild()
+
+	snap := testgraphql.NewSnapshotter(t, builtSchema)
+	defer snap.Verify()
+
+	snap.SnapshotQuery("Pagination, with ctx and error", `{
+		inner {
+			innerConnectionWithCtxAndError(first: 3, after: "", additional: "jk") {
+				totalCount
+				edges {
+					node {
+						id
+					}
+					cursor
+				}
+				pageInfo {
+					hasNextPage
+					hasPrevPage
+					startCursor
+					endCursor
+				}
+			}
+		}
+	}`)
+
+	snap.SnapshotQuery("Pagination, with ctx and error manual", `{
+		inner {
+			innerConnectionWithCtxAndErrorManual(first: 3, after: "", additional: "jk") {
+				totalCount
+				edges {
+					node {
+						id
+					}
+					cursor
+				}
+				pageInfo {
+					hasNextPage
+					hasPrevPage
+					startCursor
+					endCursor
+				}
+			}
+		}
+	}`)
+
+	shouldUseFallback = true
+	snap.SnapshotQuery("Pagination, uses manual pagination instead of fallback", `{
+		inner {
+			innerConnectionWithCtxAndErrorManualAndFallback(first: 3, after: "", additional: "jk") {
+				totalCount
+				edges {
+					node {
+						id
+					}
+					cursor
+				}
+				pageInfo {
+					hasNextPage
+					hasPrevPage
+					startCursor
+					endCursor
+				}
+			}
+		}
+	}`)
+
+	shouldUseFallback = false
+	snap.SnapshotQuery("Pagination, uses fallback method", `{
+		inner {
+			innerConnectionWithCtxAndErrorManualAndFallback(first: 3, after: "", additional: "jk") {
+				totalCount
+				edges {
+					node {
+						id
+					}
+					cursor
+				}
+				pageInfo {
+					hasNextPage
+					hasPrevPage
+					startCursor
+					endCursor
+				}
+			}
+		}
+	}`)
+
 }

--- a/graphql/schemabuilder/input.go
+++ b/graphql/schemabuilder/input.go
@@ -12,6 +12,31 @@ import (
 	"github.com/samsarahq/thunder/internal"
 )
 
+type dualArgParser struct {
+	argParser         func(interface{}) (interface{}, error)
+	fallbackArgParser func(interface{}) (interface{}, error)
+}
+
+type dualArgResponses struct {
+	argValue         interface{}
+	fallbackArgValue interface{}
+}
+
+func (p *dualArgParser) Parse(args interface{}) (interface{}, error) {
+	v1, err := p.argParser(args)
+	if err != nil {
+		return nil, err
+	}
+	v2, err := p.fallbackArgParser(args)
+	if err != nil {
+		return nil, err
+	}
+	return dualArgResponses{
+		argValue:         v1,
+		fallbackArgValue: v2,
+	}, nil
+}
+
 // argField is a representation of an input parameter field for a function.  It
 // must be a field on a struct and will have an associated "argParser" for
 // reading an input JSON and filling the struct field.

--- a/graphql/schemabuilder/output.go
+++ b/graphql/schemabuilder/output.go
@@ -108,6 +108,14 @@ func (sb *schemaBuilder) buildStruct(typ reflect.Type) error {
 		}
 
 		if method.Paginated {
+			if method.ManualPaginationArgs.FallbackFunc != nil {
+				typedField, err := sb.buildPaginatedFieldWithFallback(typ, method)
+				if err != nil {
+					return err
+				}
+				object.Fields[name] = typedField
+				continue
+			}
 			typedField, err := sb.buildPaginatedField(typ, method)
 			if err != nil {
 				return err

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -1035,7 +1035,7 @@ func (sb *schemaBuilder) buildPaginatedFieldWithFallback(typ reflect.Type, m *me
 		return nil, err
 	}
 
-	// Validate that function signatures batch between the manually paginated version and fallback version
+	// Validate that function signatures the manually paginated version and fallback version
 	if fallbackFuncCtx.hasContext != manualPaginationFuncCtx.hasContext ||
 		fallbackFuncCtx.hasArgs != manualPaginationFuncCtx.hasArgs ||
 		fallbackFuncCtx.hasSelectionSet != manualPaginationFuncCtx.hasSelectionSet ||
@@ -1048,7 +1048,7 @@ func (sb *schemaBuilder) buildPaginatedFieldWithFallback(typ reflect.Type, m *me
 		return nil, fmt.Errorf("manual pagination and fallback graphql return types did not match: ManualPagination(%v) Fallback(%v)", manualPaginationField.Type, fallbackField.Type)
 	}
 
-	if len(fallbackField.Args) != (len(manualPaginationField.Args)) {
+	if len(fallbackField.Args) != len(manualPaginationField.Args) {
 		return nil, fmt.Errorf("manual pagination and fallback arg type did not match: ManualPagination(%v) Fallback(%v)", manualPaginationField.Args, fallbackField.Args)
 	}
 

--- a/graphql/testdata/TestConnectionManual.snapshots.json
+++ b/graphql/testdata/TestConnectionManual.snapshots.json
@@ -1,0 +1,166 @@
+[
+  {
+    "Name": "batchExecutor:Pagination, with ctx and error",
+    "Values": [
+      {
+        "inner": {
+          "innerConnectionWithCtxAndError": {
+            "edges": [
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "id": 1
+                }
+              },
+              {
+                "cursor": "Mg==",
+                "node": {
+                  "__key": 2,
+                  "id": 2
+                }
+              },
+              {
+                "cursor": "Mw==",
+                "node": {
+                  "__key": 3,
+                  "id": 3
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "Mw==",
+              "hasNextPage": true,
+              "hasPrevPage": false,
+              "startCursor": "MQ=="
+            },
+            "totalCount": 5
+          }
+        }
+      }
+    ]
+  },
+  {
+    "Name": "batchExecutor:Pagination, with ctx and error manual",
+    "Values": [
+      {
+        "inner": {
+          "innerConnectionWithCtxAndErrorManual": {
+            "edges": [
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "id": 1
+                }
+              },
+              {
+                "cursor": "Mg==",
+                "node": {
+                  "__key": 2,
+                  "id": 2
+                }
+              },
+              {
+                "cursor": "Mw==",
+                "node": {
+                  "__key": 3,
+                  "id": 3
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "Mw==",
+              "hasNextPage": true,
+              "hasPrevPage": false,
+              "startCursor": "MQ=="
+            },
+            "totalCount": 5
+          }
+        }
+      }
+    ]
+  },
+  {
+    "Name": "batchExecutor:Pagination, uses manual pagination instead of fallback",
+    "Values": [
+      {
+        "inner": {
+          "innerConnectionWithCtxAndErrorManualAndFallback": {
+            "edges": [
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "id": 1
+                }
+              },
+              {
+                "cursor": "Mg==",
+                "node": {
+                  "__key": 2,
+                  "id": 2
+                }
+              },
+              {
+                "cursor": "Mw==",
+                "node": {
+                  "__key": 3,
+                  "id": 3
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "Mw==",
+              "hasNextPage": true,
+              "hasPrevPage": false,
+              "startCursor": "MQ=="
+            },
+            "totalCount": 5
+          }
+        }
+      }
+    ]
+  },
+  {
+    "Name": "batchExecutor:Pagination, uses fallback method",
+    "Values": [
+      {
+        "inner": {
+          "innerConnectionWithCtxAndErrorManualAndFallback": {
+            "edges": [
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "id": 1
+                }
+              },
+              {
+                "cursor": "Mg==",
+                "node": {
+                  "__key": 2,
+                  "id": 2
+                }
+              },
+              {
+                "cursor": "Mw==",
+                "node": {
+                  "__key": 3,
+                  "id": 3
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "Mw==",
+              "hasNextPage": true,
+              "hasPrevPage": false,
+              "startCursor": "MQ=="
+            },
+            "totalCount": 5
+          }
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
For the Fast Pagination Indices project, we want to use manual pagination such that the index reader service can handle the pagination logic and only return the data going to be displayed. As endpoints get moved over to the indexing solution, we want a nice way to feature flag them. This means that we want to register both the field func (that uses indices and is manually paginated) and the fallback, which requires a thunder change. 

RFC reference
https://paper.dropbox.com/doc/RFC-Pagination-Indices--Ajk_EnByDy_fw8S6SrVjgxhAAg-E948ZaMsM7Ls6ZAWtpT5e
