### PR TITLE
graphql introspection: make @include and @skip directive if non-null

### DIFF
--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -100,7 +100,7 @@ var includeDirective = Directive{
 	Args: []InputValue{
 		InputValue{
 			Name:        "if",
-			Type:        Type{Inner: &graphql.Scalar{Type: "bool"}},
+			Type:        Type{Inner: &graphql.NonNull{Type: &graphql.Scalar{Type: "bool"}}},
 			Description: "Included when true.",
 		},
 	},
@@ -117,12 +117,11 @@ var skipDirective = Directive{
 	Args: []InputValue{
 		InputValue{
 			Name:        "if",
-			Type:        Type{Inner: &graphql.Scalar{Type: "bool"}},
+			Type:        Type{Inner: &graphql.NonNull{Type: &graphql.Scalar{Type: "bool"}}},
 			Description: "Skipped when true.",
 		},
 	},
 }
-
 
 func (s *introspection) registerType(schema *schemabuilder.Schema) {
 	object := schema.Object("__Type", Type{})

--- a/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
+++ b/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
@@ -12,9 +12,13 @@
                   "description": "Included when true.",
                   "name": "if",
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "bool",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "bool",
+                      "ofType": null
+                    }
                   }
                 }
               ],
@@ -33,9 +37,13 @@
                   "description": "Skipped when true.",
                   "name": "if",
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "bool",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "bool",
+                      "ofType": null
+                    }
                   }
                 }
               ],


### PR DESCRIPTION
To conform to the graphql spec, the @include and @skip directives should
take in a Boolean!, not a Boolean.

This fixes a behavior where we were incorrectly reporting the schema for
these directives as nullable, which would cause clients that used that
schema for type generation to believe that they could pass in null.

If null was passed in, this would cause an entire query to fail.

This is a a backwards-incompatible change for clients using the
generated schema, but is being made as it conforms to the graphql spec.

https://spec.graphql.org/June2018/#sec--skip
https://spec.graphql.org/June2018/#sec--include