### PR TITLE
Pagination: add PostProcessOptions

### DIFF
--- a/graphql/connection_test.go
+++ b/graphql/connection_test.go
@@ -831,7 +831,7 @@ func TestEmbeddedFail(t *testing.T) {
 	inner := schema.Object("inner", Inner{})
 	item := schema.Object("item", Item{})
 	item.Key("id")
-	inner.PaginateFieldFunc("innerConnection", func(args EmbeddedArgs) ([]Item, schemabuilder.PaginationInfo, error) {
+	inner.FieldFunc("innerConnection", func(args EmbeddedArgs) ([]Item, schemabuilder.PaginationInfo, error) {
 		retList := make([]Item, 5)
 		retList[0] = Item{Id: 1}
 		retList[1] = Item{Id: 2}
@@ -844,13 +844,12 @@ func TestEmbeddedFail(t *testing.T) {
 				HasPrevPage:    false,
 				TotalCountFunc: func() int64 { return int64(5) },
 			}, nil
-	})
+	}, schemabuilder.Paginated)
 
-	badMethodStr := "bad method inner on type schemabuilder.query:"
 	_, err := schema.Build()
-	if err != nil && err.Error() != fmt.Sprintf("%s if pagination args are embedded then pagination info must be included as a return value", badMethodStr) {
-		t.Errorf("bad error: %v", err)
-	}
+	require.NotNil(t, err)
+	badMethodStr := "bad method inner on type schemabuilder.query:"
+	require.Equal(t, err.Error(), fmt.Sprintf("%s if pagination args are embedded then pagination info must be included as a return value", badMethodStr))
 }
 
 func TestPaginatedFilters(t *testing.T) {

--- a/graphql/connection_test.go
+++ b/graphql/connection_test.go
@@ -694,7 +694,7 @@ func TestEmbeddedArgs(t *testing.T) {
 	inner := schema.Object("inner", Inner{})
 	item := schema.Object("item", Item{})
 	item.Key("id")
-	inner.PaginateFieldFunc("innerConnection", func(args EmbeddedArgs) ([]Item, schemabuilder.PaginationInfo, error) {
+	inner.PaginateFieldFunc("innerConnection", func(args EmbeddedArgs) ([]Item, schemabuilder.PaginationInfo, schemabuilder.PostProcessOptions, error) {
 		retList := make([]Item, 5)
 		retList[0] = Item{Id: 1}
 		retList[1] = Item{Id: 2}
@@ -706,7 +706,7 @@ func TestEmbeddedArgs(t *testing.T) {
 				HasNextPage:    true,
 				HasPrevPage:    false,
 				TotalCountFunc: func() int64 { return int64(5) },
-			}, nil
+			}, schemabuilder.PostProcessOptions{}, nil
 	})
 	builtSchema := schema.MustBuild()
 	q := graphql.MustParse(`

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -149,6 +149,20 @@ type PaginationInfo struct {
 	Pages          []string
 }
 
+// PostProcessOptions is used to instruct Thunder to perform additional operations on the output
+// in the case of manually paginated resolvers.
+// This struct should be returned as the second result from a manually-paginated field func.
+type PostProcessOptions struct {
+	// Whether or not Thunder should apply filtering on the output. This flag can
+	// be used by externally managed resolvers when they decide to fall back to Thunder's
+	// filtering based on the query arguments.
+	ApplyTextFilter bool
+	// Whether or not Thunder should set the Page Info's fields based on the output.
+	// An exception to this are start and end cursors, which will be set by Thunder
+	// regardless of the SetPageInfo flag.
+	SetPageInfo bool
+}
+
 func (i PaginationInfo) TotalCount() (int64, error) {
 	if i.TotalCountFunc == nil {
 		return 0, errors.New("must set TotalCountFunc on PaginationInfo")

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -1009,6 +1009,11 @@ func (c *connectionContext) parsePaginatedReturnSignature(m *method) (err error)
 	if len(out) > 0 && out[0] == reflect.TypeOf(PaginationInfo{}) {
 		c.ReturnsPageInfo = true
 		out = out[1:]
+		if len(out) == 0 || out[0] != reflect.TypeOf(PostProcessOptions{}) {
+			err = fmt.Errorf("%s returns a PaginationInfo not followed by a PaginationPostProcessOptions", c.funcType)
+			return
+		}
+		out = out[1:]
 	}
 
 	if len(out) > 0 && out[0] == errType {

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -183,6 +183,8 @@ type connectionContext struct {
 	Key string
 	// Whether or not the FieldFunc returns PageInfo (overrides thunder's auto-populated PageInfo).
 	ReturnsPageInfo bool
+	// The post process options returned by the resolver.
+	PostProcessOptions PostProcessOptions
 	// The index of PaginationArgs in the arguments provided to the FieldFunc.
 	PaginationArgsIndex int
 	// The GraphQL fields for filtered text to be resolved.
@@ -1223,6 +1225,7 @@ func (c *connectionContext) extractReturnAndErr(ctx context.Context, out []refle
 		}
 	} else {
 		paginationArgs = reflect.ValueOf(args).Field(c.PaginationArgsIndex).Interface().(PaginationArgs)
+		c.PostProcessOptions = out[2].Interface().(PostProcessOptions)
 	}
 
 	result, err := c.getConnection(ctx, out, paginationArgs)

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -655,12 +655,16 @@ func (c *connectionContext) getConnection(ctx context.Context, out []reflect.Val
 		return Connection{}, nil
 	}
 
-	if !c.IsExternallyManaged() {
+	if !c.IsExternallyManaged() || c.PostProcessOptions.ApplyTextFilter {
 		var err error
 		nodes, err = c.applyTextFilter(ctx, nodes, args)
 		if err != nil {
 			return Connection{}, err
 		}
+	}
+
+	if !c.IsExternallyManaged() {
+		var err error
 		nodes, err = c.applySort(ctx, nodes, args)
 		if err != nil {
 			return Connection{}, err
@@ -679,8 +683,8 @@ func (c *connectionContext) getConnection(ctx context.Context, out []reflect.Val
 	}
 
 	// If the pagination is externally managed, thunder isn't going to handle setting page
-	// information or reducing the edges.
-	if c.IsExternallyManaged() {
+	// information or reducing the edges, unless it is explicitly instructed to.
+	if c.IsExternallyManaged() && !c.PostProcessOptions.SetPageInfo {
 		// XXX: We might want to handle the case where the externally managed result set is of
 		// incorrect size (too big) and error.
 		if err := connection.externallySetPageInfo(out[1].Interface().(PaginationInfo)); err != nil {


### PR DESCRIPTION
This adds a PostProcessOptions that externally managed paginated endpoints need to return and optionally fill options of. This lets Thunder perform additional operations on the output based on the turned-on flags.

The first flags, added in this PR, are `ApplyTextFilter`, which will apply a text filter on the output, and `SetPageInfo`, which will set the page info based on the output.