### PR TITLE
go thunder: set pages in pagination info

### DIFF
--- a/graphql/connection_test.go
+++ b/graphql/connection_test.go
@@ -1294,6 +1294,7 @@ func TestConnectionManual(t *testing.T) {
 			info.TotalCountFunc = func() int64 { return 5 }
 			info.HasNextPage = true
 			info.HasPrevPage = false
+			info.Pages = []string{}
 			return []Item{{Id: 1}, {Id: 2}, {Id: 3}}, info, nil
 		},
 		func(ctx context.Context, args Args) ([]Item, error) {
@@ -1324,6 +1325,7 @@ func TestConnectionManual(t *testing.T) {
 					hasPrevPage
 					startCursor
 					endCursor
+					pages
 				}
 			}
 		}
@@ -1344,6 +1346,7 @@ func TestConnectionManual(t *testing.T) {
 					hasPrevPage
 					startCursor
 					endCursor
+					pages
 				}
 			}
 		}
@@ -1365,6 +1368,7 @@ func TestConnectionManual(t *testing.T) {
 					hasPrevPage
 					startCursor
 					endCursor
+					pages
 				}
 			}
 		}
@@ -1386,6 +1390,7 @@ func TestConnectionManual(t *testing.T) {
 					hasPrevPage
 					startCursor
 					endCursor
+					pages
 				}
 			}
 		}

--- a/graphql/testdata/TestConnectionManual.snapshots.json
+++ b/graphql/testdata/TestConnectionManual.snapshots.json
@@ -32,6 +32,10 @@
               "endCursor": "Mw==",
               "hasNextPage": true,
               "hasPrevPage": false,
+              "pages": [
+                "",
+                "Mw=="
+              ],
               "startCursor": "MQ=="
             },
             "totalCount": 5
@@ -73,6 +77,7 @@
               "endCursor": "Mw==",
               "hasNextPage": true,
               "hasPrevPage": false,
+              "pages": [],
               "startCursor": "MQ=="
             },
             "totalCount": 5
@@ -114,6 +119,10 @@
               "endCursor": "Mw==",
               "hasNextPage": true,
               "hasPrevPage": false,
+              "pages": [
+                "",
+                "Mw=="
+              ],
               "startCursor": "MQ=="
             },
             "totalCount": 5
@@ -155,6 +164,7 @@
               "endCursor": "Mw==",
               "hasNextPage": true,
               "hasPrevPage": false,
+              "pages": [],
               "startCursor": "MQ=="
             },
             "totalCount": 5


### PR DESCRIPTION
You can set pages inside of something manually paginated if you want or set it to an empty list if that information isn't used. This keeps the apis between manual pagination and pagination the same. 