### PR TITLE
go errors: adding Reason function to errors for user  readibility

### DIFF
--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -34,6 +34,10 @@ func (e SafeError) SanitizedError() string {
 	return e.message
 }
 
+func (e SafeError) Reason() string {
+	return e.message
+}
+
 // Unwrap returns the wrapped error, implementing go's 1.13 error wrapping proposal.
 func (e SafeError) Unwrap() error {
 	return e.inner

--- a/graphql/executor.go
+++ b/graphql/executor.go
@@ -64,15 +64,26 @@ func (pe *pathError) Unwrap() error {
 
 func (pe *pathError) Error() string {
 	var buffer bytes.Buffer
+	writePath(pe, &buffer)
+	buffer.WriteString(": ")
+	buffer.WriteString(pe.inner.Error())
+	return buffer.String()
+}
+
+func (pe *pathError) Reason() string {
+	var buffer bytes.Buffer
+	writePath(pe, &buffer)
+	return buffer.String()
+}
+
+// Writes path from pe into buffer
+func writePath(pe *pathError, buffer *bytes.Buffer) {
 	for i := len(pe.path) - 1; i >= 0; i-- {
 		if i < len(pe.path)-1 {
 			buffer.WriteString(".")
 		}
 		buffer.WriteString(pe.path[i])
 	}
-	buffer.WriteString(": ")
-	buffer.WriteString(pe.inner.Error())
-	return buffer.String()
 }
 
 func isNilArgs(args interface{}) bool {

--- a/graphql/executor_test.go
+++ b/graphql/executor_test.go
@@ -3,6 +3,7 @@ package graphql_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -372,6 +373,43 @@ func TestExecutorRuns(t *testing.T) {
 				internal.MarshalJSON(wantParsedJSON),
 				internal.MarshalJSON(gotJSON),
 			)
+		})
+	}
+}
+
+func Test_pathError_Reason(t *testing.T) {
+	type fields struct {
+		inner error
+		path  []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "empty list",
+			fields: fields{
+				inner: nil,
+				path:  []string{},
+			},
+			want: "",
+		},
+		{
+			name: "non empty list",
+			fields: fields{
+				inner: fmt.Errorf("error"),
+				path:  []string{"a", "b", "c"},
+			},
+			want: "c.b.a",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pe := graphql.PathErrorInit(tt.fields.inner, tt.fields.path).(*graphql.PathError)
+			if got := pe.Reason(); got != tt.want {
+				t.Errorf("Reason() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/graphql/export_test.go
+++ b/graphql/export_test.go
@@ -1,0 +1,10 @@
+package graphql
+
+func PathErrorInit(inner error, path []string) error {
+	return &pathError{
+		inner: inner,
+		path:  path,
+	}
+}
+
+type PathError = pathError

--- a/sqlgen/errors.go
+++ b/sqlgen/errors.go
@@ -25,3 +25,8 @@ func (e *ErrorWithQuery) Error() string {
 func (e *ErrorWithQuery) Unwrap() error {
 	return e.err
 }
+
+// Reason returns a human-readable error message of the clause and args
+func (e *ErrorWithQuery) Reason() string {
+	return fmt.Sprintf("Error in query clause: '%s'; query args: '%v'", e.clause, e.args)
+}

--- a/sqlgen/errors_test.go
+++ b/sqlgen/errors_test.go
@@ -99,3 +99,45 @@ func TestErrorWithQuery(t *testing.T) {
 		})
 	}
 }
+
+func TestErrorWithQuery_Reason(t *testing.T) {
+	type fields struct {
+		err    error
+		clause string
+		args   []interface{}
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "nil err and args",
+			fields: fields{
+				clause: "clause",
+				args:   nil,
+			},
+			want: "Error in query clause: 'clause'; query args: '[]'",
+		},
+		{
+			name: "args array is not empty",
+			fields: fields{
+				clause: "clause",
+				args:   []interface{}{"a", "b"},
+			},
+			want: "Error in query clause: 'clause'; query args: '[a b]'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &ErrorWithQuery{
+				err:    tt.fields.err,
+				clause: tt.fields.clause,
+				args:   tt.fields.args,
+			}
+			if got := e.Reason(); got != tt.want {
+				t.Errorf("Reason() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding Reason function to errors so it is compatible with https://github.com/samsarahq/go/pull/12