### PR TITLE
docfix on schema.Schema{}.MustBuild

### DIFF
--- a/graphql/schemabuilder/schema.go
+++ b/graphql/schemabuilder/schema.go
@@ -164,7 +164,7 @@ func (s *Schema) Build() (*graphql.Schema, error) {
 	}, nil
 }
 
-// MustBuildSchema builds a schema and panics if an error occurs.
+// MustBuild builds a schema and panics if an error occurs.
 func (s *Schema) MustBuild() *graphql.Schema {
 	built, err := s.Build()
 	if err != nil {


### PR DESCRIPTION
This fixes a small drift in documentation introduced in e6faec0deb784e9c2451e662979f2f2da77d30ec