### PR TITLE
Federated Executor Without Nested service calls

### DIFF
--- a/federation/executor_test.go
+++ b/federation/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/graphql/introspection"
 	"github.com/samsarahq/thunder/graphql/schemabuilder"
 	"github.com/stretchr/testify/assert"
@@ -83,7 +84,14 @@ func createExecutorWithFederatedObjects() (*Executor, *schemabuilder.Schema, *sc
 		users = append(users, &UserWithEmail{Id: int64(1), Email: "yaaayeeeet@gmail.com"})
 		return users
 	})
+	s2.Query().FieldFunc("secretUsers", func(ctx context.Context) ([]*UserWithEmail, error) {
+		users := make([]*UserWithEmail, 0, 1)
+		users = append(users, &UserWithEmail{Id: int64(1), OrgId: int64(1), Email: "test@gmail.com"})
+		return users, nil
+	})
+
 	user2 := s2.Object("User", UserWithEmail{})
+	user2.Key("id")
 	user2.FieldFunc("secret", func(ctx context.Context, user *UserWithEmail) (string, error) {
 		return "shhhhh", nil
 	})
@@ -132,4 +140,123 @@ func TestMultipleExecutorGeneratedSchemas(t *testing.T) {
 	require.NoError(t, err)
 	expectedSchemaWithFederationInfo := getExpectedSchemaWithFederationInfo(t, s1, s2)
 	assert.Equal(t, getFieldServiceMaps(t, e.planner.schema), getFieldServiceMaps(t, expectedSchemaWithFederationInfo))
+}
+
+func runAndValidateQueryResults(t *testing.T, ctx context.Context, e *Executor, query string, out string) {
+	res, err := e.Execute(ctx, graphql.MustParse(query, map[string]interface{}{}))
+	var expected interface{}
+	err = json.Unmarshal([]byte(out), &expected)
+	require.NoError(t, err)
+	assert.Equal(t, expected, res)
+}
+
+func TestExecutorQueriesFieldsOnOneService(t *testing.T) {
+	e, _, _, err := createExecutorWithFederatedObjects()
+	require.NoError(t, err)
+	testCases := []struct {
+		Name   string
+		Query  string
+		Output string
+	}{
+		{
+			Name: "query fields on schema s1",
+			Query: `
+				query Foo {
+					users {
+						id
+					}
+				}`,
+			Output: `
+				{
+					"users":[
+						{
+							"__key":1,
+							"id":1
+						}
+					]
+				}`,
+		},
+		{
+			Name: "query fields on schema s2",
+			Query: `
+				query Foo {
+					secretUsers {
+						id
+						secret
+					}
+				}`,
+			Output: `
+				{
+					"secretUsers":[
+						{
+							"__key":1,
+							"id":1,
+							"secret":"shhhhh"
+						}
+					]
+				}`,
+		},
+		{
+			Name: "query fields on schema s1 and s2",
+			Query: `
+				query Foo {
+					admins {
+						superPower
+					}
+					secretUsers {
+						id
+					}
+				}`,
+			Output: `
+				{
+					"admins":[
+						{
+							"__key":1,
+							"superPower":"flying"
+						}
+					],
+					"secretUsers":[
+						{
+							"__key":1,
+							"id":1
+						}
+					]
+				}`,
+		},
+		{
+			Name: "multiple query fields on schema s1",
+			Query: `
+				query Foo {
+					admins {
+						superPower
+					}
+					users {
+						id
+					}
+				}`,
+			Output: `
+				{
+					"admins":[
+						{
+							"__key":1,
+							"superPower":"flying"
+						}
+					],
+					"users":[
+						{
+							"__key":1,
+							"id":1
+						}
+					]
+				}`,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			// Validates that we were able to execute the query on multiple
+			// schemas and correctly stitch the results back together
+			ctx := context.Background()
+			runAndValidateQueryResults(t, ctx, e, testCase.Query, testCase.Output)
+		})
+	}
 }


### PR DESCRIPTION
This supports us in parsing the plan and executing the query on multiple services. We can split up the query and run it on different schemas or multiple schemas, but not support nested queries that are on separate schemas. 

This is a stacked PR, so only the last two commits are new. 