### PR TITLE
sqlgen: add `UpdateRowWithResult` to `DB` interface

### DIFF
--- a/internal/integrationtest/helpers.go
+++ b/internal/integrationtest/helpers.go
@@ -18,6 +18,7 @@ type DB interface {
 	InsertRow(ctx context.Context, row interface{}) (sql.Result, error)
 	UpsertRow(ctx context.Context, row interface{}) (sql.Result, error)
 	UpdateRow(ctx context.Context, row interface{}) error
+	UpdateRowWithResult(ctx context.Context, row interface{}) (sql.Result, error)
 	DeleteRow(ctx context.Context, row interface{}) error
 }
 

--- a/internal/integrationtest/implicitnull_test.go
+++ b/internal/integrationtest/implicitnull_test.go
@@ -240,9 +240,18 @@ func TestImplicitNullUpdate(t *testing.T) {
 					}
 
 					tt.giveUpdate.Id = 1
-					if err := db.UpdateRow(ctx, tt.giveUpdate); err != nil {
+					result, err := db.UpdateRowWithResult(ctx, tt.giveUpdate)
+					if err != nil {
 						t.Error(err)
 					}
+
+					rowsAffected, err := result.RowsAffected()
+
+					if err != nil {
+						t.Error(err)
+					}
+
+					require.Equal(t, rowsAffected, int64(1))
 
 					for _, field := range tt.wantNullFields {
 						assertFieldIsNull(t, sqlDB, field)

--- a/sqlgen/db.go
+++ b/sqlgen/db.go
@@ -389,9 +389,26 @@ func (db *DB) UpsertRow(ctx context.Context, row interface{}) (sql.Result, error
 //   if err := db.UpdateRow(ctx, user); err != nil {
 //
 func (db *DB) UpdateRow(ctx context.Context, row interface{}) error {
+	_, err := db.updateRowWithResult(ctx, row)
+	return err
+}
+
+// UpdateRowWithResult updates a single row in the database, identified by the row's primary key
+//
+// row should be a pointer to a struct, for example:
+//
+//   user := &User{Id; 10, Name: "bar"}
+//   if result, err := db.UpdateRowWithResult(ctx, user); err != nil {
+//
+// It is identical to UpdateRow, but returns an sql.Result as well.
+func (db *DB) UpdateRowWithResult(ctx context.Context, row interface{}) (sql.Result, error) {
+	return db.updateRowWithResult(ctx, row)
+}
+
+func (db *DB) updateRowWithResult(ctx context.Context, row interface{}) (sql.Result, error) {
 	query, err := db.Schema.MakeUpdateRow(row)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := db.checkColumnValuesAgainstLimits(
@@ -399,11 +416,11 @@ func (db *DB) UpdateRow(ctx context.Context, row interface{}) error {
 		query,
 		append(query.Where.Columns, query.Columns...),
 		append(query.Where.Values, query.Values...), query.Table); err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = db.execWithTrace(ctx, query, "UpsertRow")
-	return err
+	res, err := db.execWithTrace(ctx, query, "UpdateRow")
+	return res, err
 }
 
 // DeleteRow deletes a single row from the database, identified by the row's primary key


### PR DESCRIPTION
As a user of `sqlgen`, I'd like to be able to control code-flow in
certain cases where the number of rows updated is zero. `UpdateRow`
doesn't expose the `sql.Result` returned by `execWithTrace`, so this
information is available to be exported by refactoring the logic in
`UpdateRow` into an unexported function, and using said function in
`UpdateRow` and the new function, `UpdateRowWithResult` to reduce code
duplication.