### PR TITLE
go graphql: Add ConcurrencyController option for batch and non-expensive execution

### DIFF
--- a/graphql/schemabuilder/batch.go
+++ b/graphql/schemabuilder/batch.go
@@ -125,13 +125,14 @@ func (sb *schemaBuilder) buildBatchFunctionAndFuncCtx(typ reflect.Type, m *metho
 	}
 
 	return &graphql.Field{
-		BatchResolver:  batchExecFunc,
-		Batch:          true,
-		External:       true,
-		Args:           args,
-		Type:           retType,
-		ParseArguments: argParser.Parse,
-		Expensive:      m.Expensive,
+		BatchResolver:              batchExecFunc,
+		Batch:                      true,
+		External:                   true,
+		Args:                       args,
+		Type:                       retType,
+		ParseArguments:             argParser.Parse,
+		Expensive:                  m.Expensive,
+		NumParallelInvocationsFunc: m.ConcurrencyArgs.numParallelInvocationsFunc,
 	}, funcCtx, nil
 }
 

--- a/graphql/schemabuilder/function.go
+++ b/graphql/schemabuilder/function.go
@@ -72,11 +72,12 @@ func (sb *schemaBuilder) buildFunctionAndFuncCtx(typ reflect.Type, m *method) (*
 			return funcCtx.extractResultAndErr(funcOutputArgs, retType)
 
 		},
-		Args:           args,
-		Type:           retType,
-		ParseArguments: argParser.Parse,
-		Expensive:      m.Expensive,
-		External:       true,
+		Args:                       args,
+		Type:                       retType,
+		ParseArguments:             argParser.Parse,
+		Expensive:                  m.Expensive,
+		External:                   true,
+		NumParallelInvocationsFunc: m.ConcurrencyArgs.numParallelInvocationsFunc,
 	}, funcCtx, nil
 }
 

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -1069,13 +1069,14 @@ func (sb *schemaBuilder) buildPaginatedFieldWithFallback(typ reflect.Type, m *me
 			}
 			return manualPaginationField.Resolve(ctx, source, dualArgs.argValue, selectionSet)
 		},
-		Type:           manualPaginationField.Type,
-		Args:           manualPaginationField.Args,
-		ParseArguments: dualParser.Parse,
-		UseBatchFunc:   manualPaginationField.UseBatchFunc,
-		Batch:          manualPaginationField.Batch,
-		External:       manualPaginationField.External,
-		Expensive:      manualPaginationField.Expensive,
+		Type:                       manualPaginationField.Type,
+		Args:                       manualPaginationField.Args,
+		ParseArguments:             dualParser.Parse,
+		UseBatchFunc:               manualPaginationField.UseBatchFunc,
+		Batch:                      manualPaginationField.Batch,
+		External:                   manualPaginationField.External,
+		Expensive:                  manualPaginationField.Expensive,
+		NumParallelInvocationsFunc: manualPaginationField.NumParallelInvocationsFunc,
 	}
 
 	return field, nil
@@ -1175,11 +1176,12 @@ func (sb *schemaBuilder) buildPaginatedFunctionAndFuncCtx(typ reflect.Type, m *m
 			return c.extractReturnAndErr(ctx, out, args, retType)
 
 		},
-		Args:           args,
-		Type:           retType,
-		ParseArguments: argParser.Parse,
-		Expensive:      m.Expensive,
-		External:       true,
+		Args:                       args,
+		Type:                       retType,
+		ParseArguments:             argParser.Parse,
+		Expensive:                  m.Expensive,
+		External:                   true,
+		NumParallelInvocationsFunc: m.ConcurrencyArgs.numParallelInvocationsFunc,
 	}
 	return ret, c, nil
 }

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -291,6 +291,8 @@ type method struct {
 	// Sort methods
 	SortMethods map[string]*method
 
+	ConcurrencyArgs concurrencyArgs
+
 	// Whether the FieldFunc is a batchField
 	Batch bool
 
@@ -298,6 +300,18 @@ type method struct {
 
 	ManualPaginationArgs manualPaginationArgs
 }
+
+type concurrencyArgs struct {
+	numParallelInvocationsFunc NumParallelInvocationsFunc
+}
+
+// NumParallelInvocationsFunc is a configuration option for non-expensive and batch
+// fields that controls how many goroutines will get created for the field
+// execution.  The nodes for the field execution will be evenly split across
+// the different goroutines.
+type NumParallelInvocationsFunc func(ctx context.Context, numNodes int) int
+
+func (f NumParallelInvocationsFunc) apply(m *method) { m.ConcurrencyArgs.numParallelInvocationsFunc = f }
 
 type UseFallbackFlag func(context.Context) bool
 

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -134,6 +134,11 @@ type Field struct {
 	Batch        bool
 	External     bool
 	Expensive    bool
+
+	// NumParallelInvocationsFunc controls how many goroutines we'll create for a
+	// field execution (batch or non-expensive).  We pass in the number of srcs
+	// we're executing with so implementers can write custom logic.
+	NumParallelInvocationsFunc func(ctx context.Context, numNodes int) int
 }
 
 type Schema struct {


### PR DESCRIPTION
Summary: Adds the ability to control the number of concurrent work units
we'll create for batch and non-expensive fields.  This allows us to control
how big batches get and allows us the ability to split these batches into
smaller sub-executions (sometimes we get diminishing returns from batches
after they get to a certain size).