### PR TITLE
go graphql/server: Close Mutation subscription after execution

### DIFF
--- a/graphql/server.go
+++ b/graphql/server.go
@@ -349,6 +349,7 @@ func (c *conn) handleMutate(in *inEnvelope) error {
 		go c.rerunSubscriptionsImmediately()
 
 		initial = false
+		go c.closeSubscription(id)
 		return nil, errors.New("stop")
 	}, c.minRerunIntervalFunc(c.ctx, query), c.alwaysSpawnGoroutineFunc(c.ctx, query))
 


### PR DESCRIPTION
Summary: Noticed this as a memory leak when we would upload a lot of
images through mutation endpoints.  The subscriptions for mutations are
never cleaned up, and the memory from the request (an image) would
remain in-memory until we'd kill the websocket connection.

Tested this by uploading a bunch of images and monitoring the heap usage.

Before change:
<img width="1540" alt="Screen Shot 2020-02-25 at 5 14 36 PM" src="https://user-images.githubusercontent.com/613317/75302620-2fde7900-57f3-11ea-9524-1fa7c6160a5c.png">
After change:
<img width="1543" alt="Screen Shot 2020-02-25 at 5 17 14 PM" src="https://user-images.githubusercontent.com/613317/75302628-353bc380-57f3-11ea-9219-aff26ca6eb7d.png">
(you can't even see the spike, we miss it)