### PR TITLE
federation: convertversionedschema is public

### DIFF
--- a/federation/planner_test.go
+++ b/federation/planner_test.go
@@ -30,7 +30,7 @@ func setupExecutor(t *testing.T) (*Planner, error) {
 			builtSchemas[service][version] = extractSchema(t, schema.MustBuild())
 		}
 	}
-	merged, err := convertVersionedSchemas(builtSchemas)
+	merged, err := ConvertVersionedSchemas(builtSchemas)
 	require.NoError(t, err)
 
 	f, err := newFlattener(merged.Schema)

--- a/federation/schema.go
+++ b/federation/schema.go
@@ -30,11 +30,11 @@ type SchemaWithFederationInfo struct {
 	Fields map[*graphql.Field]*FieldInfo
 }
 
-// convertVersionedSchemas takes schemas for all of versions of
+// ConvertVersionedSchemas takes schemas for all of versions of
 // all executors services and generates a single merged schema
 // annotated with mapping from field to all services that know
 // how to resolve the field
-func convertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo, error) {
+func ConvertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo, error) {
 	serviceNames := make([]string, 0, len(schemas))
 	for service := range schemas {
 		serviceNames = append(serviceNames, service)
@@ -120,7 +120,7 @@ func convertSchema(schemas map[string]*introspectionQueryResult) (*SchemaWithFed
 			"": schema,
 		}
 	}
-	return convertVersionedSchemas(versionedSchemas)
+	return ConvertVersionedSchemas(versionedSchemas)
 }
 
 // lookupTypeRef maps the a introspected type to a graphql type

--- a/federation/schema_test.go
+++ b/federation/schema_test.go
@@ -106,7 +106,7 @@ func extractConvertedVersionedSchemas(t *testing.T, schemas map[string]map[strin
 		}
 	}
 
-	merged, err := convertVersionedSchemas(builtSchemas)
+	merged, err := ConvertVersionedSchemas(builtSchemas)
 	require.NoError(t, err)
 
 	return extractSchema(t, merged.Schema), getFieldServiceMaps(t, merged)


### PR DESCRIPTION
Make convert versioned schema a public method so that we can use it in a custom schema syncer to merge the schemas. 