### PR TITLE
Fix a bug where directive on fragment selection has no effect.

### DIFF
--- a/graphql/batch_executor.go
+++ b/graphql/batch_executor.go
@@ -116,7 +116,10 @@ func (e *Executor) Execute(ctx context.Context, typ Type, source interface{}, qu
 		return nil, fmt.Errorf("expected query or mutation object for execution, got: %s", typ.String())
 	}
 
-	topLevelSelections := Flatten(query.SelectionSet)
+	topLevelSelections, err := Flatten(query.SelectionSet)
+	if err != nil {
+		return nil, err
+	}
 	topLevelRespWriter := newTopLevelOutputNode(query.Name)
 	initialSelectionWorkUnits := make([]*WorkUnit, 0, len(topLevelSelections))
 	writers := make(map[string]*outputNode)
@@ -411,7 +414,10 @@ func resolveUnionBatch(ctx context.Context, sources []interface{}, typ *Union, s
 // Traverses the object selections and resolves or creates work units to resolve
 // all of the object fields for every source passed in.
 func resolveObjectBatch(ctx context.Context, sources []interface{}, typ *Object, selectionSet *SelectionSet, destinations []*outputNode) ([]*WorkUnit, error) {
-	selections := Flatten(selectionSet)
+	selections, err := Flatten(selectionSet)
+	if err != nil {
+		return nil, err
+	}
 	numExpensive := 0
 	numNonExpensive := 0
 	for _, selection := range selections {

--- a/graphql/executor_test.go
+++ b/graphql/executor_test.go
@@ -205,6 +205,41 @@ func TestFlatten(t *testing.T) {
 	type Args struct {
 		Value int
 	}
+	result, err := graphql.Flatten(&graphql.SelectionSet{
+		Selections: []*graphql.Selection{
+			{
+				Name:  "a",
+				Alias: "b",
+				Args: &Args{
+					Value: 2,
+				},
+				ParentType: "Query",
+				SelectionSet: &graphql.SelectionSet{
+					Selections: []*graphql.Selection{{
+						Name:         "foo",
+						UnparsedArgs: map[string]interface{}{},
+						ParentType:   "A",
+					}},
+				},
+			},
+			{
+				Name:  "a",
+				Alias: "b",
+				Args: &Args{
+					Value: 2,
+				},
+				ParentType: "Query",
+				SelectionSet: &graphql.SelectionSet{
+					Selections: []*graphql.Selection{{
+						Name:         "foo",
+						UnparsedArgs: map[string]interface{}{},
+						ParentType:   "A",
+					}},
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
 
 	assert.Equal(t,
 		[]*graphql.Selection{
@@ -229,41 +264,8 @@ func TestFlatten(t *testing.T) {
 					}},
 				},
 			},
-		},
-		graphql.Flatten(&graphql.SelectionSet{
-			Selections: []*graphql.Selection{
-				{
-					Name:  "a",
-					Alias: "b",
-					Args: &Args{
-						Value: 2,
-					},
-					ParentType: "Query",
-					SelectionSet: &graphql.SelectionSet{
-						Selections: []*graphql.Selection{{
-							Name:         "foo",
-							UnparsedArgs: map[string]interface{}{},
-							ParentType:   "A",
-						}},
-					},
-				},
-				{
-					Name:  "a",
-					Alias: "b",
-					Args: &Args{
-						Value: 2,
-					},
-					ParentType: "Query",
-					SelectionSet: &graphql.SelectionSet{
-						Selections: []*graphql.Selection{{
-							Name:         "foo",
-							UnparsedArgs: map[string]interface{}{},
-							ParentType:   "A",
-						}},
-					},
-				},
-			},
-		}))
+		}, result,
+	)
 }
 
 /*

--- a/graphql/testdata/TestDirectivesWithFragments.snapshots.json
+++ b/graphql/testdata/TestDirectivesWithFragments.snapshots.json
@@ -1,12 +1,104 @@
 [
   {
-    "Name": "batchExecutor:Directive with fragment on top level",
+    "Name": "batchExecutor:Directive with fragment on top level, skip true",
     "Values": [
       {}
     ]
   },
   {
-    "Name": "batchExecutor:Directive with fragment nested",
+    "Name": "batchExecutor:Directive with fragment nested, skip true",
+    "Values": [
+      {
+        "items": [
+          {
+            "__key": 1,
+            "id": 1
+          },
+          {
+            "__key": 2,
+            "id": 2
+          },
+          {
+            "__key": 3,
+            "id": 3
+          },
+          {
+            "__key": 4,
+            "id": 4
+          },
+          {
+            "__key": 5,
+            "id": 5
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "batchExecutor:Directive on fragment selection, skip true",
+    "Values": [
+      {
+        "items": [
+          {
+            "__key": 1,
+            "id": 1
+          },
+          {
+            "__key": 2,
+            "id": 2
+          },
+          {
+            "__key": 3,
+            "id": 3
+          },
+          {
+            "__key": 4,
+            "id": 4
+          },
+          {
+            "__key": 5,
+            "id": 5
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "batchExecutor:Directive on both fragment(include true) and fragment selection(include false)",
+    "Values": [
+      {
+        "items": [
+          {
+            "__key": 1,
+            "id": 1,
+            "number": "\u000b"
+          },
+          {
+            "__key": 2,
+            "id": 2,
+            "number": "\u000c"
+          },
+          {
+            "__key": 3,
+            "id": 3,
+            "number": "\r"
+          },
+          {
+            "__key": 4,
+            "id": 4,
+            "number": "\u000e"
+          },
+          {
+            "__key": 5,
+            "id": 5,
+            "number": "\u000f"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "batchExecutor:Directive on both fragment(include false) and fragment selection(include true)",
     "Values": [
       {
         "items": [


### PR DESCRIPTION
We have verified the directive does not work on the following query.
query {
	items {
		id
		...X
	}
}
fragment X on Item {
	name @skip(if: true)
}`

This commit fixes the bug.