### PR TITLE
Anubhav/fix stuff

### DIFF
--- a/graphql/schemabuilder/build.go
+++ b/graphql/schemabuilder/build.go
@@ -15,6 +15,7 @@ import (
 // are stored in the type map which we can use to see sections of the graph.
 type schemaBuilder struct {
 	types        map[reflect.Type]graphql.Type
+	typeNames    map[string]reflect.Type
 	objects      map[reflect.Type]*Object
 	enumMappings map[reflect.Type]*EnumMapping
 	typeCache    map[reflect.Type]cachedType // typeCache maps Go types to GraphQL datatypes

--- a/graphql/schemabuilder/output.go
+++ b/graphql/schemabuilder/output.go
@@ -42,6 +42,9 @@ func (sb *schemaBuilder) buildStruct(typ reflect.Type) error {
 		if name == "" {
 			return fmt.Errorf("bad type %s: should have a name", typ)
 		}
+		if originalType, ok := sb.typeNames[name]; ok {
+			return fmt.Errorf("duplicate name %s: seen both %v and %v", name, originalType, typ)
+		}
 	}
 
 	object := &graphql.Object{
@@ -50,6 +53,7 @@ func (sb *schemaBuilder) buildStruct(typ reflect.Type) error {
 		Fields:      make(map[string]*graphql.Field),
 	}
 	sb.types[typ] = object
+	sb.typeNames[name] = typ
 
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)
@@ -169,6 +173,9 @@ func (sb *schemaBuilder) buildUnionStruct(typ reflect.Type) error {
 		if name == "" {
 			return fmt.Errorf("bad type %s: should have a name", typ)
 		}
+		if originalType, ok := sb.typeNames[name]; ok {
+			return fmt.Errorf("duplicate name %s: seen both %v and %v", name, originalType, typ)
+		}
 	}
 
 	union := &graphql.Union{
@@ -177,6 +184,7 @@ func (sb *schemaBuilder) buildUnionStruct(typ reflect.Type) error {
 		Types:       make(map[string]*graphql.Object),
 	}
 	sb.types[typ] = union
+	sb.typeNames[name] = typ
 
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)

--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/graphql"
+	"github.com/samsarahq/thunder/graphql/schemabuilder/testpackage"
 	"github.com/samsarahq/thunder/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -670,6 +671,19 @@ func TestBadArguments(t *testing.T) {
 	if _, err := schema.Build(); err.Error() != "bad method aField on type schemabuilder.query: attempted to parse int64 as arguments struct, but failed: expected struct but received type int64" {
 		t.Errorf("expected non-struct args argument to fail, but received %s", err.Error())
 	}
+}
+
+func TestTypeNamesMustBeUnique(t *testing.T) {
+	type Object struct {
+		Something string
+	}
+	builder := NewSchema()
+	builder.Query().FieldFunc("object1", func(ctx context.Context) *Object { return nil })
+	// Put other Object type in a separate package to induce name collision.
+	builder.Query().FieldFunc("object2", func(ctx context.Context) *testpackage.Object { return nil })
+	_, err := builder.Build()
+	assert.Error(t, err, "cannot have duplicate object names")
+	assert.Contains(t, err.Error(), "duplicate name")
 }
 
 func TestObjectKeyMustBeScalar(t *testing.T) {

--- a/graphql/schemabuilder/schema.go
+++ b/graphql/schemabuilder/schema.go
@@ -131,6 +131,7 @@ func (s *Schema) Mutation() *Object {
 func (s *Schema) Build() (*graphql.Schema, error) {
 	sb := &schemaBuilder{
 		types:        make(map[reflect.Type]graphql.Type),
+		typeNames:    make(map[string]reflect.Type),
 		objects:      make(map[reflect.Type]*Object),
 		enumMappings: s.enumTypes,
 		typeCache:    make(map[reflect.Type]cachedType, 0),

--- a/graphql/schemabuilder/testpackage/types.go
+++ b/graphql/schemabuilder/testpackage/types.go
@@ -1,0 +1,5 @@
+package testpackage
+
+type Object struct {
+	SomethingElse string
+}


### PR DESCRIPTION
After this, let's run it in backend and then get all conflicting type names. After that, we can fix them all and then revert the second commit here which logs the conflicting names instead erroring out like we should.