### PR TITLE
graphql: fix issue where Flatten drops args

### DIFF
--- a/graphql/executor_test.go
+++ b/graphql/executor_test.go
@@ -201,6 +201,68 @@ func TestRepeatedFragment(t *testing.T) {
 	}
 }
 
+func TestFlatten(t *testing.T) {
+	type Args struct {
+		Value int
+	}
+
+	assert.Equal(t,
+		[]*graphql.Selection{
+			{
+				Name:  "a",
+				Alias: "b",
+				Args: &Args{
+					Value: 2,
+				},
+				SelectionSet: &graphql.SelectionSet{
+					// Flatten needs to be run on every level. On a subsequent run,
+					// these foo's would also get flattened.
+					Selections: []*graphql.Selection{{
+						Name:         "foo",
+						UnparsedArgs: map[string]interface{}{},
+						ParentType:   "A",
+					}, {
+						Name:         "foo",
+						UnparsedArgs: map[string]interface{}{},
+						ParentType:   "A",
+					}},
+				},
+			},
+		},
+		graphql.Flatten(&graphql.SelectionSet{
+			Selections: []*graphql.Selection{
+				{
+					Name:  "a",
+					Alias: "b",
+					Args: &Args{
+						Value: 2,
+					},
+					SelectionSet: &graphql.SelectionSet{
+						Selections: []*graphql.Selection{{
+							Name:         "foo",
+							UnparsedArgs: map[string]interface{}{},
+							ParentType:   "A",
+						}},
+					},
+				},
+				{
+					Name:  "a",
+					Alias: "b",
+					Args: &Args{
+						Value: 2,
+					},
+					SelectionSet: &graphql.SelectionSet{
+						Selections: []*graphql.Selection{{
+							Name:         "foo",
+							UnparsedArgs: map[string]interface{}{},
+							ParentType:   "A",
+						}},
+					},
+				},
+			},
+		}))
+}
+
 /*
 func TestMissingField(t *testing.T) {
 	q := MustParse(`

--- a/graphql/parser.go
+++ b/graphql/parser.go
@@ -487,6 +487,7 @@ func Flatten(selectionSet *SelectionSet) []*Selection {
 			Name:         selections[0].Name,
 			Alias:        selections[0].Alias,
 			UnparsedArgs: selections[0].UnparsedArgs,
+			Args:         selections[0].Args,
 			SelectionSet: merged,
 		})
 	}


### PR DESCRIPTION
Fix a bug where flatten drops arguments if it needs to merge
two selections. Also add a test for this behavior.