### PR TITLE
graphql: include ParentType in Flatten

### DIFF
--- a/graphql/executor_test.go
+++ b/graphql/executor_test.go
@@ -214,6 +214,7 @@ func TestFlatten(t *testing.T) {
 				Args: &Args{
 					Value: 2,
 				},
+				ParentType: "Query",
 				SelectionSet: &graphql.SelectionSet{
 					// Flatten needs to be run on every level. On a subsequent run,
 					// these foo's would also get flattened.
@@ -237,6 +238,7 @@ func TestFlatten(t *testing.T) {
 					Args: &Args{
 						Value: 2,
 					},
+					ParentType: "Query",
 					SelectionSet: &graphql.SelectionSet{
 						Selections: []*graphql.Selection{{
 							Name:         "foo",
@@ -251,6 +253,7 @@ func TestFlatten(t *testing.T) {
 					Args: &Args{
 						Value: 2,
 					},
+					ParentType: "Query",
 					SelectionSet: &graphql.SelectionSet{
 						Selections: []*graphql.Selection{{
 							Name:         "foo",

--- a/graphql/parser.go
+++ b/graphql/parser.go
@@ -486,6 +486,7 @@ func Flatten(selectionSet *SelectionSet) []*Selection {
 		flattened = append(flattened, &Selection{
 			Name:         selections[0].Name,
 			Alias:        selections[0].Alias,
+			ParentType:   selections[0].ParentType,
 			UnparsedArgs: selections[0].UnparsedArgs,
 			Args:         selections[0].Args,
 			SelectionSet: merged,


### PR DESCRIPTION
Fix an issue where ParentType was also not being merged properly
in Flatten. Add a test.