### PR TITLE
Prototype: Federated Executor 

### DIFF
--- a/federation/executor.go
+++ b/federation/executor.go
@@ -3,6 +3,7 @@ package federation
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	"github.com/samsarahq/go/oops"
@@ -92,6 +93,33 @@ func NewExecutor(ctx context.Context, executors map[string]ExecutorClient) (*Exe
 }
 
 func (e *Executor) runOnService(ctx context.Context, service string, typName string, keys []interface{}, kind string, selectionSet *graphql.SelectionSet) (map[string]interface{}, error) {
+	schema := e.Executors[service]
+
+	isRoot := keys == nil
+	if !isRoot {
+		selectionSet = &graphql.SelectionSet{
+			Selections: []*graphql.Selection{
+				{
+					Name:  "__federation",
+					Alias: "__federation",
+					Args:  map[string]interface{}{},
+					SelectionSet: &graphql.SelectionSet{
+						Selections: []*graphql.Selection{
+							{
+								Name:  typName,
+								Alias: typName,
+								UnparsedArgs: map[string]interface{}{
+									"keys": keys,
+								},
+								SelectionSet: selectionSet,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
 	// Execute query on specified service
 	schema, ok := e.Executors[service]
 	if !ok {
@@ -113,7 +141,87 @@ func (e *Executor) runOnService(ctx context.Context, service string, typName str
 	if !ok {
 		return nil, oops.Errorf("executor res not a map[string]interface{}")
 	}
+	if !isRoot {
+		result, ok = result["__federation"].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("root did not have a federation map, got %v", res)
+		}
+
+		r, ok := result[typName].([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("federation map did not have a %s slice, got %v", typName, res)
+		}
+
+		if len(r) != 1 {
+			return nil, fmt.Errorf("federation had incorect number of results for %s slice, got %v", typName, res)
+		}
+
+		res, ok := r[0].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("federation map did not have an element in %s slice, got %v", typName, res)
+		}
+		return res, nil
+
+	}
 	return result, nil
+}
+
+func (pathTargets *pathSubqueryMetadata) extractKeys(node interface{}, path []PathStep) error {
+
+	if slice, ok := node.([]interface{}); ok {
+		for i, elem := range slice {
+			if err := pathTargets.extractKeys(elem, path); err != nil {
+				return fmt.Errorf("idx %d: %v", i, err)
+			}
+		}
+		return nil
+	}
+
+	if len(path) == 0 {
+		obj, ok := node.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("not an object: %v", obj)
+		}
+		key, ok := obj["__federation"]
+		if !ok {
+			return fmt.Errorf("missing __federation: %v", obj)
+		}
+		pathTargets.results = obj
+		pathTargets.keys = append(pathTargets.keys, key)
+		return nil
+	}
+
+	obj, ok := node.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	step := path[0]
+	switch step.Kind {
+	case KindField:
+		next, ok := obj[step.Name]
+		if !ok {
+			return fmt.Errorf("does not have key %s", step.Name)
+		}
+
+		if err := pathTargets.extractKeys(next, path[1:]); err != nil {
+			return fmt.Errorf("elem %s: %v", next, err)
+		}
+
+	case KindType:
+		typ, ok := obj["__typename"].(string)
+		if !ok {
+			return fmt.Errorf("does not have string key __typename")
+		}
+
+		if typ == step.Name {
+			if err := pathTargets.extractKeys(obj, path[1:]); err != nil {
+				return fmt.Errorf("typ %s: %v", typ, err)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (e *Executor) execute(ctx context.Context, p *Plan, keys []interface{}) (interface{}, error) {
@@ -141,6 +249,10 @@ func (e *Executor) execute(ctx context.Context, p *Plan, keys []interface{}) (in
 		if p.Service == gatewayCoordinatorServiceName {
 			subPlanMetaData.keys = nil // On the root query there are no specified keys
 			subPlanMetaData.results = res
+		} else {
+			if err := subPlanMetaData.extractKeys(res, subPlan.Path); err != nil {
+				return nil, fmt.Errorf("failed to extratc keys %v: %v", subPlan.Path, err)
+			}
 		}
 
 		g.Go(func() error {
@@ -159,11 +271,9 @@ func (e *Executor) execute(ctx context.Context, p *Plan, keys []interface{}) (in
 			resMu.Lock()
 			defer resMu.Unlock()
 			for k, v := range result {
-				if _, ok := subPlanMetaData.results[k]; ok {
-					return oops.Errorf("key already exists in results: %v", k)
-				}
 				subPlanMetaData.results[k] = v
 			}
+
 			return nil
 		})
 	}
@@ -181,6 +291,20 @@ type pathSubqueryMetadata struct {
 	results map[string]interface{} // Results from subquery
 }
 
+func deleteKey(v interface{}, k string) {
+	switch v := v.(type) {
+	case []interface{}:
+		for _, e := range v {
+			deleteKey(e, k)
+		}
+	case map[string]interface{}:
+		delete(v, k)
+		for _, e := range v {
+			deleteKey(e, k)
+		}
+	}
+}
+
 func (e *Executor) Execute(ctx context.Context, query *graphql.Query) (interface{}, error) {
 	plan, err := e.planner.planRoot(query)
 	if err != nil {
@@ -192,5 +316,6 @@ func (e *Executor) Execute(ctx context.Context, query *graphql.Query) (interface
 		return nil, err
 	}
 
+	deleteKey(r, "__federation")
 	return r, nil
 }

--- a/federation/executor_federated_keys_test.go
+++ b/federation/executor_federated_keys_test.go
@@ -1,0 +1,171 @@
+package federation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samsarahq/thunder/graphql/schemabuilder"
+	"github.com/stretchr/testify/require"
+)
+
+func createExecutorWithFederatedObjects2() (*Executor, *schemabuilder.Schema, *schemabuilder.Schema, error) {
+	// The first schema has a user object with an id and orgId
+	type User struct {
+		Id    int64
+		OrgId int64
+		Name  string
+	}
+	s1 := schemabuilder.NewSchemaWithName("s1")
+	user := s1.Object("User", User{})
+	user.Key("id")
+	type UserIds struct {
+		Id    int64
+		OrgId int64
+	}
+	user.Federation(func(u *User) *User {
+		return u
+	})
+	s1.Query().FieldFunc("users", func(ctx context.Context) ([]*User, error) {
+		users := make([]*User, 0, 1)
+		users = append(users, &User{Id: int64(1), OrgId: int64(9086)})
+		return users, nil
+	})
+
+	s1.Query().FieldFunc("usersWithArgs", func(args struct {
+		Name string
+	}) ([]*User, error) {
+		users := make([]*User, 0, 1)
+		users = append(users, &User{Id: int64(1), OrgId: int64(9086), Name: args.Name})
+		return users, nil
+	})
+
+	// The second schema has a user with an email and a secret field
+	type UserWithContactInfo struct {
+		Id          int64
+		OrgId       int64
+		Name        string
+		Email       string
+		PhoneNumber string
+	}
+
+	type UserKeys struct {
+		Id    int64
+		OrgId int64
+	}
+	s2 := schemabuilder.NewSchemaWithName("s2")
+	s2.Federation().FederatedFieldFunc("User", func(args struct{ Keys []UserKeys }) []*UserWithContactInfo {
+		users := make([]*UserWithContactInfo, 0, len(args.Keys))
+		users = append(users, &UserWithContactInfo{Id: int64(1), Email: "yaaayeeeet@gmail.com", PhoneNumber: "555"})
+		return users
+	})
+
+	user2 := s2.Object("User", UserWithContactInfo{})
+	user2.Key("id")
+	user2.FieldFunc("secret", func(ctx context.Context, user *UserWithContactInfo) (string, error) {
+		return "shhhhh", nil
+	})
+
+	// The second schema has a user with an email and a secret field
+	type UserWithAdminPrivelages struct {
+		Id      int64
+		OrgId   int64
+		Name    string
+		IsAdmin bool
+	}
+
+	type UserKeys2 struct {
+		Id int64
+	}
+	s3 := schemabuilder.NewSchemaWithName("s3")
+	s3.Federation().FederatedFieldFunc("User", func(args struct{ Keys []UserKeys2 }) []*UserWithAdminPrivelages {
+		users := make([]*UserWithAdminPrivelages, 0, len(args.Keys))
+		users = append(users, &UserWithAdminPrivelages{Id: int64(1), IsAdmin: true})
+		return users
+	})
+
+	user3 := s3.Object("User", UserWithAdminPrivelages{})
+	user3.Key("id")
+	user3.FieldFunc("privelages", func(ctx context.Context, user *UserWithAdminPrivelages) (string, error) {
+		return "all", nil
+	})
+
+	// Create the executor with all the schemas
+	ctx := context.Background()
+	execs, err := makeExecutors(map[string]*schemabuilder.Schema{
+		"s1": s1,
+		"s2": s2,
+		"s3": s3,
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	e, err := NewExecutor(ctx, execs)
+	return e, s1, s2, err
+}
+
+func TestExecutorQueriesFieldsOnMultipleServices2(t *testing.T) {
+	e, _, _, err := createExecutorWithFederatedObjects2()
+	require.NoError(t, err)
+	testCases := []struct {
+		Name          string
+		Query         string
+		Output        string
+		Error         bool
+		ExpectedError string
+	}{
+		{
+			Name: "query fields with args",
+			Query: `
+			query Foo {
+				users {
+					email
+				}
+			}`,
+			Output: `
+			{
+				"users":[
+					{
+						"__key":1,
+						"email":"yaaayeeeet@gmail.com"
+					}
+				]
+			}`,
+			Error: false,
+		},
+		{
+			Name: "query fields with args 2",
+			Query: `
+			query Foo {
+				users {
+					secret
+					privelages
+				}
+			}`,
+			Output: `
+			{
+				"users":[
+					{
+						"__key":1,
+						"secret":"shhhhh",
+						"privelages": "all"
+					}
+				]
+			}`,
+			Error: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			ctx := context.Background()
+			if !testCase.Error {
+				// Validates that we were able to execute the query on multiple
+				// schemas and correctly stitch the results back together
+				runAndValidateQueryResults(t, ctx, e, testCase.Query, testCase.Output)
+			} else {
+				runAndValidateQueryError(t, ctx, e, testCase.Query, testCase.Output, testCase.ExpectedError)
+			}
+
+		})
+	}
+}

--- a/federation/executor_test.go
+++ b/federation/executor_test.go
@@ -34,11 +34,15 @@ func createExecutorWithFederatedObjects() (*Executor, *schemabuilder.Schema, *sc
 		OrgId int64
 		Name  string
 	}
-	s1 := schemabuilder.NewSchema()
+	s1 := schemabuilder.NewSchemaWithName("s1")
 	user := s1.Object("User", User{})
 	user.Key("id")
-	user.Federation(func(u *User) int64 {
-		return u.Id
+	type UserIds struct {
+		Id    int64
+		OrgId int64
+	}
+	user.Federation(func(u *User) *User {
+		return u
 	})
 	s1.Query().FieldFunc("users", func(ctx context.Context) ([]*User, error) {
 		users := make([]*User, 0, 1)
@@ -89,8 +93,13 @@ func createExecutorWithFederatedObjects() (*Executor, *schemabuilder.Schema, *sc
 		Email       string
 		PhoneNumber string
 	}
-	s2 := schemabuilder.NewSchema()
-	s2.Federation().FieldFunc("User", func(args struct{ Keys []int64 }) []*UserWithContactInfo {
+
+	type UserKeys struct {
+		Id    int64
+		OrgId int64
+	}
+	s2 := schemabuilder.NewSchemaWithName("s2")
+	s2.Federation().FederatedFieldFunc("User", func(args struct{ Keys []UserKeys }) []*UserWithContactInfo {
 		users := make([]*UserWithContactInfo, 0, len(args.Keys))
 		users = append(users, &UserWithContactInfo{Id: int64(1), Email: "yaaayeeeet@gmail.com", PhoneNumber: "555"})
 		return users

--- a/federation/kitchen_sink_test.go
+++ b/federation/kitchen_sink_test.go
@@ -3,6 +3,7 @@ package federation
 import (
 	"context"
 	"fmt"
+
 	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/graphql/schemabuilder"
 )
@@ -28,7 +29,7 @@ type Pair struct {
 }
 
 func buildTestSchema1() *schemabuilder.Schema {
-	schema := schemabuilder.NewSchema()
+	schema := schemabuilder.NewSchemaWithName("schema1")
 
 	query := schema.Query()
 	query.FieldFunc("s1f", func() *Foo {
@@ -68,8 +69,8 @@ func buildTestSchema1() *schemabuilder.Schema {
 	})
 
 	foo := schema.Object("Foo", Foo{})
-	foo.Federation(func(f *Foo) string {
-		return f.Name
+	foo.Federation(func(f *Foo) *Foo {
+		return f
 	})
 	foo.BatchFieldFunc("s1hmm", func(ctx context.Context, in map[batch.Index]*Foo) (map[batch.Index]string, error) {
 		out := make(map[batch.Index]string)
@@ -85,10 +86,14 @@ func buildTestSchema1() *schemabuilder.Schema {
 		return Enum(1)
 	})
 
-	schema.Federation().FieldFunc("Bar", func(args struct{ Keys []int64 }) []*Bar {
+	type BarKeys struct {
+		Id int64
+	}
+
+	schema.Federation().FederatedFieldFunc("Bar", func(args struct{ Keys []*BarKeys }) []*Bar {
 		bars := make([]*Bar, 0, len(args.Keys))
 		for _, key := range args.Keys {
-			bars = append(bars, &Bar{Id: key})
+			bars = append(bars, &Bar{Id: key.Id})
 		}
 		return bars
 	})
@@ -117,12 +122,15 @@ func buildTestSchema1() *schemabuilder.Schema {
 }
 
 func buildTestSchema2() *schemabuilder.Schema {
-	schema := schemabuilder.NewSchema()
+	schema := schemabuilder.NewSchemaWithName("schema2")
 
-	schema.Federation().FieldFunc("Foo", func(args struct{ Keys []string }) []*Foo {
+	type FooKeys struct {
+		Name string
+	}
+	schema.Federation().FederatedFieldFunc("Foo", func(args struct{ Keys []*FooKeys }) []*Foo {
 		foos := make([]*Foo, 0, len(args.Keys))
 		for _, key := range args.Keys {
-			foos = append(foos, &Foo{Name: key})
+			foos = append(foos, &Foo{Name: key.Name})
 		}
 		return foos
 	})
@@ -152,8 +160,8 @@ func buildTestSchema2() *schemabuilder.Schema {
 	})
 
 	bar := schema.Object("Bar", Bar{})
-	bar.Federation(func(b *Bar) int64 {
-		return b.Id
+	bar.Federation(func(b *Bar) *Bar {
+		return b
 	})
 
 	return schema

--- a/federation/planner_test.go
+++ b/federation/planner_test.go
@@ -195,7 +195,7 @@ func TestPlanner(t *testing.T) {
 						}
 					}`),
 					After: []*Plan{
-						
+
 						{
 							Path: []PathStep{
 								{Kind: KindField, Name: "s1both"},

--- a/graphql/schemabuilder/schema.go
+++ b/graphql/schemabuilder/schema.go
@@ -11,6 +11,7 @@ import (
 // can be registered against the "Mutation" and "Query" objects in order to
 // build out a full GraphQL schema.
 type Schema struct {
+	Name      string
 	objects   map[string]*Object
 	enumTypes map[reflect.Type]*EnumMapping
 }
@@ -18,6 +19,23 @@ type Schema struct {
 // NewSchema creates a new schema.
 func NewSchema() *Schema {
 	schema := &Schema{
+		objects: make(map[string]*Object),
+	}
+
+	// Default registrations.
+	schema.Enum(SortOrder(0), map[string]SortOrder{
+		"asc":  SortOrder_Ascending,
+		"desc": SortOrder_Descending,
+	})
+
+	return schema
+}
+
+// NewSchema creates a new schema.
+func NewSchemaWithName(name string) *Schema {
+
+	schema := &Schema{
+		Name:    name,
 		objects: make(map[string]*Object),
 	}
 
@@ -100,8 +118,9 @@ func (s *Schema) Object(name string, typ interface{}) *Object {
 		return object
 	}
 	object := &Object{
-		Name: name,
-		Type: typ,
+		Name:        name,
+		Type:        typ,
+		ServiceName: s.Name,
 	}
 	s.objects[name] = object
 	return object
@@ -175,7 +194,6 @@ func (s *Schema) MustBuild() *graphql.Schema {
 	}
 	return built
 }
-
 
 type federation struct{}
 

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -135,6 +135,8 @@ type Field struct {
 	External     bool
 	Expensive    bool
 
+	FederatedKey map[string]bool
+
 	// NumParallelInvocationsFunc controls how many goroutines we'll create for a
 	// field execution (batch or non-expensive).  We pass in the number of srcs
 	// we're executing with so implementers can write custom logic.


### PR DESCRIPTION
This is a pretty large PR, so Im going to split it into a few and continue to add more to this prototype. 

This allows us to query downstream gqlservers with subqueries that are not nested on the root queries. We look at the previous stage's query results to key the keys and structure the subqueries to look like the example below. That means if a nested field is on a separate gqlserver, we can parse that query and resolve it correctly
```
__federation {
   ObjectName(keys){
        ...subQuery
   }
}
``

