### PR TITLE
go graphql: expose SanitizeError helper

### DIFF
--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -53,7 +53,8 @@ func WrapAsSafeError(err error, format string, a ...interface{}) error {
 	return SafeError{inner: err, message: fmt.Sprintf(format, a...)}
 }
 
-func sanitizeError(err error) string {
+// SanitizeError returns a sanitized error message for an error.
+func SanitizeError(err error) string {
 	if sanitized, ok := err.(SanitizedError); ok {
 		return sanitized.SanitizedError()
 	}

--- a/graphql/server.go
+++ b/graphql/server.go
@@ -217,7 +217,7 @@ func (c *conn) handleSubscribe(in *inEnvelope) error {
 			c.writeOrClose(outEnvelope{
 				ID:       id,
 				Type:     "error",
-				Message:  sanitizeError(err),
+				Message:  SanitizeError(err),
 				Metadata: output.Metadata,
 			})
 			go c.closeSubscription(id)
@@ -323,7 +323,7 @@ func (c *conn) handleMutate(in *inEnvelope) error {
 			c.writeOrClose(outEnvelope{
 				ID:       id,
 				Type:     "error",
-				Message:  sanitizeError(err),
+				Message:  SanitizeError(err),
 				Metadata: output.Metadata,
 			})
 
@@ -586,7 +586,7 @@ func (c *conn) ServeJSONSocket() {
 			c.writeOrClose(outEnvelope{
 				ID:       envelope.ID,
 				Type:     "error",
-				Message:  sanitizeError(err),
+				Message:  SanitizeError(err),
 				Metadata: nil,
 			})
 		}


### PR DESCRIPTION
Make a helper function for calculating the
sanitized error message public so we can use
it outside of Thunder.