### PR TITLE
Federation: Support multiple federated keys

### DIFF
--- a/federation/executor.go
+++ b/federation/executor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"reflect"
 
 	"github.com/samsarahq/go/oops"
 	"golang.org/x/sync/errgroup"
@@ -12,6 +13,7 @@ import (
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/graphql/introspection"
 )
+
 
 const keyField = "__key"
 const federationField = "__federation"
@@ -100,7 +102,7 @@ func NewExecutorWithOptionalArgs(ctx context.Context, executors map[string]Execu
 
 }
 
-func (e *Executor) runOnService(ctx context.Context, service string, typName string, keys []interface{}, kind string, selectionSet *graphql.SelectionSet, optionalArgs interface{}) (map[string]interface{}, interface{}, error) {
+func (e *Executor) runOnService(ctx context.Context, service string, typName string, keys []interface{}, kind string, selectionSet *graphql.SelectionSet, optionalArgs interface{}) ([]interface{}, interface{}, error) {
 	// Execute query on specified service
 	schema, ok := e.Executors[service]
 	if !ok {
@@ -109,15 +111,58 @@ func (e *Executor) runOnService(ctx context.Context, service string, typName str
 
 	// If it is not a root query, nest the subquery on the federation field
 	// and pass the keys in to find the object that the subquery is nested on
+	// Pass all federated keys for that service as arguments
 	// {
 	//    __federation {
-	//     [ObjectName] (keys: Keys) {
+	//     [ObjectName]-[Service] (keys: Keys) {
 	//       subQuery
 	// 		}
 	//   }
 	// }
 	isRoot := keys == nil
 	if !isRoot {
+		federatedName := fmt.Sprintf("%s-%s", typName, service)
+		
+		var rootObject *graphql.Object
+		var ok bool
+		for f, _ := range e.planner.schema.Fields {
+			if f.Type.String() == typName {
+				rootObject, ok = f.Type.(*graphql.Object)
+				if !ok {
+					return nil, nil, oops.Errorf("root object isn't a graphql object")
+				}
+			}
+		}
+		if rootObject == nil {
+			return nil, nil, oops.Errorf("root object not found for type %s", typName)
+		}
+	
+		// If it is a federated key on that service, add it to the input args
+		// passed in to the federated field func as one of the federated keys
+		newKeys := make([]interface{}, len(keys))
+
+		for i, key := range keys {
+			keyFields, ok := key.(map[string]interface{})
+			if !ok {
+				return nil, nil, oops.Errorf("key field is an incorrect type expected map[string]interface{} got %s", reflect.TypeOf(typName))
+			}
+			newKey := make(map[string]interface{}, len(keyFields))
+			for name, keyField := range keyFields {
+				if name == "__key" {
+					continue
+				}
+				for fieldName, field := range rootObject.Fields {
+					if fieldName == name {
+						_, ok := field.FederatedKey[service]
+						if ok {
+							newKey[name] = keyField
+						}
+					}
+				}
+			}
+			newKeys[i] = newKey
+		}
+
 		selectionSet = &graphql.SelectionSet{
 			Selections: []*graphql.Selection{
 				{
@@ -127,10 +172,10 @@ func (e *Executor) runOnService(ctx context.Context, service string, typName str
 					SelectionSet: &graphql.SelectionSet{
 						Selections: []*graphql.Selection{
 							{
-								Name:  typName,
-								Alias: typName,
+								Name:  federatedName,
+								Alias: federatedName,
 								UnparsedArgs: map[string]interface{}{
-									"keys": keys,
+									"keys": newKeys,
 								},
 								SelectionSet: selectionSet,
 							},
@@ -154,34 +199,27 @@ func (e *Executor) runOnService(ctx context.Context, service string, typName str
 	if err := json.Unmarshal(bytes, &res); err != nil {
 		return nil, nil, oops.Wrapf(err, "unmarshal res")
 	}
-	result, ok := res.(map[string]interface{})
-	if !ok {
-		return nil, nil, oops.Errorf("executor res not a map[string]interface{}")
-	}
+
 	if !isRoot {
+		result, ok := res.(map[string]interface{})
+		if !ok {
+			return nil, nil, oops.Errorf("executor res not a map[string]interface{}")
+		}
 		result, ok = result[federationField].(map[string]interface{})
+		if !ok {
+			return nil, nil, oops.Errorf("executor res not a map[string]interface{}")
+		}
+		federatedName := fmt.Sprintf("%s-%s", typName, service)
+		r, ok := result[federatedName].([]interface{})
 		if !ok {
 			return nil, nil, fmt.Errorf("root did not have a federation map, got %v", res)
 		}
-
-		r, ok := result[typName].([]interface{})
-		if !ok {
-			return nil, nil, fmt.Errorf("federation map did not have a %s slice, got %v", typName, res)
-		}
-
-		if len(r) != 1 {
-			return nil, nil, fmt.Errorf("federation had incorect number of results for %s slice, got %v", typName, res)
-		}
-
-		res, ok := r[0].(map[string]interface{})
-		if !ok {
-			return nil, nil, fmt.Errorf("federation map did not have an element in %s slice, got %v", typName, res)
-		}
-		return res, optionalResponseMetadata, nil
+		return r, optionalResponseMetadata, nil
 
 	}
-	return result, optionalResponseMetadata, nil
+	return []interface{}{res},optionalResponseMetadata, nil
 }
+
 
 func (pathTargets *pathSubqueryMetadata) extractKeys(node interface{}, path []PathStep) error {
 	// Extract key for every element in the slice
@@ -205,7 +243,7 @@ func (pathTargets *pathSubqueryMetadata) extractKeys(node interface{}, path []Pa
 		}
 		// Add a pointer to the object for where the results from
 		// the subquery will be added into the final result
-		pathTargets.results = obj
+		pathTargets.results = append(pathTargets.results, obj)
 		// Keys from the "__federation" field func are passed to
 		// the subquery
 		pathTargets.keys = append(pathTargets.keys, key)
@@ -245,8 +283,8 @@ func (pathTargets *pathSubqueryMetadata) extractKeys(node interface{}, path []Pa
 	return nil
 }
 
-func (e *Executor) execute(ctx context.Context, p *Plan, keys []interface{}, optionalArgs interface{}) (interface{}, []interface{}, error) {
-	res := map[string]interface{}{}
+func (e *Executor) execute(ctx context.Context, p *Plan, keys []interface{}, optionalArgs interface{}) ([]interface{}, []interface{}, error) {
+	var res []interface{}
 	optionalRespMetadata := make([]interface{}, 0)
 	// var optionalResponseArg interface{}
 	// Executes that part of the plan (the subquery) on one of the federated gqlservers
@@ -258,6 +296,10 @@ func (e *Executor) execute(ctx context.Context, p *Plan, keys []interface{}, opt
 			return nil, nil, oops.Wrapf(err, "run on service")
 		}
 		optionalRespMetadata = append(optionalRespMetadata, optionalRespQueryMetaData)
+	} else {
+		res = []interface{}{
+			map[string]interface{}{},
+		}
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -272,7 +314,11 @@ func (e *Executor) execute(ctx context.Context, p *Plan, keys []interface{}, opt
 		var subPlanMetaData pathSubqueryMetadata
 		if p.Service == gatewayCoordinatorServiceName {
 			subPlanMetaData.keys = nil // On the root query there are no specified keys
-			subPlanMetaData.results = res
+			// On the root query, there will only be one result since 
+			// it is on either the "query" or "mutation object"
+			subPlanMetaData.results = []map[string]interface{}{
+				res[0].(map[string]interface{}),
+			}
 			subPlanMetaData.optionalResponseMetatda = nil
 		} else {
 			if err := subPlanMetaData.extractKeys(res, subPlan.Path); err != nil {
@@ -282,29 +328,34 @@ func (e *Executor) execute(ctx context.Context, p *Plan, keys []interface{}, opt
 
 		g.Go(func() error {
 			// Execute the subquery on the specified service
-			results, subQueryRespMetadata, err := e.execute(ctx, subPlan, subPlanMetaData.keys, optionalArgs)
+			executionResults, subQueryRespMetadata, err := e.execute(ctx, subPlan, subPlanMetaData.keys, optionalArgs)
 			if err != nil {
 				return oops.Wrapf(err, "executing sub plan: %v", err)
 			}
 			optionalRespMetadata = append(optionalRespMetadata, subQueryRespMetadata...)
 
-			result, ok := results.(map[string]interface{})
-			if !ok {
-				return oops.Errorf("result is not an object: %v", result)
+			if len(executionResults) != len(subPlanMetaData.results) {
+				return fmt.Errorf("got %d results for %d targets", len(executionResults), len(subPlanMetaData.results))
 			}
 
 			// Acquire mutex lock before modifying results
 			resMu.Lock()
 			defer resMu.Unlock()
-			for k, v := range result {
-				if _, ok := subPlanMetaData.results[k]; !ok {
-					subPlanMetaData.results[k] = v
-				} else {
-					if k != keyField || v != subPlanMetaData.results[k] {
-						return oops.Errorf("key already exists in results: %v", k)
+			for i, result := range subPlanMetaData.results {
+				executionResult, ok := executionResults[i].(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("result is not an object: %v", executionResult)
+				}
+				
+				for k, v := range executionResult {
+					if _, ok := result[k]; !ok {
+						result[k] = v
+					} else {
+						if k != keyField || v != result[k] {
+							return oops.Errorf("key already exists in results: %v", k)
+						}
 					}
 				}
-
 			}
 			return nil
 		})
@@ -334,7 +385,7 @@ func deleteKey(v interface{}, k string) {
 // Metadata for a subquery
 type pathSubqueryMetadata struct {
 	keys                    []interface{}          // Federated Keys passed into subquery
-	results                 map[string]interface{} // Results from subquery
+	results                 []map[string]interface{} // Results from subquery
 	optionalResponseMetatda []interface{}
 }
 
@@ -348,6 +399,14 @@ func (e *Executor) Execute(ctx context.Context, query *graphql.Query, optionalAr
 	if err != nil {
 		return nil, nil, err
 	}
-	deleteKey(r, federationField)
-	return r, optionalResponseMetatdata, nil
+
+	if len(r) != 1 {
+		return nil, nil, oops.Errorf("Multiple results, expected one %v", r)
+	}
+	// The interface for results assumes we always get back a list of objects
+	// On the root query, we know there is only one object (a query or mutation)
+	// So we expect only one item in this list
+	res := r[0]
+	deleteKey(res, federationField)
+	return res,optionalResponseMetatdata,  nil
 }

--- a/federation/kitchen_sink_test.go
+++ b/federation/kitchen_sink_test.go
@@ -28,7 +28,7 @@ type Pair struct {
 }
 
 func buildTestSchema1() *schemabuilder.Schema {
-	schema := schemabuilder.NewSchema()
+	schema := schemabuilder.NewSchemaWithName("schema1")
 
 	query := schema.Query()
 	query.FieldFunc("s1f", func() *Foo {
@@ -68,8 +68,8 @@ func buildTestSchema1() *schemabuilder.Schema {
 	})
 
 	foo := schema.Object("Foo", Foo{})
-	foo.Federation(func(f *Foo) string {
-		return f.Name
+	foo.Federation(func(f *Foo) *Foo {
+		return f
 	})
 	foo.BatchFieldFunc("s1hmm", func(ctx context.Context, in map[batch.Index]*Foo) (map[batch.Index]string, error) {
 		out := make(map[batch.Index]string)
@@ -85,10 +85,13 @@ func buildTestSchema1() *schemabuilder.Schema {
 		return Enum(1)
 	})
 
-	schema.Federation().FieldFunc("Bar", func(args struct{ Keys []int64 }) []*Bar {
+	type BarKeys struct {
+		Id int64
+	}
+	schema.Federation().FederatedFieldFunc("Bar", func(args struct{ Keys []*BarKeys }) []*Bar {
 		bars := make([]*Bar, 0, len(args.Keys))
 		for _, key := range args.Keys {
-			bars = append(bars, &Bar{Id: key})
+			bars = append(bars, &Bar{Id: key.Id})
 		}
 		return bars
 	})
@@ -117,12 +120,14 @@ func buildTestSchema1() *schemabuilder.Schema {
 }
 
 func buildTestSchema2() *schemabuilder.Schema {
-	schema := schemabuilder.NewSchema()
-
-	schema.Federation().FieldFunc("Foo", func(args struct{ Keys []string }) []*Foo {
+	schema := schemabuilder.NewSchemaWithName("schema2")
+	type FooKeys struct {
+		Name string
+	}
+	schema.Federation().FederatedFieldFunc("Foo", func(args struct{ Keys []*FooKeys }) []*Foo {
 		foos := make([]*Foo, 0, len(args.Keys))
 		for _, key := range args.Keys {
-			foos = append(foos, &Foo{Name: key})
+			foos = append(foos, &Foo{Name: key.Name})
 		}
 		return foos
 	})
@@ -152,8 +157,8 @@ func buildTestSchema2() *schemabuilder.Schema {
 	})
 
 	bar := schema.Object("Bar", Bar{})
-	bar.Federation(func(b *Bar) int64 {
-		return b.Id
+	bar.Federation(func(b *Bar)  *Bar {
+		return b
 	})
 
 	return schema

--- a/federation/planner_test.go
+++ b/federation/planner_test.go
@@ -86,7 +86,9 @@ func TestPlanner(t *testing.T) {
 					SelectionSet: mustParse(`{
 						s1fff {
 							name
-							__federation
+							__federation {
+								name
+							}
 						}
 					}`),
 					After: []*Plan{
@@ -121,7 +123,9 @@ func TestPlanner(t *testing.T) {
 					Kind:    "query",
 					SelectionSet: mustParse(`{
 						s1fff {
-							__federation
+							__federation {
+								name
+							}
 						}
 					}`),
 					After: []*Plan{
@@ -134,7 +138,9 @@ func TestPlanner(t *testing.T) {
 							Service: "schema2",
 							SelectionSet: mustParse(`{
 								s2bar {
-									__federation
+									__federation {
+										id
+									}
 								}
 							}`),
 							After: []*Plan{
@@ -187,15 +193,17 @@ func TestPlanner(t *testing.T) {
 							}
 							... on Foo {
 								__typename
-								a: s1nest { b: s1nest { c: s1nest { __federation } } }
+								a: s1nest { b: s1nest { c: s1nest { __federation { name } } } }
 								name
 								s1hmm
-								__federation
+								__federation {
+									name
+								}
 							}
 						}
 					}`),
 					After: []*Plan{
-						
+
 						{
 							Path: []PathStep{
 								{Kind: KindField, Name: "s1both"},
@@ -256,12 +264,14 @@ func TestPlanner(t *testing.T) {
 					SelectionSet: mustParse(`{
 						s1echo(foo: "foo", pair: {a: 1, b: 3})
 						s1fff {
-							a: s1nest { b: s1nest { c: s1nest { __federation } } }
+							a: s1nest { b: s1nest { c: s1nest { __federation { name } } } }
 							s1hmm
 							s1nest {
 								name
 							}
-							__federation
+							__federation {
+								name
+							}
 						}
 					}`),
 					After: []*Plan{
@@ -289,7 +299,9 @@ func TestPlanner(t *testing.T) {
 							SelectionSet: mustParse(`{
 								s2bar {
 									id
-									__federation
+									__federation {
+										id
+									}
 								}
 								s2nest {
 									name

--- a/federation/schema.go
+++ b/federation/schema.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
+	"github.com/samsarahq/go/oops"
 	"github.com/samsarahq/thunder/graphql"
 )
 
@@ -28,6 +30,13 @@ type SchemaWithFederationInfo struct {
 	Schema *graphql.Schema
 	// Fields is a map of fields to services which they belong to
 	Fields map[*graphql.Field]*FieldInfo
+}
+
+func getRootType(typ *introspectionTypeRef) *introspectionTypeRef {
+	if typ.OfType == nil {
+		return typ
+	}
+	return getRootType(typ.OfType)
 }
 
 // ConvertVersionedSchemas takes schemas for all of versions of
@@ -83,6 +92,43 @@ func ConvertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo,
 	fieldInfos := make(map[*graphql.Field]*FieldInfo)
 	for _, service := range serviceNames {
 		for _, typ := range serviceSchemasByName[service].Schema.Types {
+			// For federated fields parse the arguments to figure out which
+			// fields are the federated keys. They annotate that information
+			// on the field object.
+			if typ.Name == "Federation" {
+				for _, field := range typ.Fields {
+				    // Extract the type name from the formatting <object>-<service>
+				    // And check that the object type exists
+					names := strings.SplitN(field.Name, "-", 2)
+					if len(names) != 2 {
+						return nil, oops.Errorf("Field %s doesnt have an object name and service name", field.Name)
+					}
+					objName := names[0]
+					obj, ok := types[objName].(*graphql.Object)
+					if !ok {
+						return nil, oops.Errorf("Expected objectName %s on merged schema", objName)
+					}
+					for _, arg := range field.Args {
+						rootType := getRootType(arg.Type)
+
+						inputType, ok := types[rootType.Name].(*graphql.InputObject)
+						if !ok {
+							return nil, oops.Errorf("Object %s is not an input object, but it is an argument to the field %s", rootType.Name, field.Name)
+						}
+						// If the field is one of the input fields to the federatedfieldfunc,
+						// add the service name to the list of federated keys
+						for fName, f := range obj.Fields {
+							if _, ok := inputType.InputFields[fName]; !ok {
+								continue
+							}
+							if f.FederatedKey == nil {
+								f.FederatedKey = make(map[string]bool, len(serviceNames))
+							}
+							f.FederatedKey[service] = true
+						}
+					}
+				}
+			}
 			if typ.Kind == "OBJECT" {
 				obj := types[typ.Name].(*graphql.Object)
 

--- a/federation/schema.go
+++ b/federation/schema.go
@@ -115,6 +115,14 @@ func ConvertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo,
 						if !ok {
 							return nil, oops.Errorf("Object %s is not an input object, but it is an argument to the field %s", rootType.Name, field.Name)
 						}
+
+						// Check that all the input fields are on the federated object
+						for fName := range inputType.InputFields {
+							if _, ok := obj.Fields[fName]; !ok {
+								return nil, oops.Errorf("input field %s is not a field on the object %s", fName, rootType.Name)
+							}
+						}
+
 						// If the field is one of the input fields to the federatedfieldfunc,
 						// add the service name to the list of federated keys
 						for fName, f := range obj.Fields {

--- a/federation/testdata/TestBuildSchemaKitchenSink.snapshots.json
+++ b/federation/testdata/TestBuildSchemaKitchenSink.snapshots.json
@@ -12,13 +12,9 @@
                   "args": [],
                   "name": "__federation",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": "",
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "int64",
-                      "ofType": null
-                    }
+                    "kind": "OBJECT",
+                    "name": "Bar",
+                    "ofType": null
                   }
                 },
                 {
@@ -54,6 +50,27 @@
               "possibleTypes": []
             },
             {
+              "enumValues": [],
+              "fields": [],
+              "inputFields": [
+                {
+                  "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "int64",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "kind": "INPUT_OBJECT",
+              "name": "BarKeys_InputObject",
+              "possibleTypes": []
+            },
+            {
               "enumValues": [
                 {
                   "name": "one"
@@ -79,19 +96,15 @@
                           "kind": "LIST",
                           "name": "",
                           "ofType": {
-                            "kind": "NON_NULL",
-                            "name": "",
-                            "ofType": {
-                              "kind": "SCALAR",
-                              "name": "int64",
-                              "ofType": null
-                            }
+                            "kind": "INPUT_OBJECT",
+                            "name": "BarKeys_InputObject",
+                            "ofType": null
                           }
                         }
                       }
                     }
                   ],
-                  "name": "Bar",
+                  "name": "Bar-schema1",
                   "type": {
                     "kind": "NON_NULL",
                     "name": "",
@@ -121,19 +134,15 @@
                           "kind": "LIST",
                           "name": "",
                           "ofType": {
-                            "kind": "NON_NULL",
-                            "name": "",
-                            "ofType": {
-                              "kind": "SCALAR",
-                              "name": "string",
-                              "ofType": null
-                            }
+                            "kind": "INPUT_OBJECT",
+                            "name": "FooKeys_InputObject",
+                            "ofType": null
                           }
                         }
                       }
                     }
                   ],
-                  "name": "Foo",
+                  "name": "Foo-schema2",
                   "type": {
                     "kind": "NON_NULL",
                     "name": "",
@@ -165,13 +174,9 @@
                   "args": [],
                   "name": "__federation",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": "",
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "string",
-                      "ofType": null
-                    }
+                    "kind": "OBJECT",
+                    "name": "Foo",
+                    "ofType": null
                   }
                 },
                 {
@@ -266,6 +271,27 @@
               "inputFields": [],
               "kind": "OBJECT",
               "name": "Foo",
+              "possibleTypes": []
+            },
+            {
+              "enumValues": [],
+              "fields": [],
+              "inputFields": [
+                {
+                  "name": "name",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "string",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "kind": "INPUT_OBJECT",
+              "name": "FooKeys_InputObject",
               "possibleTypes": []
             },
             {

--- a/graphql/schemabuilder/schema.go
+++ b/graphql/schemabuilder/schema.go
@@ -11,6 +11,7 @@ import (
 // can be registered against the "Mutation" and "Query" objects in order to
 // build out a full GraphQL schema.
 type Schema struct {
+	Name      string
 	objects   map[string]*Object
 	enumTypes map[reflect.Type]*EnumMapping
 }
@@ -29,6 +30,22 @@ func NewSchema() *Schema {
 
 	return schema
 }
+
+// NewSchema creates a new schema with a schema name
+func NewSchemaWithName(name string) *Schema {
+	schema := &Schema{
+		Name:    name,
+		objects: make(map[string]*Object),
+	}
+
+	// Default registrations.
+	schema.Enum(SortOrder(0), map[string]SortOrder{
+		"asc":  SortOrder_Ascending,
+		"desc": SortOrder_Descending,
+	})
+	return schema
+}
+
 
 // Enum registers an enumType in the schema. The val should be any arbitrary value
 // of the enumType to be used for reflection, and the enumMap should be
@@ -102,6 +119,7 @@ func (s *Schema) Object(name string, typ interface{}) *Object {
 	object := &Object{
 		Name: name,
 		Type: typ,
+		ServiceName: s.Name,
 	}
 	s.objects[name] = object
 	return object

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -12,8 +12,8 @@ type Object struct {
 	Description string
 	Type        interface{}
 	Methods     Methods // Deprecated, use FieldFunc instead.
-
 	key string
+	ServiceName   string 
 }
 
 type paginationObject struct {
@@ -262,6 +262,22 @@ func (s *Object) ManualPaginationWithFallback(name string, manualPaginatedFunc i
 	}
 	s.Methods[name] = m
 }
+
+func (s *Object) FederatedFieldFunc(name string, f interface{}, options ...FieldFuncOption) {
+	if s.Methods == nil {
+		s.Methods = make(Methods)
+	}
+	m := &method{Fn: f}
+	for _, opt := range options {
+		opt.apply(m)
+	}
+	federatedMethodName := fmt.Sprintf("%s-%s", name, s.ServiceName)
+	if _, ok := s.Methods[federatedMethodName]; ok {
+		panic("duplicate method")
+	}
+	s.Methods[federatedMethodName] = m
+}
+
 
 // Key registers the key field on an object. The field should be specified by the name of the
 // graphql field.

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -368,3 +368,20 @@ func (s *Object) Federation(f interface{}) {
 	}
 	s.FieldFunc("__federation", f)
 }
+
+func (s *Schema) FederatedObject(name string, typ interface{}) *Object {
+	if object, ok := s.objects[name]; ok {
+		if reflect.TypeOf(object.Type) != reflect.TypeOf(typ) {
+			panic("re-registered object with different type")
+		}
+		return object
+	}
+	object := &Object{
+		Name:        name,
+		Type:        typ,
+		ServiceName: s.Name,
+		IsFederated: true,
+	}
+	s.objects[name] = object
+	return object
+}

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -13,7 +13,8 @@ type Object struct {
 	Type        interface{}
 	Methods     Methods // Deprecated, use FieldFunc instead.
 	key string
-	ServiceName   string 
+	ServiceName string 
+	IsFederated bool
 }
 
 type paginationObject struct {
@@ -362,5 +363,8 @@ type Union struct{}
 var unionType = reflect.TypeOf(Union{})
 
 func (s *Object) Federation(f interface{}) {
+	if s.IsFederated {
+		panic("can't federate a federated method")
+	}
 	s.FieldFunc("__federation", f)
 }

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -2,6 +2,7 @@ package schemabuilder
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 )
 

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -139,6 +139,9 @@ type Field struct {
 	// field execution (batch or non-expensive).  We pass in the number of srcs
 	// we're executing with so implementers can write custom logic.
 	NumParallelInvocationsFunc func(ctx context.Context, numNodes int) int
+
+	// FederatedKey tells us which services need this field as federated key.
+	FederatedKey map[string]bool
 }
 
 type Schema struct {


### PR DESCRIPTION
A federated server can have multiple keys. We pass only the necessary keys to each service by checking what keys that federated schema knows about.

(This is the same PR as https://github.com/samsarahq/thunder/pull/375)