### PR TITLE
Federation Schema Merging 

### DIFF
--- a/federation/schema/kitchen_sink_test.go
+++ b/federation/schema/kitchen_sink_test.go
@@ -1,0 +1,133 @@
+package federation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samsarahq/thunder/batch"
+	"github.com/samsarahq/thunder/graphql/schemabuilder"
+)
+
+type Enum int
+
+type Foo struct {
+	Name string
+}
+
+type Bar struct {
+	Id int64
+}
+
+type FooOrBar struct {
+	schemabuilder.Union
+	*Foo
+	*Bar
+}
+
+type Pair struct {
+	A, B int64
+}
+
+func buildTestSchema1() *schemabuilder.Schema {
+	schema := schemabuilder.NewSchema()
+
+	query := schema.Query()
+	query.FieldFunc("s1f", func() *Foo {
+		return &Foo{
+			Name: "jimbob",
+		}
+	})
+	query.FieldFunc("s1fff", func() []*Foo {
+		return []*Foo{
+			{
+				Name: "jimbo",
+			},
+			{
+				Name: "bob",
+			},
+		}
+	})
+
+	query.FieldFunc("s1echo", func(args struct {
+		Foo      string
+		Required Pair
+		Optional *int64
+	}) string {
+		return fmt.Sprintf("%s %v %v", args.Foo, args.Required, args.Optional)
+	})
+
+	schema.Enum(Enum(1), map[string]Enum{
+		"one": 1,
+	})
+
+	mutation := schema.Mutation()
+
+	mutation.FieldFunc("s1addFoo", func(args struct{ Name string }) *Foo {
+		return &Foo{
+			Name: args.Name,
+		}
+	})
+
+	foo := schema.Object("Foo", Foo{})
+	foo.BatchFieldFunc("s1hmm", func(ctx context.Context, in map[batch.Index]*Foo) (map[batch.Index]string, error) {
+		out := make(map[batch.Index]string)
+		for i, foo := range in {
+			out[i] = foo.Name + "!!!"
+		}
+		return out, nil
+	})
+	foo.FieldFunc("s1nest", func(f *Foo) *Foo {
+		return f
+	})
+	foo.FieldFunc("s1enum", func(f *Foo) Enum {
+		return Enum(1)
+	})
+
+	bar := schema.Object("Bar", Bar{})
+	bar.FieldFunc("s1baz", func(b *Bar) string {
+		return fmt.Sprint(b.Id)
+	})
+
+	query.FieldFunc("s1both", func() []FooOrBar {
+		return []FooOrBar{
+			{
+				Foo: &Foo{
+					Name: "this is the foo",
+				},
+			},
+			{
+				Bar: &Bar{
+					Id: 1234,
+				},
+			},
+		}
+	})
+
+	return schema
+}
+
+func buildTestSchema2() *schemabuilder.Schema {
+	schema := schemabuilder.NewSchema()
+
+	schema.Query().FieldFunc("s2root", func() string {
+		return "hello"
+	})
+
+	foo := schema.Object("Foo", Foo{})
+
+	foo.FieldFunc("s2ok", func(ctx context.Context, in *Foo) (int, error) {
+		return len(in.Name), nil
+	})
+
+	foo.FieldFunc("s2bar", func(in *Foo) *Bar {
+		return &Bar{
+			Id: int64(len(in.Name)*2 + 4),
+		}
+	})
+
+	foo.FieldFunc("s2nest", func(f *Foo) *Foo {
+		return f
+	})
+
+	return schema
+}

--- a/federation/schema/merge_schemas.go
+++ b/federation/schema/merge_schemas.go
@@ -1,0 +1,419 @@
+package federation
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+)
+
+// MergeMode controls how to combine two different schemas. Union is used for
+// two independent services, Intersection for two different versions of the same
+// service.
+type MergeMode string
+
+const (
+	// Union computes a schema that is supported by the two services combined.
+	//
+	// A Union is used to to combine the schema of two independent services.
+	// The proxy will split a GraphQL query to ask each service the fields
+	// it knows about.
+	//
+	// Two schemas must be compatible: Any overlapping types (eg. a field that
+	// is implemented by both services, or two input types) must be compatible.
+	// In practice, this means types must be identical except for non-nil
+	// modifiers.
+	//
+	// XXX: take intersection on ENUM values to not confuse a service with a
+	// type it doesn't support?
+	Union MergeMode = "union"
+
+	// Intersection computes a schema that is supported by both services.
+	//
+	// An Intersection is used to combine two schemas of different versions
+	// of the same service. During a deploy, only of two versions might be
+	// available, and so queries must be compatible with both schemas.
+	//
+	// Intersection computes a schema that can be executed by both services.
+	// It only includes types and fields (etc.) exported by both services.
+	// Overlapping types must be compatible as in a Union merge.
+	//
+	// One surprise might be that newly added ENUM values or UNION types might
+	// be returned by the merged schema.
+	Intersection MergeMode = "intersection"
+)
+
+// introspectionTypeRef is a type reference from the GraphQL introspection
+// query.
+type introspectionTypeRef struct {
+	Kind   string                `json:"kind"`
+	Name   string                `json:"name"`
+	OfType *introspectionTypeRef `json:"ofType"`
+}
+
+func (t *introspectionTypeRef) String() string {
+	if t == nil {
+		return "<nil>"
+	}
+	switch t.Kind {
+	case "SCALAR", "ENUM", "UNION", "OBJECT", "INPUT_OBJECT":
+		return t.Name
+	case "NON_NULL":
+		return t.OfType.String() + "!"
+	case "LIST":
+		return "[" + t.OfType.String() + "]"
+	default:
+		return fmt.Sprintf("<kind=%s name=%s ofType%s>", t.Kind, t.Name, t.OfType)
+	}
+}
+
+type introspectionInputField struct {
+	Name string                `json:"name"`
+	Type *introspectionTypeRef `json:"type"`
+}
+
+type introspectionField struct {
+	Name string                    `json:"name"`
+	Type *introspectionTypeRef     `json:"type"`
+	Args []introspectionInputField `json:"args"`
+}
+
+type introspectionEnumValue struct {
+	Name string `json:"name"`
+}
+
+type introspectionType struct {
+	Name          string                    `json:"name"`
+	Kind          string                    `json:"kind"`
+	Fields        []introspectionField      `json:"fields"`
+	InputFields   []introspectionInputField `json:"inputFields"`
+	PossibleTypes []*introspectionTypeRef   `json:"possibleTypes"`
+	EnumValues    []introspectionEnumValue  `json:"enumValues"`
+}
+
+type introspectionSchema struct {
+	Types []introspectionType `json:"types"`
+}
+
+type introspectionQueryResult struct {
+	Schema introspectionSchema `json:"__schema"`
+}
+
+// mergeTypeRefs takes two types from two different services, makes sure
+// they are compatible, and computes a merged type.
+//
+// Two types are compatible if they are the same besides non-nullable modifiers.
+//
+// The merged type gets non-nullable modifiers depending on how the type is used.
+// For input types, the merged type should be accepted by both services, so it's
+// nullable only if both services accept a nullable type.
+// For output types, the merged type should work for either service, so it's
+// nullable if either service might return null.
+func mergeTypeRefs(a, b *introspectionTypeRef, isInput bool) (*introspectionTypeRef, error) {
+	// If either a or b is non-nil, unwrap it, recurse, and maybe mark the
+	// resulting type as non-nil.
+	aNonNil := false
+	if a.Kind == "NON_NULL" {
+		aNonNil = true
+		a = a.OfType
+	}
+	bNonNil := false
+	if b.Kind == "NON_NULL" {
+		bNonNil = true
+		b = b.OfType
+	}
+	if aNonNil || bNonNil {
+		merged, err := mergeTypeRefs(a, b, isInput)
+		if err != nil {
+			return nil, err
+		}
+
+		// Input types are non-nil if either type is non-nil, as one service will always
+		// want an input. Output types are non-nil if both types are non-nil, as we can
+		// only guarantee non-nil values if both services play along.
+		resultNonNil := isInput || (aNonNil && bNonNil)
+
+		if resultNonNil {
+			return &introspectionTypeRef{Kind: "NON_NULL", OfType: merged}, nil
+		}
+		return merged, nil
+	}
+
+	// Otherwise, recursively assert that the input types are compatible.
+	if a.Kind != b.Kind {
+		return nil, fmt.Errorf("kinds %s and %s differ", a.Name, b.Kind)
+	}
+	switch a.Kind {
+	// Basic types must be identical.
+	case "SCALAR", "ENUM", "INPUT_OBJECT", "UNION", "OBJECT":
+		if a.Name != b.Name {
+			return nil, errors.New("types must be identical")
+		}
+		return &introspectionTypeRef{
+			Kind: a.Kind,
+			Name: a.Name,
+		}, nil
+
+	// Recursive must be compatible but don't have to be identical.
+	case "LIST":
+		inner, err := mergeTypeRefs(a.OfType, b.OfType, isInput)
+		if err != nil {
+			return nil, err
+		}
+		return &introspectionTypeRef{Kind: "LIST", OfType: inner}, nil
+
+	default:
+		return nil, errors.New("unknown type kind")
+	}
+}
+
+// mergeInputFields combines two sets of input fields from two schemas.
+//
+// It checks the types are compabible and takes the union or intersection of the
+// fields depending on the Mergemode
+func mergeInputFields(a, b []introspectionInputField, mode MergeMode) ([]introspectionInputField, error) {
+	types := make(map[string][]introspectionInputField)
+	for _, a := range a {
+		types[a.Name] = append(types[a.Name], a)
+	}
+	for _, b := range b {
+		types[b.Name] = append(types[b.Name], b)
+	}
+	names := make([]string, 0, len(types))
+	for name := range types {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	merged := make([]introspectionInputField, 0, len(names))
+	for _, name := range names {
+		p := types[name]
+		if len(p) == 1 {
+			if p[0].Type.Kind == "NON_NULL" {
+				return nil, fmt.Errorf("new field %s is non-null: %v", name, p[0].Type)
+			}
+			if mode == Union {
+				merged = append(merged, p[0])
+			}
+			continue
+		}
+		m, err := mergeTypeRefs(p[0].Type, p[1].Type, true)
+		if err != nil {
+			return nil, fmt.Errorf("field %s has incompatible types %s and %s: %v", name, p[0].Type, p[1].Type, err)
+		}
+		merged = append(merged, introspectionInputField{
+			Name: name,
+			Type: m,
+		})
+	}
+
+	return merged, nil
+}
+
+func mergeFields(a, b []introspectionField, mode MergeMode) ([]introspectionField, error) {
+	types := make(map[string][]introspectionField)
+	for _, a := range a {
+		types[a.Name] = append(types[a.Name], a)
+	}
+	for _, b := range b {
+		types[b.Name] = append(types[b.Name], b)
+	}
+	names := make([]string, 0, len(types))
+	for name := range types {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	merged := make([]introspectionField, 0, len(names))
+	for _, name := range names {
+		p := types[name]
+		if len(p) == 1 {
+			if mode == Union {
+				merged = append(merged, p[0])
+			}
+			continue
+		}
+
+		typ, err := mergeTypeRefs(p[0].Type, p[1].Type, false)
+		if err != nil {
+			return nil, fmt.Errorf("field %s has incompatible types %v and %v: %v", name, p[0], p[1], err)
+		}
+		args, err := mergeInputFields(p[0].Args, p[1].Args, mode)
+		if err != nil {
+			return nil, fmt.Errorf("field %s has incompatible arguments: %v", name, err)
+		}
+
+		merged = append(merged, introspectionField{
+			Name: name,
+			Type: typ,
+			Args: args,
+		})
+	}
+
+	return merged, nil
+}
+
+func mergePossibleTypes(a, b []*introspectionTypeRef, mode MergeMode) ([]*introspectionTypeRef, error) {
+	types := make(map[string][]*introspectionTypeRef)
+	for _, a := range a {
+		types[a.Name] = append(types[a.Name], a)
+	}
+	for _, b := range b {
+		types[b.Name] = append(types[b.Name], b)
+	}
+	names := make([]string, 0, len(types))
+	for name := range types {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	merged := make([]*introspectionTypeRef, 0, len(names))
+	for _, name := range names {
+		p := types[name]
+		if len(p) == 1 {
+			if mode == Union {
+				merged = append(merged, p[0])
+			}
+			continue
+		}
+
+		merged = append(merged, p[0])
+	}
+
+	return merged, nil
+}
+
+func mergeEnumValues(a, b []introspectionEnumValue, mode MergeMode) ([]introspectionEnumValue, error) {
+	types := make(map[string][]introspectionEnumValue)
+	for _, a := range a {
+		types[a.Name] = append(types[a.Name], a)
+	}
+	for _, b := range b {
+		types[b.Name] = append(types[b.Name], b)
+	}
+	names := make([]string, 0, len(types))
+	for name := range types {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	merged := make([]introspectionEnumValue, 0, len(names))
+	for _, name := range names {
+		p := types[name]
+		if len(p) == 1 {
+			if mode == Union {
+				merged = append(merged, p[0])
+			}
+			continue
+		}
+
+		merged = append(merged, p[0])
+	}
+
+	return merged, nil
+}
+
+func mergeTypes(a, b introspectionType, mode MergeMode) (*introspectionType, error) {
+	if a.Kind != b.Kind {
+		return nil, fmt.Errorf("conflicting kinds %s and %s", a.Kind, b.Kind)
+	}
+
+	merged := introspectionType{
+		Name:          a.Name,
+		Kind:          a.Kind,
+		Fields:        []introspectionField{},
+		InputFields:   []introspectionInputField{},
+		PossibleTypes: []*introspectionTypeRef{},
+		EnumValues:    []introspectionEnumValue{},
+	}
+
+	switch a.Kind {
+	case "INPUT_OBJECT":
+		inputFields, err := mergeInputFields(a.InputFields, b.InputFields, mode)
+		if err != nil {
+			return nil, fmt.Errorf("merging input fields: %v", err)
+		}
+		merged.InputFields = inputFields
+
+	case "OBJECT":
+		fields, err := mergeFields(a.Fields, b.Fields, mode)
+		if err != nil {
+			return nil, fmt.Errorf("merging fields: %v", err)
+		}
+		merged.Fields = fields
+
+	case "UNION":
+		possibleTypes, err := mergePossibleTypes(a.PossibleTypes, b.PossibleTypes, mode)
+		if err != nil {
+			return nil, fmt.Errorf("merging possible types: %v", err)
+		}
+		merged.PossibleTypes = possibleTypes
+
+	case "ENUM":
+		enumValues, err := mergeEnumValues(a.EnumValues, b.EnumValues, mode)
+		if err != nil {
+			return nil, fmt.Errorf("merging enum values: %v", err)
+		}
+		merged.EnumValues = enumValues
+
+	case "SCALAR":
+
+	default:
+		return nil, fmt.Errorf("unknown kind %s", a.Kind)
+	}
+
+	return &merged, nil
+}
+
+func mergeSchemas(a, b *introspectionQueryResult, mode MergeMode) (*introspectionQueryResult, error) {
+	types := make(map[string][]introspectionType)
+	for _, a := range a.Schema.Types {
+		types[a.Name] = append(types[a.Name], a)
+	}
+	for _, b := range b.Schema.Types {
+		types[b.Name] = append(types[b.Name], b)
+	}
+	names := make([]string, 0, len(types))
+	for name := range types {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	merged := make([]introspectionType, 0, len(names))
+	for _, name := range names {
+		p := types[name]
+		if len(p) == 1 {
+			// When intersection only include types that appear in both schemas
+			if mode == Union {
+				merged = append(merged, p[0])
+			}
+			continue
+		}
+		m, err := mergeTypes(p[0], p[1], mode)
+		if err != nil {
+			return nil, fmt.Errorf("can't merge type %s: %v", name, err)
+		}
+		merged = append(merged, *m)
+	}
+
+	return &introspectionQueryResult{
+		Schema: introspectionSchema{
+			Types: merged,
+		},
+	}, nil
+}
+
+func mergeSchemaSlice(schemas []*introspectionQueryResult, mode MergeMode) (*introspectionQueryResult, error) {
+	if len(schemas) == 0 {
+		return nil, errors.New("no schemas")
+	}
+	merged := schemas[0]
+	for _, schema := range schemas[1:] {
+		var err error
+		merged, err = mergeSchemas(merged, schema, mode)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return merged, nil
+}

--- a/federation/schema/normalize.go
+++ b/federation/schema/normalize.go
@@ -1,0 +1,47 @@
+package federation
+
+
+import (
+	"fmt"
+
+	"github.com/samsarahq/thunder/graphql"
+)
+
+// collectTypes finds all types reachable from typ and stores them in types as a map from type to name.
+func collectTypes(typ graphql.Type, types map[graphql.Type]string) error {
+	if _, ok := types[typ]; ok {
+		return nil
+	}
+
+	switch typ := typ.(type) {
+	case *graphql.NonNull:
+		collectTypes(typ.Type, types)
+
+	case *graphql.List:
+		collectTypes(typ.Type, types)
+
+	case *graphql.Object:
+		types[typ] = typ.Name
+
+		for _, field := range typ.Fields {
+			collectTypes(field.Type, types)
+		}
+
+	case *graphql.Union:
+		types[typ] = typ.Name
+		for _, obj := range typ.Types {
+			collectTypes(obj, types)
+		}
+
+	case *graphql.Enum:
+		types[typ] = typ.Type
+
+	case *graphql.Scalar:
+		types[typ] = typ.Type
+
+	default:
+		return fmt.Errorf("bad typ %v", typ)
+	}
+
+	return nil
+}

--- a/federation/schema/schema.go
+++ b/federation/schema/schema.go
@@ -1,0 +1,325 @@
+package federation
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/samsarahq/thunder/graphql"
+)
+
+// serviceSchemas holds all schemas for all of versions of
+// all executors services. It is a map from service name
+// and version to schema.
+type serviceSchemas map[string]map[string]*introspectionQueryResult
+
+// FieldInfo holds federation-specific information for
+// graphql.Fields used to plan and execute queries.
+type FieldInfo struct {
+	// Services is the set of all services that can resolve this
+	// field. If a service has multiple versions, all versions
+	// must be able to resolve the field.
+	Services map[string]bool
+}
+
+// SchemaWithFederationInfo holds a graphql.Schema along with
+// federtion-specific annotations per field.
+type SchemaWithFederationInfo struct {
+	Schema *graphql.Schema
+	// Fields is a map of fields to services which they belong to
+	Fields map[*graphql.Field]*FieldInfo
+}
+
+// convertVersionedSchemas takes schemas for all of versions of
+// all executors services and generates a single merged schema
+// annotated with mapping from field to all services that know
+// how to resolve the field
+func convertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo, error) {
+	serviceNames := make([]string, 0, len(schemas))
+	for service := range schemas {
+		serviceNames = append(serviceNames, service)
+	}
+	sort.Strings(serviceNames)
+
+	serviceSchemasByName := make(map[string]*introspectionQueryResult)
+
+	// Finds the intersection of different version of the schemas
+	var serviceSchemas []*introspectionQueryResult
+	for _, service := range serviceNames {
+		versions := schemas[service]
+
+		versionNames := make([]string, 0, len(versions))
+		for version := range versions {
+			versionNames = append(versionNames, version)
+		}
+		sort.Strings(versionNames)
+
+		var versionSchemas []*introspectionQueryResult
+		for _, version := range versionNames {
+			versionSchemas = append(versionSchemas, versions[version])
+		}
+
+		serviceSchema, err := mergeSchemaSlice(versionSchemas, Intersection)
+		if err != nil {
+			return nil, err
+		}
+
+		serviceSchemasByName[service] = serviceSchema
+
+		serviceSchemas = append(serviceSchemas, serviceSchema)
+	}
+
+	// Finds the union of all the schemas from different executor services
+	merged, err := mergeSchemaSlice(serviceSchemas, Union)
+	if err != nil {
+		return nil, err
+	}
+
+	types, err := parseSchema(merged)
+	if err != nil {
+		return nil, err
+	}
+
+	fieldInfos := make(map[*graphql.Field]*FieldInfo)
+	for _, service := range serviceNames {
+		for _, typ := range serviceSchemasByName[service].Schema.Types {
+			if typ.Kind == "OBJECT" {
+				obj := types[typ.Name].(*graphql.Object)
+
+				for _, field := range typ.Fields {
+					f := obj.Fields[field.Name]
+
+					info, ok := fieldInfos[f]
+					if !ok {
+						info = &FieldInfo{
+							Services: map[string]bool{},
+						}
+						fieldInfos[f] = info
+					}
+					info.Services[service] = true
+				}
+			}
+		}
+	}
+
+	return &SchemaWithFederationInfo{
+		Schema: &graphql.Schema{
+			Query:    types["Query"],
+			Mutation: types["Mutation"],
+		},
+		Fields: fieldInfos,
+	}, nil
+}
+
+// convertSchema annotates the schema with federation information vt
+// mapping fields to the corresponding services.
+func convertSchema(schemas map[string]*introspectionQueryResult) (*SchemaWithFederationInfo, error) {
+	versionedSchemas := make(serviceSchemas)
+	for service, schema := range schemas {
+		versionedSchemas[service] = map[string]*introspectionQueryResult{
+			"": schema,
+		}
+	}
+	return convertVersionedSchemas(versionedSchemas)
+}
+
+// lookupTypeRef maps the a introspected type to a graphql type
+func lookupType(t *introspectionTypeRef, all map[string]graphql.Type) (*introspectionTypeRef, error) {
+	if t == nil {
+		return nil, errors.New("malformed typeref")
+	}
+	switch t.Kind {
+	case "SCALAR", "OBJECT", "UNION", "INPUT_OBJECT", "ENUM":
+		return t, nil
+	case "LIST":
+		return lookupType(t.OfType, all)
+	case "NON_NULL":
+		return lookupType(t.OfType, all)
+	default:
+		return nil, fmt.Errorf("unknown type kind %s", t.Kind)
+	}
+}
+
+// lookupTypeRef maps the a introspected type to a graphql type
+func lookupTypeRef(t *introspectionTypeRef, all map[string]graphql.Type) (graphql.Type, error) {
+	if t == nil {
+		return nil, errors.New("malformed typeref")
+	}
+
+	switch t.Kind {
+	case "SCALAR", "OBJECT", "UNION", "INPUT_OBJECT", "ENUM":
+		// TODO: enforce type?
+		typ, ok := all[t.Name]
+		if !ok {
+			return nil, fmt.Errorf("type %s not found among top-level types", t.Name)
+		}
+		return typ, nil
+
+	case "LIST":
+		inner, err := lookupTypeRef(t.OfType, all)
+		if err != nil {
+			return nil, err
+		}
+		return &graphql.List{
+			Type: inner,
+		}, nil
+
+	case "NON_NULL":
+		inner, err := lookupTypeRef(t.OfType, all)
+		if err != nil {
+			return nil, err
+		}
+		return &graphql.NonNull{
+			Type: inner,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown type kind %s", t.Kind)
+	}
+}
+
+// parseInputFields maps a list of input types to a list of graphql types
+func parseInputFields(source []introspectionInputField, all map[string]graphql.Type) (map[string]graphql.Type, error) {
+	fields := make(map[string]graphql.Type)
+
+	for _, field := range source {
+		// Validate the inputType is valid
+		rawType, err := lookupType(field.Type, all)
+		if err != nil {
+			return nil, fmt.Errorf("type %s not found", rawType.Name)
+		}
+		switch rawType.Kind {
+		case "INPUT_OBJECT", "SCALAR":
+		default:
+			return nil, fmt.Errorf("input field %s has bad typ: %s", field.Name, rawType.Kind)
+		}
+
+		inputType, err := lookupTypeRef(field.Type, all)
+		if err != nil {
+			return nil, fmt.Errorf("field %s has bad typ: %v", field.Name, err)
+		}
+		fields[field.Name] = inputType
+	}
+
+	return fields, nil
+}
+
+// parseSchema takes the introspected schema, validates the types,
+// and maps every field to the graphql types
+func parseSchema(schema *introspectionQueryResult) (map[string]graphql.Type, error) {
+	all := make(map[string]graphql.Type)
+
+	for _, typ := range schema.Schema.Types {
+		if _, ok := all[typ.Name]; ok {
+			return nil, fmt.Errorf("duplicate type %s", typ.Name)
+		}
+
+		switch typ.Kind {
+		case "OBJECT":
+			all[typ.Name] = &graphql.Object{
+				Name: typ.Name,
+			}
+
+		case "INPUT_OBJECT":
+			all[typ.Name] = &graphql.InputObject{
+				Name: typ.Name,
+			}
+
+		case "SCALAR":
+			all[typ.Name] = &graphql.Scalar{
+				Type: typ.Name,
+			}
+
+		case "UNION":
+			all[typ.Name] = &graphql.Union{
+				Name: typ.Name,
+			}
+
+		case "ENUM":
+			all[typ.Name] = &graphql.Enum{
+				Type: typ.Name,
+			}
+
+		default:
+			return nil, fmt.Errorf("unknown type kind %s", typ.Kind)
+		}
+	}
+
+	// Initialize barebone types
+	for _, typ := range schema.Schema.Types {
+		switch typ.Kind {
+		case "OBJECT":
+			fields := make(map[string]*graphql.Field)
+			for _, field := range typ.Fields {
+				fieldTyp, err := lookupTypeRef(field.Type, all)
+				if err != nil {
+					return nil, fmt.Errorf("typ %s field %s has bad typ: %v",
+						typ.Name, field.Name, err)
+				}
+
+				parsed, err := parseInputFields(field.Args, all)
+				if err != nil {
+					return nil, fmt.Errorf("field %s input: %v", field.Name, err)
+				}
+
+				fields[field.Name] = &graphql.Field{
+					Args: parsed,
+					Type: fieldTyp,
+				}
+			}
+
+			all[typ.Name].(*graphql.Object).Fields = fields
+
+		case "INPUT_OBJECT":
+			parsed, err := parseInputFields(typ.InputFields, all)
+			if err != nil {
+				return nil, fmt.Errorf("typ %s: %v", typ.Name, err)
+			}
+
+			all[typ.Name].(*graphql.InputObject).InputFields = parsed
+
+		case "UNION":
+			types := make(map[string]*graphql.Object)
+			for _, other := range typ.PossibleTypes {
+				if other.Kind != "OBJECT" {
+					return nil, fmt.Errorf("typ %s has possible typ not OBJECT: %v", typ.Name, other)
+				}
+				typ, ok := all[other.Name].(*graphql.Object)
+				if !ok {
+					return nil, fmt.Errorf("typ %s possible typ %s does not refer to obj", typ.Name, other.Name)
+				}
+				types[typ.Name] = typ
+			}
+
+			all[typ.Name].(*graphql.Union).Types = types
+
+		case "ENUM":
+			// XXX: introspection relies on the EnumValues map.
+			reverseMap := make(map[interface{}]string)
+			values := make([]string, 0, len(typ.EnumValues))
+			for _, value := range typ.EnumValues {
+				values = append(values, value.Name)
+				reverseMap[value.Name] = value.Name
+			}
+
+			enum := all[typ.Name].(*graphql.Enum)
+			enum.Values = values
+			enum.ReverseMap = reverseMap
+
+		case "SCALAR":
+			// pass
+
+		default:
+			return nil, fmt.Errorf("unknown type kind %s", typ.Kind)
+		}
+	}
+
+	return all, nil
+}
+
+// XXX: for types missing __federation, take intersection?
+
+// XXX: for (merged) unions, make sure we only send possible types
+// to each service
+
+// TODO: support descriptions in merging

--- a/federation/schema/schema_test.go
+++ b/federation/schema/schema_test.go
@@ -1,0 +1,820 @@
+package federation
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/samsarahq/go/snapshotter"
+	"github.com/samsarahq/thunder/graphql"
+	"github.com/samsarahq/thunder/graphql/introspection"
+	"github.com/samsarahq/thunder/graphql/schemabuilder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func extractSchema(t *testing.T, schema *graphql.Schema) *introspectionQueryResult {
+	bytes, err := introspection.RunIntrospectionQuery(introspection.BareIntrospectionSchema(schema))
+	require.NoError(t, err)
+	var iq introspectionQueryResult
+	err = json.Unmarshal(bytes, &iq)
+	require.NoError(t, err)
+	return &iq
+}
+
+func extractSchemas(t *testing.T, schemas map[string]*schemabuilder.Schema) map[string]*introspectionQueryResult {
+	out := make(map[string]*introspectionQueryResult)
+	for k, v := range schemas {
+		out[k] = extractSchema(t, v.MustBuild())
+	}
+	return out
+}
+
+func extractConvertedSchemas(t *testing.T, schemas map[string]*schemabuilder.Schema) *introspectionQueryResult {
+	combined, err := convertSchema(extractSchemas(t, schemas))
+	assert.NoError(t, err)
+	return extractSchema(t, combined.Schema)
+}
+
+func assertSchemaUnionError(t *testing.T, a, b *schemabuilder.Schema, msg string) {
+	_, err := convertSchema(extractSchemas(t, map[string]*schemabuilder.Schema{
+		"schema1": a,
+		"schema2": b,
+	}))
+	assert.EqualError(t, err, msg)
+}
+
+func assertSchemaUnionEq(t *testing.T, a, b, c *schemabuilder.Schema) {
+	combined := extractConvertedSchemas(t, map[string]*schemabuilder.Schema{
+		"schema1": a,
+		"schema2": b,
+	})
+	expected := extractSchema(t, c.MustBuild())
+	assert.Equal(t, expected, combined)
+}
+
+func assertSchemaIntersectionEq(t *testing.T, a, b, c *schemabuilder.Schema) {
+	combined, _ := extractConvertedVersionedSchemas(t, map[string]map[string]*schemabuilder.Schema{
+		"": map[string]*schemabuilder.Schema{
+			"schema1": a,
+			"schema2": b,
+		},
+	})
+	expected := extractSchema(t, c.MustBuild())
+	assert.Equal(t, expected, combined)
+}
+
+
+func getFieldServiceMaps(t *testing.T, s *SchemaWithFederationInfo) map[string][]string {
+	types := make(map[graphql.Type]string)
+	err := collectTypes(s.Schema.Query, types)
+	require.NoError(t, err)
+	err = collectTypes(s.Schema.Mutation, types)
+	require.NoError(t, err)
+
+	fieldServices := make(map[string][]string)
+
+	for typ := range types {
+		obj, ok := typ.(*graphql.Object)
+		if !ok {
+			continue
+		}
+
+		for fieldName, field := range obj.Fields {
+			info, ok := s.Fields[field]
+			if ok {
+				services := make([]string, 0, len(info.Services))
+				for service := range info.Services {
+					services = append(services, service)
+				}
+				sort.Strings(services)
+				name := fmt.Sprintf("%s.%s", obj.Name, fieldName)
+				fieldServices[name] = services
+			}
+		}
+	}
+
+	return fieldServices
+}
+
+func extractConvertedVersionedSchemas(t *testing.T, schemas map[string]map[string]*schemabuilder.Schema) (*introspectionQueryResult, map[string][]string) {
+	builtSchemas := make(serviceSchemas)
+	for service, versions := range schemas {
+		builtSchemas[service] = make(map[string]*introspectionQueryResult)
+		for version, schema := range versions {
+			builtSchemas[service][version] = extractSchema(t, schema.MustBuild())
+		}
+	}
+
+	merged, err := convertVersionedSchemas(builtSchemas)
+	require.NoError(t, err)
+
+	return extractSchema(t, merged.Schema), getFieldServiceMaps(t, merged)
+}
+
+
+func TestBuildSchemaKitchenSink(t *testing.T) {
+	schemas := map[string]*schemabuilder.Schema{
+		"schema1": buildTestSchema1(),
+		"schema2": buildTestSchema2(),
+	}
+
+	types, err := convertSchema(extractSchemas(t, schemas))
+	require.NoError(t, err)
+
+	introspection.AddIntrospectionToSchema(types.Schema)
+	out, err := introspection.RunIntrospectionQuery(types.Schema)
+	require.NoError(t, err)
+
+	var iq introspectionQueryResult
+	err = json.Unmarshal(out, &iq)
+	require.NoError(t, err)
+
+	snapshotter := snapshotter.New(t)
+	defer snapshotter.Verify()
+
+	snapshotter.Snapshot("resulting schema", iq)
+	// XXX: test field -> service mapping
+}
+
+
+
+// TestIncompatibleTypeKinds tests that incompatible types are caught by the
+// schema merging.
+func TestIncompatibleTypeKinds(t *testing.T) {
+	// In s1, int is an object. In s2, int is a scalar. This is not allowed, as
+	// different kinds can not be merged.
+	type IntStruct struct{}
+	s1 := schemabuilder.NewSchema()
+	s1.Object("int", IntStruct{})
+	s1.Query().FieldFunc("intStruct", func() IntStruct { return IntStruct{} })
+
+	s2 := schemabuilder.NewSchema()
+	s2.Query().FieldFunc("intScalar", func() int { return 0 })
+
+	assertSchemaUnionError(t, s1, s2, "can't merge type int: conflicting kinds OBJECT and SCALAR")
+}
+
+// TestIncompatibleInputTypesConflictingTypes tests that incompatible input types
+// are caught by the schema merging.
+func TestIncompatibleInputTypesConflictingTypes(t *testing.T) {
+	s1 := schemabuilder.NewSchema()
+	{
+		type InputStruct struct{ Foo string }
+		s1.Query().FieldFunc("f", func(args struct{ I InputStruct }) string { return "" })
+	}
+
+	s2 := schemabuilder.NewSchema()
+	{
+		type InputStruct struct{ Foo int32 }
+		s2.Query().FieldFunc("f", func(args struct{ I InputStruct }) string { return "" })
+	}
+
+	assertSchemaUnionError(t, s1, s2, "can't merge type InputStruct_InputObject: merging input fields: field foo has incompatible types string! and int32!: types must be identical")
+}
+
+// TestIncompatibleInputTypesMissingNonNullField tests that incompatible input types
+// are caught by the schema merging.
+func TestIncompatibleInputTypesMissingNonNullField(t *testing.T) {
+	s1 := schemabuilder.NewSchema()
+	{
+		type InputStruct struct{ Foo string }
+		s1.Query().FieldFunc("f", func(args struct{ I InputStruct }) string { return "" })
+	}
+
+	s2 := schemabuilder.NewSchema()
+	{
+		type InputStruct struct{}
+		s2.Query().FieldFunc("f", func(args struct{ I InputStruct }) string { return "" })
+	}
+
+	assertSchemaUnionError(t, s1, s2, "can't merge type InputStruct_InputObject: merging input fields: new field foo is non-null: string!")
+}
+
+// TestIncompatibleInputsConflictingTypes tests that incompatible input fields
+// are caught by the schema merging.
+func TestIncompatibleInputsConflictingTypes(t *testing.T) {
+	s1 := schemabuilder.NewSchema()
+	s1.Query().FieldFunc("f", func(args struct{ Foo string }) string { return "" })
+
+	s2 := schemabuilder.NewSchema()
+	s2.Query().FieldFunc("f", func(args struct{ Foo int32 }) string { return "" })
+
+	assertSchemaUnionError(t, s1, s2, "can't merge type Query: merging fields: field f has incompatible arguments: field foo has incompatible types string! and int32!: types must be identical")
+}
+
+// TestMergeNonNilNonNilField tests that a non-nil field combined with a non-nil
+// field is non-nil in the combined schema.
+func TestMergeNonNilNonNilField(t *testing.T) {
+	s1 := schemabuilder.NewSchema()
+	s1.Query().FieldFunc("f", func(args struct{}) string { return "" })
+
+	s2 := schemabuilder.NewSchema()
+	s2.Query().FieldFunc("f", func(args struct{}) string { return "" })
+
+	s3 := schemabuilder.NewSchema()
+	s3.Query().FieldFunc("f", func(args struct{}) string { return "" })
+
+	assertSchemaUnionEq(t, s1, s2, s3)
+}
+
+// TestMergeNonNilNilField tests that a non-nil field combined with a nilable
+// field is nilable in the combined schema.
+func TestMergeNonNilNilField(t *testing.T) {
+	s1 := schemabuilder.NewSchema()
+	s1.Query().FieldFunc("f", func(args struct{}) *string { return nil })
+
+	s2 := schemabuilder.NewSchema()
+	s2.Query().FieldFunc("f", func(args struct{}) string { return "" })
+
+	s3 := schemabuilder.NewSchema()
+	s3.Query().FieldFunc("f", func(args struct{}) *string { return nil })
+
+	assertSchemaUnionEq(t, s1, s2, s3)
+}
+
+// TestMergeNonNilNilArgument tests that a non-nil argument combined with a
+// nilable field is not nilable in the combined schema.
+func TestMergeNonNilNilArgument(t *testing.T) {
+	s1 := schemabuilder.NewSchema()
+	s1.Query().FieldFunc("f", func(args struct{ X string }) string { return "" })
+
+	s2 := schemabuilder.NewSchema()
+	s2.Query().FieldFunc("f", func(args struct{ X *string }) string { return "" })
+
+	s3 := schemabuilder.NewSchema()
+	s3.Query().FieldFunc("f", func(args struct{ X string }) string { return "" })
+
+	assertSchemaUnionEq(t, s1, s2, s3)
+}
+
+// TestIntersectionNewField tests that a new field is not included in the
+// intersection of two schemas.
+func TestIntersectionNewField(t *testing.T) {
+	s1 := schemabuilder.NewSchema()
+	s1.Query().FieldFunc("a", func() string { return "" })
+	s1.Query().FieldFunc("b", func() string { return "" })
+
+	s2 := schemabuilder.NewSchema()
+	s2.Query().FieldFunc("a", func() string { return "" })
+
+	s3 := schemabuilder.NewSchema()
+	s3.Query().FieldFunc("a", func() string { return "" })
+
+	assertSchemaIntersectionEq(t, s1, s2, s3)
+}
+
+// TestMergeUnionUnion tests that merging union types takes the union of their
+// types.
+func TestMergeUnionUnion(t *testing.T) {
+	type Foo struct {
+		Name string
+	}
+	type Bar struct {
+		Id int64
+	}
+	type Baz struct {
+		Address string
+	}
+
+	s1 := schemabuilder.NewSchema()
+	{
+		type Union struct {
+			schemabuilder.Union
+			*Foo
+			*Bar
+		}
+		s1.Query().FieldFunc("f", func() Union { return Union{} })
+	}
+
+	s2 := schemabuilder.NewSchema()
+	{
+		type Union struct {
+			schemabuilder.Union
+			*Foo
+			*Baz
+		}
+		s2.Query().FieldFunc("f", func() Union { return Union{} })
+	}
+
+	s3 := schemabuilder.NewSchema()
+	{
+		type Union struct {
+			schemabuilder.Union
+			*Foo
+			*Bar
+			*Baz
+		}
+		s3.Query().FieldFunc("f", func() Union { return Union{} })
+	}
+
+	assertSchemaUnionEq(t, s1, s2, s3)
+}
+
+// TestMergeUnionIntersection tests that merging union types takes the union of their
+// types.
+func TestMergeUnionIntersection(t *testing.T) {
+	type Foo struct {
+		Name string
+	}
+	type Bar struct {
+		Id int64
+	}
+	type Baz struct {
+		Address string
+	}
+
+	s1 := schemabuilder.NewSchema()
+	{
+		type Union struct {
+			schemabuilder.Union
+			*Foo
+			*Bar
+		}
+		s1.Query().FieldFunc("f", func() Union { return Union{} })
+	}
+
+	s2 := schemabuilder.NewSchema()
+	{
+		type Union struct {
+			schemabuilder.Union
+			*Foo
+			*Baz
+		}
+		s2.Query().FieldFunc("f", func() Union { return Union{} })
+	}
+
+	s3 := schemabuilder.NewSchema()
+	{
+		type Union struct {
+			schemabuilder.Union
+			*Foo
+		}
+		s3.Query().FieldFunc("f", func() Union { return Union{} })
+	}
+
+	assertSchemaIntersectionEq(t, s1, s2, s3)
+}
+
+// TestMergeEnumUnion tests that merging union types takes the union of their
+// values.
+func TestMergeEnumUnion(t *testing.T) {
+	type Enum int32
+
+	s1 := schemabuilder.NewSchema()
+	{
+		s1.Enum(Enum(0), map[string]Enum{
+			"zero": 0,
+			"one":  1,
+		})
+		s1.Query().FieldFunc("f", func() Enum { return Enum(1) })
+	}
+
+	s2 := schemabuilder.NewSchema()
+	{
+		s2.Enum(Enum(0), map[string]Enum{
+			"zero": 0,
+			"two":  2,
+		})
+		s2.Query().FieldFunc("f", func() Enum { return Enum(1) })
+	}
+
+	s3 := schemabuilder.NewSchema()
+	{
+		s3.Enum(Enum(0), map[string]Enum{
+			"zero": 0,
+			"one":  1,
+			"two":  2,
+		})
+		s3.Query().FieldFunc("f", func() Enum { return Enum(1) })
+	}
+
+	assertSchemaUnionEq(t, s1, s2, s3)
+}
+
+// TestMergeEnumIntersection tests that merging union types takes the union of their
+// values.
+func TestMergeEnumIntersection(t *testing.T) {
+	type Enum int32
+
+	s1 := schemabuilder.NewSchema()
+	{
+		s1.Enum(Enum(0), map[string]Enum{
+			"zero": 0,
+			"one":  1,
+		})
+		s1.Query().FieldFunc("f", func() Enum { return Enum(1) })
+	}
+
+	s2 := schemabuilder.NewSchema()
+	{
+		s2.Enum(Enum(0), map[string]Enum{
+			"zero": 0,
+			"two":  2,
+		})
+		s2.Query().FieldFunc("f", func() Enum { return Enum(1) })
+	}
+
+	s3 := schemabuilder.NewSchema()
+	{
+		s3.Enum(Enum(0), map[string]Enum{
+			"zero": 0,
+		})
+		s3.Query().FieldFunc("f", func() Enum { return Enum(1) })
+	}
+
+	assertSchemaIntersectionEq(t, s1, s2, s3)
+}
+
+// TestSchemaMoveField tests that moving a field from one service to another
+// over the course of two deploys behaves sanely.
+func TestSchemaMoveField(t *testing.T) {
+	// In this test, a field "a" move from service s1 to service s2. At the
+	// start, only s1 has the field. Then we deploy it to s2, let that deploy
+	// stabilize, remove it from s1, and let that deploy stabilize.
+
+	// s1old has the field.
+	s1old := schemabuilder.NewSchema()
+	s1old.Query().FieldFunc("a", func() string { return "" })
+
+	// s1new does not.
+	s1new := schemabuilder.NewSchema()
+
+	// s2old does not have the field.
+	s2old := schemabuilder.NewSchema()
+
+	// s2new does.
+	s2new := schemabuilder.NewSchema()
+	s2new.Query().FieldFunc("a", func() string { return "" })
+
+	// both has the field. This is what the final schema always should look
+	// like.
+	both := schemabuilder.NewSchema()
+	both.Query().FieldFunc("a", func() string { return "" })
+	expected := extractSchema(t, both.MustBuild())
+
+	// Initial state, s1 has field a.
+	combined, fieldServices := extractConvertedVersionedSchemas(t, map[string]map[string]*schemabuilder.Schema{
+		"s1": map[string]*schemabuilder.Schema{
+			"old": s1old,
+		},
+		"s2": map[string]*schemabuilder.Schema{
+			"old": s2old,
+		},
+	})
+	assert.Equal(t, expected, combined)
+	assert.Equal(t, map[string][]string{
+		"Query.a": []string{"s1"},
+	}, fieldServices)
+
+	// Add field to s2. Should still only route to s1.
+	combined, fieldServices = extractConvertedVersionedSchemas(t, map[string]map[string]*schemabuilder.Schema{
+		"s1": map[string]*schemabuilder.Schema{
+			"old": s1old,
+		},
+		"s2": map[string]*schemabuilder.Schema{
+			"old": s2old,
+			"new": s2new,
+		},
+	})
+	assert.Equal(t, expected, combined)
+	assert.Equal(t, map[string][]string{
+		"Query.a": []string{"s1"},
+	}, fieldServices)
+
+	// Let s2 stabilize. Should now route to both.
+	combined, fieldServices = extractConvertedVersionedSchemas(t, map[string]map[string]*schemabuilder.Schema{
+		"s1": map[string]*schemabuilder.Schema{
+			"old": s1old,
+		},
+		"s2": map[string]*schemabuilder.Schema{
+			"new": s2new,
+		},
+	})
+	assert.Equal(t, expected, combined)
+	assert.Equal(t, map[string][]string{
+		"Query.a": []string{"s1", "s2"},
+	}, fieldServices)
+
+	// Remove from s1. Should route to only s2.
+	combined, fieldServices = extractConvertedVersionedSchemas(t, map[string]map[string]*schemabuilder.Schema{
+		"s1": map[string]*schemabuilder.Schema{
+			"old": s1old,
+			"new": s1new,
+		},
+		"s2": map[string]*schemabuilder.Schema{
+			"new": s2new,
+		},
+	})
+	assert.Equal(t, expected, combined)
+	assert.Equal(t, map[string][]string{
+		"Query.a": []string{"s2"},
+	}, fieldServices)
+
+	// Let s1 stabilize. Should still route s2.
+	combined, fieldServices = extractConvertedVersionedSchemas(t, map[string]map[string]*schemabuilder.Schema{
+		"s1": map[string]*schemabuilder.Schema{
+			"new": s1new,
+		},
+		"s2": map[string]*schemabuilder.Schema{
+			"new": s2new,
+		},
+	})
+	assert.Equal(t, expected, combined)
+	assert.Equal(t, map[string][]string{
+		"Query.a": []string{"s2"},
+	}, fieldServices)
+}
+
+// TestSchemaAddField tests adding a new field to a service.
+func TestSchemaAddField(t *testing.T) {
+	// In this test, a field "b" is added to service s1.
+
+	// s1old has a field "a".
+	s1old := schemabuilder.NewSchema()
+	s1old.Query().FieldFunc("a", func() string { return "" })
+
+	// s1new has both "a" and "b".
+	s1new := schemabuilder.NewSchema()
+	s1new.Query().FieldFunc("a", func() string { return "" })
+	s1new.Query().FieldFunc("b", func() string { return "" })
+
+	// s2 has a field "c".
+	s2 := schemabuilder.NewSchema()
+	s2.Query().FieldFunc("c", func() string { return "" })
+
+	// before has "a" and "c".
+	before := schemabuilder.NewSchema()
+	before.Query().FieldFunc("a", func() string { return "" })
+	before.Query().FieldFunc("c", func() string { return "" })
+	builtBefore := extractSchema(t, before.MustBuild())
+
+	// after has "a", "b", and "c".
+	after := schemabuilder.NewSchema()
+	after.Query().FieldFunc("a", func() string { return "" })
+	after.Query().FieldFunc("b", func() string { return "" })
+	after.Query().FieldFunc("c", func() string { return "" })
+	builtAfter := extractSchema(t, after.MustBuild())
+
+	// Initial state, s1 has field a and s2 has field c.
+	combined, fieldServices := extractConvertedVersionedSchemas(t, map[string]map[string]*schemabuilder.Schema{
+		"s1": map[string]*schemabuilder.Schema{
+			"old": s1old,
+		},
+		"s2": map[string]*schemabuilder.Schema{
+			"only": s2,
+		},
+	})
+	assert.Equal(t, builtBefore, combined)
+	assert.Equal(t, map[string][]string{
+		"Query.a": []string{"s1"},
+		"Query.c": []string{"s2"},
+	}, fieldServices)
+
+	// Add field b to s1. Should not yet be exposed in schema.
+	combined, fieldServices = extractConvertedVersionedSchemas(t, map[string]map[string]*schemabuilder.Schema{
+		"s1": map[string]*schemabuilder.Schema{
+			"old": s1old,
+			"new": s1new,
+		},
+		"s2": map[string]*schemabuilder.Schema{
+			"only": s2,
+		},
+	})
+	assert.Equal(t, builtBefore, combined)
+	assert.Equal(t, map[string][]string{
+		"Query.a": []string{"s1"},
+		"Query.c": []string{"s2"},
+	}, fieldServices)
+
+	// Let s1 stabilize. New field should now be visible.
+	combined, fieldServices = extractConvertedVersionedSchemas(t, map[string]map[string]*schemabuilder.Schema{
+		"s1": map[string]*schemabuilder.Schema{
+			"new": s1new,
+		},
+		"s2": map[string]*schemabuilder.Schema{
+			"only": s2,
+		},
+	})
+	assert.Equal(t, builtAfter, combined)
+	assert.Equal(t, map[string][]string{
+		"Query.a": []string{"s1"},
+		"Query.b": []string{"s1"},
+		"Query.c": []string{"s2"},
+	}, fieldServices)
+}
+
+// TestSchemaRemoveField tests removing an existing field from a service.
+func TestSchemaRemoveField(t *testing.T) {
+	// In this test, a field "a" is removed from service s1.
+
+	// s1old has a field "a".
+	s1old := schemabuilder.NewSchema()
+	s1old.Query().FieldFunc("a", func() string { return "" })
+
+	// s1new has no field.
+	s1new := schemabuilder.NewSchema()
+
+	// s2 has a field "b".
+	s2 := schemabuilder.NewSchema()
+	s2.Query().FieldFunc("b", func() string { return "" })
+
+	// before has "a" and "b".
+	before := schemabuilder.NewSchema()
+	before.Query().FieldFunc("a", func() string { return "" })
+	before.Query().FieldFunc("b", func() string { return "" })
+	builtBefore := extractSchema(t, before.MustBuild())
+
+	// after has "b".
+	after := schemabuilder.NewSchema()
+	after.Query().FieldFunc("b", func() string { return "" })
+	builtAfter := extractSchema(t, after.MustBuild())
+
+	// Initial state, s1 has field a and s2 has field b.
+	combined, fieldServices := extractConvertedVersionedSchemas(t, map[string]map[string]*schemabuilder.Schema{
+		"s1": map[string]*schemabuilder.Schema{
+			"old": s1old,
+		},
+		"s2": map[string]*schemabuilder.Schema{
+			"only": s2,
+		},
+	})
+	assert.Equal(t, builtBefore, combined)
+	assert.Equal(t, map[string][]string{
+		"Query.a": []string{"s1"},
+		"Query.b": []string{"s2"},
+	}, fieldServices)
+
+	// Remove field from s1. Should immediately disappear from schema.
+	combined, fieldServices = extractConvertedVersionedSchemas(t, map[string]map[string]*schemabuilder.Schema{
+		"s1": map[string]*schemabuilder.Schema{
+			"old": s1old,
+			"new": s1new,
+		},
+		"s2": map[string]*schemabuilder.Schema{
+			"only": s2,
+		},
+	})
+	assert.Equal(t, builtAfter, combined)
+	assert.Equal(t, map[string][]string{
+		"Query.b": []string{"s2"},
+	}, fieldServices)
+
+	// Let s1 stabilize.
+	combined, fieldServices = extractConvertedVersionedSchemas(t, map[string]map[string]*schemabuilder.Schema{
+		"s1": map[string]*schemabuilder.Schema{
+			"new": s1new,
+		},
+		"s2": map[string]*schemabuilder.Schema{
+			"only": s2,
+		},
+	})
+	assert.Equal(t, builtAfter, combined)
+	assert.Equal(t, map[string][]string{
+		"Query.b": []string{"s2"},
+	}, fieldServices)
+}
+
+func buildTestSchemaFoo() *schemabuilder.Schema {
+	schema := schemabuilder.NewSchema()
+	query := schema.Query()
+	foo := schema.Object("foo", Foo{})
+	foo.Key("name")
+	query.FieldFunc("name", func() *Foo {
+		return &Foo{
+			Name: "jim",
+		}
+	})
+
+	mutation := schema.Mutation()
+	mutation.FieldFunc("addName", func(args struct{ Name string }) *Foo {
+		return &Foo{
+			Name: args.Name,
+		}
+	})
+
+	return schema
+}
+
+func buildTestSchemaBar() *schemabuilder.Schema {
+	schema := schemabuilder.NewSchema()
+	bar := schema.Object("bar", Bar{})
+	bar.Key("id")
+	query := schema.Query()
+	query.FieldFunc("id", func() *Bar {
+		return &Bar{
+			Id: int64(1),
+		}
+	})
+	mutation := schema.Mutation()
+	mutation.FieldFunc("addId", func(args struct{ Id int64 }) *Bar {
+		return &Bar{
+			Id: args.Id,
+		}
+	})
+	return schema
+}
+
+
+func TestBuildSchema(t *testing.T) {
+	schemas := map[string]*schemabuilder.Schema{
+		"schema1": buildTestSchemaFoo(),
+		"schema2": buildTestSchemaBar(),
+	}
+
+
+	types, err := convertSchema(extractSchemas(t, schemas))
+	require.NoError(t, err)
+
+	introspection.AddIntrospectionToSchema(types.Schema)
+	out, err := introspection.RunIntrospectionQuery(types.Schema)
+	require.NoError(t, err)
+
+	var iq introspectionQueryResult
+	err = json.Unmarshal(out, &iq)
+	require.NoError(t, err)
+	fmt.Println(iq)
+}
+
+// TestSchemaUnionInputFields merges two schemas, getting the union of two sets of input fields
+func TestSchemaUnionInputFields(t *testing.T) {
+	type User struct {
+		Id int64
+	}
+	s1 := schemabuilder.NewSchema()
+	user := s1.Object("user", User{})
+	user.Key("id")
+	user.FieldFunc("id", func(user *User) int64 {
+		return user.Id
+	})
+	q := s1.Query()
+	q.FieldFunc("user", func(args struct{ Id int64; Number1 *int64 }) *User {
+		return &User{
+			Id: args.Id,
+		}
+	})
+
+	s2 := schemabuilder.NewSchema()
+	user2 := s2.Object("user", User{})
+	user2.Key("id")
+	user2.FieldFunc("id", func(user *User) int64 {
+		return user.Id
+	})
+	q2 := s2.Query()
+	q2.FieldFunc("user", func(args struct{ Id int64; Number2 *int64 }) *User {
+		return &User{
+			Id: args.Id,
+		}
+	})
+
+	s3 := schemabuilder.NewSchema()
+	user3 := s3.Object("user", User{})
+	user3.Key("id")
+	user3.FieldFunc("id", func(user *User) int64 {
+		return user.Id
+	})
+	q3 := s3.Query()
+	q3.FieldFunc("user", func(args struct{ Id int64; Number1 *int64; Number2 *int64 }) *User {
+		return &User{
+			Id: int64(1),
+		}
+	})
+	assertSchemaUnionEq(t, s1, s2, s3)
+}
+
+
+// TestSchemaIntersectionInputFields merges two schemas, getting the intersection of two sets of input fields
+func TestSchemaIntersectionInputFields(t *testing.T) {
+	type User struct {
+		Id int64
+	}
+
+	s1 := schemabuilder.NewSchema()
+	user := s1.Object("user", User{})
+	user.Key("id")
+	user.FieldFunc("id", func(user *User) int64 {
+		return user.Id
+	})
+	q := s1.Query()
+	q.FieldFunc("user", func(args struct{ Id int64}) *User {
+		return &User{
+			Id: args.Id,
+		}
+	})
+
+	s2 := schemabuilder.NewSchema()
+	user2 := s2.Object("user", User{})
+	user2.Key("id")
+	user2.FieldFunc("id", func(user *User) int64 {
+		return user.Id
+	})
+	q2 := s2.Query()
+	q2.FieldFunc("user", func(args struct{ Id int64; Number *int64 }) *User {
+		return &User{
+			Id: args.Id,
+		}
+	})
+	assertSchemaIntersectionEq(t, s1, s2, s1)
+}
+

--- a/federation/schema/testdata/TestBuildSchemaKitchenSink.snapshots.json
+++ b/federation/schema/testdata/TestBuildSchemaKitchenSink.snapshots.json
@@ -1,0 +1,331 @@
+[
+  {
+    "Name": "resulting schema",
+    "Values": [
+      {
+        "__schema": {
+          "types": [
+            {
+              "enumValues": [],
+              "fields": [
+                {
+                  "args": [],
+                  "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "int64",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "args": [],
+                  "name": "s1baz",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "string",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "inputFields": [],
+              "kind": "OBJECT",
+              "name": "Bar",
+              "possibleTypes": []
+            },
+            {
+              "enumValues": [
+                {
+                  "name": "one"
+                }
+              ],
+              "fields": [],
+              "inputFields": [],
+              "kind": "ENUM",
+              "name": "Enum",
+              "possibleTypes": []
+            },
+            {
+              "enumValues": [],
+              "fields": [
+                {
+                  "args": [],
+                  "name": "name",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "string",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "args": [],
+                  "name": "s1enum",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Enum",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "args": [],
+                  "name": "s1hmm",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                },
+                {
+                  "args": [],
+                  "name": "s1nest",
+                  "type": {
+                    "kind": "OBJECT",
+                    "name": "Foo",
+                    "ofType": null
+                  }
+                }
+              ],
+              "inputFields": [],
+              "kind": "OBJECT",
+              "name": "Foo",
+              "possibleTypes": []
+            },
+            {
+              "enumValues": [],
+              "fields": [],
+              "inputFields": [],
+              "kind": "UNION",
+              "name": "FooOrBar",
+              "possibleTypes": [
+                {
+                  "kind": "OBJECT",
+                  "name": "Bar",
+                  "ofType": null
+                },
+                {
+                  "kind": "OBJECT",
+                  "name": "Foo",
+                  "ofType": null
+                }
+              ]
+            },
+            {
+              "enumValues": [],
+              "fields": [
+                {
+                  "args": [
+                    {
+                      "name": "name",
+                      "type": {
+                        "kind": "NON_NULL",
+                        "name": "",
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "string",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  ],
+                  "name": "s1addFoo",
+                  "type": {
+                    "kind": "OBJECT",
+                    "name": "Foo",
+                    "ofType": null
+                  }
+                }
+              ],
+              "inputFields": [],
+              "kind": "OBJECT",
+              "name": "Mutation",
+              "possibleTypes": []
+            },
+            {
+              "enumValues": [],
+              "fields": [],
+              "inputFields": [
+                {
+                  "name": "a",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "int64",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "name": "b",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "int64",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "kind": "INPUT_OBJECT",
+              "name": "Pair_InputObject",
+              "possibleTypes": []
+            },
+            {
+              "enumValues": [],
+              "fields": [
+                {
+                  "args": [],
+                  "name": "s1both",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": "",
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": "",
+                        "ofType": {
+                          "kind": "UNION",
+                          "name": "FooOrBar",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "args": [
+                    {
+                      "name": "foo",
+                      "type": {
+                        "kind": "NON_NULL",
+                        "name": "",
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "string",
+                          "ofType": null
+                        }
+                      }
+                    },
+                    {
+                      "name": "optional",
+                      "type": {
+                        "kind": "SCALAR",
+                        "name": "int64",
+                        "ofType": null
+                      }
+                    },
+                    {
+                      "name": "required",
+                      "type": {
+                        "kind": "NON_NULL",
+                        "name": "",
+                        "ofType": {
+                          "kind": "INPUT_OBJECT",
+                          "name": "Pair_InputObject",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  ],
+                  "name": "s1echo",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "string",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "args": [],
+                  "name": "s1f",
+                  "type": {
+                    "kind": "OBJECT",
+                    "name": "Foo",
+                    "ofType": null
+                  }
+                },
+                {
+                  "args": [],
+                  "name": "s1fff",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": "",
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": "",
+                        "ofType": {
+                          "kind": "OBJECT",
+                          "name": "Foo",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "args": [],
+                  "name": "s2root",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "string",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "inputFields": [],
+              "kind": "OBJECT",
+              "name": "Query",
+              "possibleTypes": []
+            },
+            {
+              "enumValues": [],
+              "fields": [],
+              "inputFields": [],
+              "kind": "SCALAR",
+              "name": "int64",
+              "possibleTypes": []
+            },
+            {
+              "enumValues": [],
+              "fields": [],
+              "inputFields": [],
+              "kind": "SCALAR",
+              "name": "string",
+              "possibleTypes": []
+            }
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -344,7 +344,7 @@ func (s *introspection) schema() *graphql.Schema {
 	return schema.MustBuild()
 }
 
-func AddIntrospectionToSchema(schema *graphql.Schema) {
+func BareIntrospectionSchema(schema *graphql.Schema) *graphql.Schema {
 	types := make(map[string]graphql.Type)
 	collectTypes(schema.Query, types)
 	collectTypes(schema.Mutation, types)
@@ -353,8 +353,11 @@ func AddIntrospectionToSchema(schema *graphql.Schema) {
 		query:    schema.Query,
 		mutation: schema.Mutation,
 	}
-	isSchema := is.schema()
+	return is.schema()
+}
 
+func AddIntrospectionToSchema(schema *graphql.Schema) {
+	isSchema := BareIntrospectionSchema(schema)
 	query := schema.Query.(*graphql.Object)
 
 	isQuery := isSchema.Query.(*graphql.Object)
@@ -370,7 +373,12 @@ func AddIntrospectionToSchema(schema *graphql.Schema) {
 func ComputeSchemaJSON(schemaBuilderSchema schemabuilder.Schema) ([]byte, error) {
 	schema := schemaBuilderSchema.MustBuild()
 	AddIntrospectionToSchema(schema)
+	return RunIntrospectionQuery(schema)
+}
 
+// RunIntrospectionQuery returns the result of executing a GraphQL introspection
+// query.
+func RunIntrospectionQuery(schema *graphql.Schema) ([]byte, error) {
 	query, err := graphql.Parse(introspectionQuery, map[string]interface{}{})
 	if err != nil {
 		return nil, err

--- a/graphql/schemabuilder/schema.go
+++ b/graphql/schemabuilder/schema.go
@@ -137,6 +137,9 @@ func (s *Schema) Build() (*graphql.Schema, error) {
 		typeCache:    make(map[reflect.Type]cachedType, 0),
 	}
 
+	s.Object("Query", query{})
+	s.Object("Mutation", mutation{})
+
 	for _, object := range s.objects {
 		typ := reflect.TypeOf(object.Type)
 		if typ.Kind() != reflect.Struct {


### PR DESCRIPTION
Federation Part 1: Schema Merging

Merging between versions (intersection)
During an update to a new version, we want to have a version of the schema that is compatible with both schemas. In this case, we want to get the intersection between the two schemas so that we know what we are running is compatible with both schemas. 

Merging between schemas (union)
The gateway needs to be able to take all the schemas from separate servers and generate a merged version that is compatible with all schemas and annotated with federation info (ie which server has which field func) so that it can generate a query plan 
