### PR TITLE
graphql: expose UnparsedArgs and ParentType for traceability

### DIFF
--- a/graphql/parser.go
+++ b/graphql/parser.go
@@ -72,7 +72,7 @@ func valueToJson(value ast.Value, vars map[string]interface{}) (interface{}, err
 
 // argsToJson converts a graphql-go ast argument list to a json.Marshal-style
 // map[string]interface{}
-func argsToJson(input []*ast.Argument, vars map[string]interface{}) (interface{}, error) {
+func argsToJson(input []*ast.Argument, vars map[string]interface{}) (map[string]interface{}, error) {
 	args := make(map[string]interface{})
 	for _, arg := range input {
 		name := arg.Name.Value
@@ -122,7 +122,7 @@ func parseSelectionSet(input *ast.SelectionSet, globalFragments map[string]*Frag
 			selections = append(selections, &Selection{
 				Alias:        alias,
 				Name:         selection.Name.Value,
-				Args:         args,
+				UnparsedArgs: args,
 				SelectionSet: selectionSet,
 			})
 
@@ -259,7 +259,7 @@ func detectConflicts(selectionSet *SelectionSet) error {
 					if other.Name != selection.Name {
 						return NewClientError("same alias with different name")
 					}
-					if !reflect.DeepEqual(other.Args, selection.Args) {
+					if !reflect.DeepEqual(other.UnparsedArgs, selection.UnparsedArgs) {
 						return NewClientError("same alias with different args")
 					}
 				} else {
@@ -486,7 +486,7 @@ func Flatten(selectionSet *SelectionSet) []*Selection {
 		flattened = append(flattened, &Selection{
 			Name:         selections[0].Name,
 			Alias:        selections[0].Alias,
-			Args:         selections[0].Args,
+			UnparsedArgs: selections[0].UnparsedArgs,
 			SelectionSet: merged,
 		})
 	}

--- a/graphql/parser_test.go
+++ b/graphql/parser_test.go
@@ -40,25 +40,25 @@ fragment Bar on Foo {
 		SelectionSet: &SelectionSet{
 			Selections: []*Selection{
 				{
-					Name:  "foo",
-					Alias: "foo",
-					Args:  map[string]interface{}{},
+					Name:         "foo",
+					Alias:        "foo",
+					UnparsedArgs: map[string]interface{}{},
 					SelectionSet: &SelectionSet{
 						Selections: []*Selection{
 							{
-								Name:  "bar",
-								Alias: "alias",
-								Args:  map[string]interface{}{},
+								Name:         "bar",
+								Alias:        "alias",
+								UnparsedArgs: map[string]interface{}{},
 							},
 							{
-								Name:  "bar",
-								Alias: "alias",
-								Args:  map[string]interface{}{},
+								Name:         "bar",
+								Alias:        "alias",
+								UnparsedArgs: map[string]interface{}{},
 							},
 							{
 								Name:  "baz",
 								Alias: "baz",
-								Args: map[string]interface{}{
+								UnparsedArgs: map[string]interface{}{
 									"arg": float64(3),
 								},
 								SelectionSet: &SelectionSet{
@@ -66,7 +66,7 @@ fragment Bar on Foo {
 										{
 											Name:  "bah",
 											Alias: "bah",
-											Args: map[string]interface{}{
+											UnparsedArgs: map[string]interface{}{
 												"x": float64(1),
 												"y": "123",
 												"z": true,
@@ -75,7 +75,7 @@ fragment Bar on Foo {
 										{
 											Name:  "hum",
 											Alias: "hum",
-											Args: map[string]interface{}{
+											UnparsedArgs: map[string]interface{}{
 												"foo": map[string]interface{}{
 													"x": "var value!!",
 												},
@@ -95,9 +95,9 @@ fragment Bar on Foo {
 								SelectionSet: &SelectionSet{
 									Selections: []*Selection{
 										{
-											Name:  "asd",
-											Alias: "asd",
-											Args:  map[string]interface{}{},
+											Name:         "asd",
+											Alias:        "asd",
+											UnparsedArgs: map[string]interface{}{},
 										},
 									},
 									Fragments: []*Fragment{
@@ -106,9 +106,9 @@ fragment Bar on Foo {
 											SelectionSet: &SelectionSet{
 												Selections: []*Selection{
 													{
-														Name:  "zxc",
-														Alias: "zxc",
-														Args:  map[string]interface{}{},
+														Name:         "zxc",
+														Alias:        "zxc",
+														UnparsedArgs: map[string]interface{}{},
 													},
 												},
 											},
@@ -120,9 +120,9 @@ fragment Bar on Foo {
 					},
 				},
 				{
-					Name:  "xyz",
-					Alias: "xyz",
-					Args:  map[string]interface{}{},
+					Name:         "xyz",
+					Alias:        "xyz",
+					UnparsedArgs: map[string]interface{}{},
 				},
 			},
 		},
@@ -149,9 +149,9 @@ mutation foo($var: bar) {
 		SelectionSet: &SelectionSet{
 			Selections: []*Selection{
 				{
-					Name:  "baz",
-					Alias: "baz",
-					Args:  map[string]interface{}{},
+					Name:         "baz",
+					Alias:        "baz",
+					UnparsedArgs: map[string]interface{}{},
 				},
 			},
 		},
@@ -270,7 +270,7 @@ query Operation($x: int64 = 2) {
 		t.Error("expected default value to be used, but received", err)
 	}
 
-	args := query.SelectionSet.Selections[0].Args.(map[string]interface{})
+	args := query.SelectionSet.Selections[0].UnparsedArgs
 
 	if len := len(args); len != 1 {
 		t.Errorf("expected 1 argument, received %d", len)

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -189,6 +189,13 @@ type Selection struct {
 	// The parsed flag is used to make sure the args for this Selection are only
 	// parsed once.
 	parsed bool
+
+	// UnparsedArgs are the original json map[string]interface{} arguments.
+	// This field is only available able after PrepareQuery has been called.
+	UnparsedArgs map[string]interface{}
+
+	// ParentType is the type that this field hangs off of.
+	ParentType string
 }
 
 // A Fragment represents a reusable part of a GraphQL query


### PR DESCRIPTION
Expose these two types on selections so that middleware can read
them for debugging/tracing.