### PR TITLE
Federation: Schema parsing where an enum as input object 

### DIFF
--- a/federation/schema.go
+++ b/federation/schema.go
@@ -189,7 +189,7 @@ func parseInputFields(source []introspectionInputField, all map[string]graphql.T
 			return nil, fmt.Errorf("type %s not found", rawType.Name)
 		}
 		switch rawType.Kind {
-		case "INPUT_OBJECT", "SCALAR":
+		case "INPUT_OBJECT", "SCALAR", "ENUM":
 		default:
 			return nil, fmt.Errorf("input field %s has bad typ: %s", field.Name, rawType.Kind)
 		}

--- a/federation/schema_test.go
+++ b/federation/schema_test.go
@@ -394,13 +394,14 @@ func TestMergeEnumUnion(t *testing.T) {
 func TestMergeEnumIntersection(t *testing.T) {
 	type Enum int32
 
+	type enumType int32
 	s1 := schemabuilder.NewSchema()
 	{
 		s1.Enum(Enum(0), map[string]Enum{
 			"zero": 0,
 			"one":  1,
 		})
-		s1.Query().FieldFunc("f", func() Enum { return Enum(1) })
+		s1.Query().FieldFunc("f", func(args struct{EnumField Enum}) Enum { return Enum(1) })
 	}
 
 	s2 := schemabuilder.NewSchema()
@@ -409,7 +410,7 @@ func TestMergeEnumIntersection(t *testing.T) {
 			"zero": 0,
 			"two":  2,
 		})
-		s2.Query().FieldFunc("f", func() Enum { return Enum(1) })
+		s2.Query().FieldFunc("f", func(args struct{EnumField Enum}) Enum { return Enum(1) })
 	}
 
 	s3 := schemabuilder.NewSchema()
@@ -417,7 +418,7 @@ func TestMergeEnumIntersection(t *testing.T) {
 		s3.Enum(Enum(0), map[string]Enum{
 			"zero": 0,
 		})
-		s3.Query().FieldFunc("f", func() Enum { return Enum(1) })
+		s3.Query().FieldFunc("f", func(args struct{EnumField Enum}) Enum { return Enum(1) })
 	}
 
 	assertSchemaIntersectionEq(t, s1, s2, s3)


### PR DESCRIPTION
In the args of a field func, we should be able to pass an enum in and have it parsed as a valid type. This is something thunder already supports in a nonfederated world, so we would like to continue to support it with federation. 