### PR TITLE
sqlgen db: more detailed error for DynamicLimit failures

### DIFF
--- a/sqlgen/errors.go
+++ b/sqlgen/errors.go
@@ -1,0 +1,27 @@
+package sqlgen
+
+import (
+	"fmt"
+)
+
+// ErrorWithQuery is an error wrapper that includes
+// the clause and arguments of a sqlgen query.
+type ErrorWithQuery struct {
+	err    error         // the wrapped error
+	clause string        // the string clause of the query
+	args   []interface{} // the args of the query
+
+}
+
+func (e *ErrorWithQuery) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return fmt.Sprintf("Error: %s; query clause: '%s'; query args: '%v'\n", e.err.Error(), e.clause, e.args)
+}
+
+// Unwrap returns the error without the clause
+// or arguments.
+func (e *ErrorWithQuery) Unwrap() error {
+	return e.err
+}

--- a/sqlgen/errors_test.go
+++ b/sqlgen/errors_test.go
@@ -1,0 +1,101 @@
+package sqlgen
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorWithQuery(t *testing.T) {
+
+	ints := []int{1, 2, 3, 4}
+	intsInterfaceArr := make([]interface{}, len(ints))
+	for i, s := range ints {
+		intsInterfaceArr[i] = s
+	}
+
+	strs := []string{"a", "b", "c", "asdf"}
+	strsInterfaceArr := make([]interface{}, len(strs))
+	for i, s := range strs {
+		strsInterfaceArr[i] = s
+	}
+
+	bools := []bool{true, false, false, true}
+	boolsInterfaceArr := make([]interface{}, len(bools))
+	for i, s := range bools {
+		boolsInterfaceArr[i] = s
+	}
+
+	testcases := []struct {
+		title         string
+		originalError error
+		clause        string
+		args          []interface{}
+		isNested      bool
+	}{
+		{
+			title:         "nil original error",
+			originalError: nil,
+			clause:        "some clause, foo, bar, baz",
+			args:          intsInterfaceArr,
+		},
+		{
+			title:         "ok original error with no args",
+			originalError: fmt.Errorf("original"),
+			clause:        "select * from mysql.users",
+		},
+		{
+			title:         "ok original error with no clause",
+			originalError: fmt.Errorf("original"),
+			args:          boolsInterfaceArr,
+		},
+		{
+			title:         "ok original error with clause and args",
+			originalError: fmt.Errorf("original"),
+			clause:        "some clause, foo, bar, baz",
+			args:          intsInterfaceArr,
+		},
+		{
+			title: "wrapped original error with clause and args",
+			originalError: &ErrorWithQuery{
+				err:    fmt.Errorf("innermost"),
+				clause: "some inner clause",
+				args:   intsInterfaceArr,
+			},
+			clause:   "some outer clause, foo, bar, baz",
+			args:     strsInterfaceArr,
+			isNested: true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.title, func(t *testing.T) {
+			originalError := testcase.originalError
+			wrapped := &ErrorWithQuery{
+				err:    originalError,
+				clause: testcase.clause,
+				args:   testcase.args,
+			}
+
+			if originalError == nil {
+				assert.Equal(t, wrapped.Error(), "")
+				return
+			}
+
+			assert.Contains(t, wrapped.Error(), fmt.Sprintf("Error: %s;", originalError.Error()))
+			assert.Contains(t, wrapped.Error(), fmt.Sprintf("query clause: '%s'", testcase.clause))
+			assert.Contains(t, wrapped.Error(), fmt.Sprintf("query args: '%v'", testcase.args))
+
+			assert.Equal(t, wrapped.Unwrap(), originalError)
+
+			if testcase.isNested {
+				assert.Contains(t, wrapped.Unwrap().Error(), "query clause:")
+				assert.Contains(t, wrapped.Unwrap().Error(), "query args:")
+			} else {
+				assert.NotContains(t, wrapped.Unwrap().Error(), "query clause:")
+				assert.NotContains(t, wrapped.Unwrap().Error(), "query args:")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding more information about the query on a dynamic limit failure is helpful for understanding why a limit failed in the first place.

This PR adds the query clause and arguments to the error returned to a client on a DynamicLimit failure.