### PR TITLE
Prototype: Federation API changes

### DIFF
--- a/federation/customexecutor_test.go
+++ b/federation/customexecutor_test.go
@@ -88,11 +88,9 @@ func createFederatedSchema(t *testing.T) *schemabuilder.Schema {
 		Name  string
 	}
 	s1 := schemabuilder.NewSchema()
-	user := s1.Object("User", User{})
+	user := s1.Object("User", User{}, schemabuilder.RootObject)
 	user.Key("id")
-	user.Federation(func(u *User) int64 {
-		return u.Id
-	})
+
 	s1.Query().FieldFunc("users", func(ctx context.Context) ([]*User, error) {
 		value, ok := ctx.Value("authtoken").(string)
 		if ok && value == "testToken" {

--- a/federation/executor_test.go
+++ b/federation/executor_test.go
@@ -148,7 +148,7 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 		OrgId int64
 	}
 	s2 := schemabuilder.NewSchemaWithName("s2")
-	s2.Federation().FederatedFieldFunc("User", func(ctx context.Context, args struct{ Keys []UserKeysWithOrgId }) []*UserWithContactInfo {
+	s2.FederatedFieldFunc("User", func(ctx context.Context, args struct{ Keys []UserKeysWithOrgId }) []*UserWithContactInfo {
 		users := make([]*UserWithContactInfo, 0, len(args.Keys))
 		for _, key := range args.Keys {
 			users = append(users, &UserWithContactInfo{Id: key.Id, OrgId: key.OrgId, Name: "userWithContactInfo", Email: "email@gmail.com", PhoneNumber: "555-5555"})
@@ -193,7 +193,7 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 		Id int64
 	}
 	s3 := schemabuilder.NewSchemaWithName("s3")
-	s3.Federation().FederatedFieldFunc("User", func(args struct{ Keys []UserKeys }) []*UserWithAdminPrivelages {
+	s3.FederatedFieldFunc("User", func(args struct{ Keys []UserKeys }) []*UserWithAdminPrivelages {
 		users := make([]*UserWithAdminPrivelages, 0, len(args.Keys))
 		for _, key := range args.Keys {
 			users = append(users, &UserWithAdminPrivelages{Id: key.Id, OrgId: 0, IsAdmin: true})
@@ -206,7 +206,7 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 		return "all", nil
 	})
 
-	s1.Federation().FederatedFieldFunc("User", func(ctx context.Context, args struct{ Keys []UserKeysWithOrgId }) []*UserWithContactInfo {
+	s1.FederatedFieldFunc("User", func(ctx context.Context, args struct{ Keys []UserKeysWithOrgId }) []*UserWithContactInfo {
 		users := make([]*UserWithContactInfo, 0, len(args.Keys))
 		for _, key := range args.Keys {
 			users = append(users, &UserWithContactInfo{Id: key.Id, OrgId: key.OrgId, Name: "userWithContactInfo", Email: "email@gmail.com", PhoneNumber: "555-5555"})
@@ -223,7 +223,7 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 		Id    int64
 		OrgId int64
 	}
-	s3.Federation().FederatedFieldFunc("Device", func(args struct{ Keys []DeviceKeys }) []*DeviceWithTemperature {
+	s3.FederatedFieldFunc("Device", func(args struct{ Keys []DeviceKeys }) []*DeviceWithTemperature {
 		devices := make([]*DeviceWithTemperature, 0, len(args.Keys))
 		for _, key := range args.Keys {
 			devices = append(devices, &DeviceWithTemperature{Id: key.Id, OrgId: key.OrgId, Temp: int64(70)})
@@ -780,33 +780,31 @@ func TestExecutorQueriesWithBatching(t *testing.T) {
 
 func TestSchemaFederationKeys(t *testing.T) {
 	type Device struct {
-        Id    int64
-        OrgId int64
-        Name  string
-        IsMulticam bool
-        ProductId int64
+		Id         int64
+		OrgId      int64
+		Name       string
+		IsMulticam bool
+		ProductId  int64
 	}
 	s1 := schemabuilder.NewSchemaWithName("rootgqlserver")
 	device := s1.Object("Device", Device{})
 	device.Key("id")
-	device.Federation(func(u *Device) *Device { 
-			return u
+	device.Federation(func(u *Device) *Device {
+		return u
 	})
 	s1.Query().FieldFunc("device", func(ctx context.Context) (*Device, error) {
-		return &Device{Id:1, OrgId:1, Name:"bob", IsMulticam: true, ProductId: 1}, nil
+		return &Device{Id: 1, OrgId: 1, Name: "bob", IsMulticam: true, ProductId: 1}, nil
 	})
-
 
 	s2 := schemabuilder.NewSchemaWithName("safetyserver")
 	type SafetyDevice struct {
-		Id          int64
-		IsMulticam   bool
+		Id                    int64
+		IsMulticam            bool
 		FieldThatDoesntBelong int64
 	}
-	s2.Federation().FederatedFieldFunc("Device", func(args struct{ Keys []*SafetyDevice }) []*SafetyDevice {
-		return args.Keys 
+	s2.FederatedFieldFunc("Device", func(args struct{ Keys []*SafetyDevice }) []*SafetyDevice {
+		return args.Keys
 	})
-
 
 	// Register executor clients
 	executors := make(map[string]ExecutorClient)

--- a/federation/kitchen_sink_test.go
+++ b/federation/kitchen_sink_test.go
@@ -3,6 +3,7 @@ package federation
 import (
 	"context"
 	"fmt"
+
 	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/graphql/schemabuilder"
 )
@@ -88,7 +89,7 @@ func buildTestSchema1() *schemabuilder.Schema {
 	type BarKeys struct {
 		Id int64
 	}
-	schema.Federation().FederatedFieldFunc("Bar", func(args struct{ Keys []*BarKeys }) []*Bar {
+	schema.FederatedFieldFunc("Bar", func(args struct{ Keys []*BarKeys }) []*Bar {
 		bars := make([]*Bar, 0, len(args.Keys))
 		for _, key := range args.Keys {
 			bars = append(bars, &Bar{Id: key.Id})
@@ -124,7 +125,7 @@ func buildTestSchema2() *schemabuilder.Schema {
 	type FooKeys struct {
 		Name string
 	}
-	schema.Federation().FederatedFieldFunc("Foo", func(args struct{ Keys []*FooKeys }) []*Foo {
+	schema.FederatedFieldFunc("Foo", func(args struct{ Keys []*FooKeys }) []*Foo {
 		foos := make([]*Foo, 0, len(args.Keys))
 		for _, key := range args.Keys {
 			foos = append(foos, &Foo{Name: key.Name})
@@ -157,7 +158,7 @@ func buildTestSchema2() *schemabuilder.Schema {
 	})
 
 	bar := schema.Object("Bar", Bar{})
-	bar.Federation(func(b *Bar)  *Bar {
+	bar.Federation(func(b *Bar) *Bar {
 		return b
 	})
 

--- a/federation/kitchen_sink_test.go
+++ b/federation/kitchen_sink_test.go
@@ -68,10 +68,8 @@ func buildTestSchema1() *schemabuilder.Schema {
 		}
 	})
 
-	foo := schema.Object("Foo", Foo{})
-	foo.Federation(func(f *Foo) *Foo {
-		return f
-	})
+	foo := schema.Object("Foo", Foo{}, schemabuilder.RootObject)
+
 	foo.BatchFieldFunc("s1hmm", func(ctx context.Context, in map[batch.Index]*Foo) (map[batch.Index]string, error) {
 		out := make(map[batch.Index]string)
 		for i, foo := range in {
@@ -89,7 +87,7 @@ func buildTestSchema1() *schemabuilder.Schema {
 	type BarKeys struct {
 		Id int64
 	}
-	schema.FederatedFieldFunc("Bar", func(args struct{ Keys []*BarKeys }) []*Bar {
+	schema.FederatedFieldFunc("Bar", BarKeys{}, func(args struct{ Keys []*BarKeys }) []*Bar {
 		bars := make([]*Bar, 0, len(args.Keys))
 		for _, key := range args.Keys {
 			bars = append(bars, &Bar{Id: key.Id})
@@ -125,7 +123,7 @@ func buildTestSchema2() *schemabuilder.Schema {
 	type FooKeys struct {
 		Name string
 	}
-	schema.FederatedFieldFunc("Foo", func(args struct{ Keys []*FooKeys }) []*Foo {
+	schema.FederatedFieldFunc("Foo", FooKeys{}, func(args struct{ Keys []*FooKeys }) []*Foo {
 		foos := make([]*Foo, 0, len(args.Keys))
 		for _, key := range args.Keys {
 			foos = append(foos, &Foo{Name: key.Name})
@@ -157,10 +155,7 @@ func buildTestSchema2() *schemabuilder.Schema {
 		return f
 	})
 
-	bar := schema.Object("Bar", Bar{})
-	bar.Federation(func(b *Bar) *Bar {
-		return b
-	})
+	schema.Object("Bar", Bar{}, schemabuilder.RootObject)
 
 	return schema
 }

--- a/federation/merge_schemas.go
+++ b/federation/merge_schemas.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-
 )
 
 // MergeMode controls how to combine two different schemas. Union is used for

--- a/federation/planner.go
+++ b/federation/planner.go
@@ -79,7 +79,7 @@ type Planner struct {
 // 		  name
 // 		}
 // 	  }
-// }  
+// }
 // "__federation" becomes the root query that the subquery is nested under,
 // "Foo" is the federated object type that we need to refetch,
 // and "__typename" lets gateway know what type the object is.
@@ -104,7 +104,7 @@ func printSelections(selectionSet *graphql.SelectionSet) {
 		fmt.Println(" selections")
 		for _, subSelection := range selectionSet.Selections {
 			fmt.Println(" ", subSelection.Name)
-			if (subSelection.Args != nil) {
+			if subSelection.Args != nil {
 				fmt.Println("   args ", subSelection.Args)
 			}
 			printSelections(subSelection.SelectionSet)
@@ -268,9 +268,7 @@ func (e *Planner) planObject(typ *graphql.Object, selectionSet *graphql.Selectio
 			p.SelectionSet.Selections = append(p.SelectionSet.Selections, federatedSelection)
 		}
 	}
-
 	return p, nil
-
 }
 
 func (e *Planner) planUnion(typ *graphql.Union, selectionSet *graphql.SelectionSet, service string) (*Plan, error) {
@@ -281,8 +279,8 @@ func (e *Planner) planUnion(typ *graphql.Union, selectionSet *graphql.SelectionS
 		SelectionSet: &graphql.SelectionSet{
 			Selections: []*graphql.Selection{
 				{
-					Name:  "__typename",
-					Alias: "__typename",
+					Name:         "__typename",
+					Alias:        "__typename",
 					UnparsedArgs: map[string]interface{}{},
 				},
 			},

--- a/federation/schema.go
+++ b/federation/schema.go
@@ -97,8 +97,8 @@ func ConvertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo,
 			// on the field object.
 			if typ.Name == "Federation" {
 				for _, field := range typ.Fields {
-				    // Extract the type name from the formatting <object>-<service>
-				    // And check that the object type exists
+					// Extract the type name from the formatting <object>-<service>
+					// And check that the object type exists
 					names := strings.SplitN(field.Name, "-", 2)
 					if len(names) != 2 {
 						return nil, oops.Errorf("Field %s doesnt have an object name and service name", field.Name)
@@ -139,7 +139,6 @@ func ConvertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo,
 			}
 			if typ.Kind == "OBJECT" {
 				obj := types[typ.Name].(*graphql.Object)
-
 				for _, field := range typ.Fields {
 					f := obj.Fields[field.Name]
 

--- a/federation/schema_test.go
+++ b/federation/schema_test.go
@@ -401,7 +401,7 @@ func TestMergeEnumIntersection(t *testing.T) {
 			"zero": 0,
 			"one":  1,
 		})
-		s1.Query().FieldFunc("f", func(args struct{EnumField Enum}) Enum { return Enum(1) })
+		s1.Query().FieldFunc("f", func(args struct{ EnumField Enum }) Enum { return Enum(1) })
 	}
 
 	s2 := schemabuilder.NewSchema()
@@ -410,7 +410,7 @@ func TestMergeEnumIntersection(t *testing.T) {
 			"zero": 0,
 			"two":  2,
 		})
-		s2.Query().FieldFunc("f", func(args struct{EnumField Enum}) Enum { return Enum(1) })
+		s2.Query().FieldFunc("f", func(args struct{ EnumField Enum }) Enum { return Enum(1) })
 	}
 
 	s3 := schemabuilder.NewSchema()
@@ -418,7 +418,7 @@ func TestMergeEnumIntersection(t *testing.T) {
 		s3.Enum(Enum(0), map[string]Enum{
 			"zero": 0,
 		})
-		s3.Query().FieldFunc("f", func(args struct{EnumField Enum}) Enum { return Enum(1) })
+		s3.Query().FieldFunc("f", func(args struct{ EnumField Enum }) Enum { return Enum(1) })
 	}
 
 	assertSchemaIntersectionEq(t, s1, s2, s3)

--- a/graphql/schemabuilder/function.go
+++ b/graphql/schemabuilder/function.go
@@ -90,7 +90,7 @@ func (sb *schemaBuilder) buildFunctionAndFuncCtx(typ reflect.Type, m *method) (*
 	}
 
 	if typ.Name() == "federation" {
-		fmt.Println("yolo     ", reflect.TypeOf(args["keys"]).Elem(), args["keys"], m.FederationType)
+		fmt.Println("yolo     ", reflect.TypeOf(args["keys"]), args["keys"], m.FederationType)
 		// iA := make(map[string]reflect.Type)0
 		// k := reflect.ValueOf(m.FederationType)
 
@@ -101,9 +101,35 @@ func (sb *schemaBuilder) buildFunctionAndFuncCtx(typ reflect.Type, m *method) (*
 
 		fmt.Println("jhbkjn    ", reflect.TypeOf(listOfFederatedType))
 		// iA["keys"] = reflect.New(reflect.List(reflect.TypeOf(args["keys"])))
+
+		// var typeRegistry = map[string]reflect.Type{
+		// 	"keys": reflect.TypeOf(listOfFederatedType),
+		// }
+
+		// keys := make(map[string]reflect.Type, 1)
+		// keys["keys"] = reflect.TypeOf(listOfFederatedType)
+		// fmt.Println(typeRegistry)
+		// reflect.Struct()
+		// t := reflect.TypeOf(listOfFederatedType)
+		// type k struct {
+		// 	keys t
+		// }
+
+		listOfFederatedType = []*Object
+
+		struct {
+			Keys []*Object
+		}
+
 		a, b, err := sb.makeStructParser(reflect.TypeOf(m.FederationType))
-		fmt.Println(a, b, err)
+
+		fmt.Println("VB", a, b, err)
 		fmt.Println(argParser, argType, err)
+
+		args2, _ := funcCtx.argsTypeMap(b)
+
+		fmt.Println("yolo2     ", reflect.TypeOf(args2))
+
 		// c, err := funcCtx.argsTypeMap(b)
 		// if err != nil {
 		// 	return nil, nil, err
@@ -214,6 +240,8 @@ func (funcCtx *funcContext) getArgParserAndTyp(sb *schemaBuilder, in []reflect.T
 	var argType graphql.Type
 	if len(in) > 0 && in[0] != selectionSetType {
 		var err error
+		fmt.Println(" IN ", in[0], reflect.TypeOf(in[0]))
+
 		if argParser, argType, err = sb.makeStructParser(in[0]); err != nil {
 			return nil, nil, in, fmt.Errorf("attempted to parse %s as arguments struct, but failed: %s", in[0].Name(), err.Error())
 		}

--- a/graphql/schemabuilder/function.go
+++ b/graphql/schemabuilder/function.go
@@ -15,6 +15,11 @@ import (
 func (sb *schemaBuilder) buildFunction(typ reflect.Type, m *method) (*graphql.Field, error) {
 	// If the method is federated, we want to built a graphql field that returns all
 	// fields on that object. This allows them to be sent as federated keys to other servers.
+	// if typ.Name() == "federation" && m.FederationType != nil {
+	// returnType, err := sb.getType(reflect.TypeOf(m.FederationType))
+	// fmt.Println("VUHBJN ", typ.Name(), reflect.TypeOf(m.FederationType))
+	// }
+
 	if m.Federated {
 		var argParser *argParser
 		returnType, err := sb.getType(reflect.TypeOf(m.FederationType))
@@ -84,6 +89,45 @@ func (sb *schemaBuilder) buildFunctionAndFuncCtx(typ reflect.Type, m *method) (*
 		return nil, nil, err
 	}
 
+	if typ.Name() == "federation" {
+		fmt.Println("yolo     ", reflect.TypeOf(args["keys"]).Elem(), args["keys"], m.FederationType)
+		// iA := make(map[string]reflect.Type)0
+		// k := reflect.ValueOf(m.FederationType)
+
+		// Create a new instance of the underlying type
+		// vp := reflect.MakeSlice(reflect.TypeOf(m.FederationType), 0, 0)
+		federatedType := reflect.New(reflect.TypeOf(m.FederationType)).Type()
+		listOfFederatedType := reflect.MakeSlice(reflect.SliceOf(federatedType), 0, 0).Interface()
+
+		fmt.Println("jhbkjn    ", reflect.TypeOf(listOfFederatedType))
+		// iA["keys"] = reflect.New(reflect.List(reflect.TypeOf(args["keys"])))
+		a, b, err := sb.makeStructParser(reflect.TypeOf(m.FederationType))
+		fmt.Println(a, b, err)
+		fmt.Println(argParser, argType, err)
+		// c, err := funcCtx.argsTypeMap(b)
+		// if err != nil {
+		// 	return nil, nil, err
+		// }
+		// return &graphql.Field{
+		// 	Resolve: func(ctx context.Context, source, funcRawArgs interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
+		// 		// Set up function arguments.
+		// 		funcInputArgs := funcCtx.prepareResolveArgs(source, funcCtx.hasArgs, funcRawArgs, ctx, selectionSet)
+
+		// 		// Call the function.
+		// 		funcOutputArgs := callableFunc.Call(funcInputArgs)
+
+		// 		return funcCtx.extractResultAndErr(funcOutputArgs, retType)
+
+		// 	},
+		// 	Args:                       c,
+		// 	Type:                       retType,
+		// 	ParseArguments:             a.Parse,
+		// 	Expensive:                  m.Expensive,
+		// 	External:                   true,
+		// 	NumParallelInvocationsFunc: m.ConcurrencyArgs.numParallelInvocationsFunc,
+		// }, funcCtx, nil
+
+	}
 	return &graphql.Field{
 		Resolve: func(ctx context.Context, source, funcRawArgs interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			// Set up function arguments.

--- a/graphql/schemabuilder/output.go
+++ b/graphql/schemabuilder/output.go
@@ -234,7 +234,6 @@ func (sb *schemaBuilder) buildField(field reflect.StructField) (*graphql.Field, 
 	if err != nil {
 		return nil, err
 	}
-
 	return &graphql.Field{
 		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
 			value := reflect.ValueOf(source)

--- a/graphql/schemabuilder/schema.go
+++ b/graphql/schemabuilder/schema.go
@@ -46,7 +46,6 @@ func NewSchemaWithName(name string) *Schema {
 	return schema
 }
 
-
 // Enum registers an enumType in the schema. The val should be any arbitrary value
 // of the enumType to be used for reflection, and the enumMap should be
 // the corresponding map of the enums.
@@ -117,8 +116,8 @@ func (s *Schema) Object(name string, typ interface{}) *Object {
 		return object
 	}
 	object := &Object{
-		Name: name,
-		Type: typ,
+		Name:        name,
+		Type:        typ,
 		ServiceName: s.Name,
 	}
 	s.objects[name] = object
@@ -192,16 +191,4 @@ func (s *Schema) MustBuild() *graphql.Schema {
 		panic(err)
 	}
 	return built
-}
-
-
-type federation struct{}
-
-// Federation returns an object struct for exposing federated objects.
-func (s *Schema) Federation() *Object {
-	q := s.Query()
-	if _, ok := q.Methods["__federation"]; !ok {
-		q.FieldFunc("__federation", func() federation { return federation{} })
-	}
-	return s.Object("Federation", federation{})
 }

--- a/graphql/schemabuilder/schema.go
+++ b/graphql/schemabuilder/schema.go
@@ -119,7 +119,7 @@ func (f objectOptionFunc) apply(m *Object) { f(m) }
 // NonNullable is an option that can be passed to a FieldFunc to indicate that
 // its return value is required, even if the return value is a pointer type.
 var ShadowObject objectOptionFunc = func(m *Object) {
-	m.IsFederated = true
+	m.IsShadow = true
 }
 
 // NonNullable is an option that can be passed to a FieldFunc to indicate that
@@ -165,7 +165,29 @@ func (s *Schema) Object(name string, typ interface{}, options ...ObjectOption) *
 		object.Methods[federationField] = m
 
 	}
+	if object.IsShadow {
+		federatedObjectType := reflect.New(reflect.TypeOf(typ)).Interface()
+		if object.Methods == nil {
+			object.Methods = make(Methods)
+		}
 
+		m := &method{}
+		if _, ok := object.Methods[federationField]; ok {
+			panic("duplicate federation method")
+		}
+		m.FederationType = federatedObjectType
+		m.Federated = true
+		m.ShadowType = federatedObjectType
+		object.Methods[federationField] = m
+
+		// fo := reflect.New(reflect.SliceOf(reflect.TypeOf(typ))).Interface()
+		// reflect.
+
+		fmt.Println("F   F  O  ", reflect.TypeOf(federatedObjectType))
+
+		// s.FederatedFieldFunc("User", typ, nil)
+
+	}
 	s.objects[name] = object
 	return object
 }

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -13,8 +13,8 @@ type Object struct {
 	Description string
 	Type        interface{}
 	Methods     Methods // Deprecated, use FieldFunc instead.
-	key string
-	ServiceName string 
+	key         string
+	ServiceName string
 	IsFederated bool
 }
 
@@ -265,21 +265,28 @@ func (s *Object) ManualPaginationWithFallback(name string, manualPaginatedFunc i
 	s.Methods[name] = m
 }
 
-func (s *Object) FederatedFieldFunc(name string, f interface{}, options ...FieldFuncOption) {
-	if s.Methods == nil {
-		s.Methods = make(Methods)
+type federation struct{}
+
+func (s *Schema) FederatedFieldFunc(name string, f interface{}, options ...FieldFuncOption) {
+	q := s.Query()
+	if _, ok := q.Methods["__federation"]; !ok {
+		q.FieldFunc("__federation", func() federation { return federation{} })
+	}
+	obj := s.Object("Federation", federation{})
+
+	if obj.Methods == nil {
+		obj.Methods = make(Methods)
 	}
 	m := &method{Fn: f}
 	for _, opt := range options {
 		opt.apply(m)
 	}
-	federatedMethodName := fmt.Sprintf("%s-%s", name, s.ServiceName)
-	if _, ok := s.Methods[federatedMethodName]; ok {
+	federatedMethodName := fmt.Sprintf("%s-%s", name, obj.ServiceName)
+	if _, ok := obj.Methods[federatedMethodName]; ok {
 		panic("duplicate method")
 	}
-	s.Methods[federatedMethodName] = m
+	obj.Methods[federatedMethodName] = m
 }
-
 
 // Key registers the key field on an object. The field should be specified by the name of the
 // graphql field.

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -16,6 +16,7 @@ type Object struct {
 	key           string
 	ServiceName   string
 	IsFederated   bool
+	IsShadow      bool
 	FederatedType interface{}
 }
 
@@ -292,6 +293,7 @@ func (s *Schema) FederatedFieldFunc(name string, typ interface{}, f interface{},
 	if _, ok := obj.Methods[federatedMethodName]; ok {
 		panic("duplicate method")
 	}
+	m.FederationType = typ
 	obj.Methods[federatedMethodName] = m
 }
 
@@ -333,6 +335,8 @@ type method struct {
 	ManualPaginationArgs manualPaginationArgs
 
 	FederationType interface{}
+
+	ShadowType interface{}
 
 	Federated bool
 }


### PR DESCRIPTION
When created a federated field func we use to have to do 
```
schema.Federation().FederatedFieldFunc("Device", func(args struct{ Keys []SafetyDevice }) []*SafetyDevice {
        return args.Keys 
})
```
but since this is always on a federated object we can simplify the api
```
s2.FederatedFieldFunc("Device", func(args struct{ Keys []SafetyDevice }) []*SafetyDevice {
        return args.Keys 
})
```
Also fixed any linting issues in the files changed.