### PR TITLE
Simplify api for federating a object 

### DIFF
--- a/federation/customexecutor_test.go
+++ b/federation/customexecutor_test.go
@@ -88,11 +88,8 @@ func createFederatedSchema(t *testing.T) *schemabuilder.Schema {
 		Name  string
 	}
 	s1 := schemabuilder.NewSchema()
-	user := s1.Object("User", User{})
+	user := s1.Object("User", User{}, schemabuilder.RootObject)
 	user.Key("id")
-	user.Federation(func(u *User) int64 {
-		return u.Id
-	})
 	s1.Query().FieldFunc("users", func(ctx context.Context) ([]*User, error) {
 		value, ok := ctx.Value("authtoken").(string)
 		if ok && value == "testToken" {

--- a/federation/kitchen_sink_test.go
+++ b/federation/kitchen_sink_test.go
@@ -3,6 +3,7 @@ package federation
 import (
 	"context"
 	"fmt"
+
 	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/graphql/schemabuilder"
 )
@@ -67,10 +68,7 @@ func buildTestSchema1() *schemabuilder.Schema {
 		}
 	})
 
-	foo := schema.Object("Foo", Foo{})
-	foo.Federation(func(f *Foo) *Foo {
-		return f
-	})
+	foo := schema.Object("Foo", Foo{}, schemabuilder.RootObject)
 	foo.BatchFieldFunc("s1hmm", func(ctx context.Context, in map[batch.Index]*Foo) (map[batch.Index]string, error) {
 		out := make(map[batch.Index]string)
 		for i, foo := range in {
@@ -156,10 +154,6 @@ func buildTestSchema2() *schemabuilder.Schema {
 		return f
 	})
 
-	bar := schema.Object("Bar", Bar{})
-	bar.Federation(func(b *Bar)  *Bar {
-		return b
-	})
-
+	schema.Object("Bar", Bar{}, schemabuilder.RootObject)
 	return schema
 }

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -13,8 +13,8 @@ type Object struct {
 	Description string
 	Type        interface{}
 	Methods     Methods // Deprecated, use FieldFunc instead.
-	key string
-	ServiceName string 
+	key         string
+	ServiceName string
 	IsFederated bool
 }
 
@@ -280,7 +280,6 @@ func (s *Object) FederatedFieldFunc(name string, f interface{}, options ...Field
 	s.Methods[federatedMethodName] = m
 }
 
-
 // Key registers the key field on an object. The field should be specified by the name of the
 // graphql field.
 // For example, for an object User:
@@ -317,6 +316,10 @@ type method struct {
 	BatchArgs batchArgs
 
 	ManualPaginationArgs manualPaginationArgs
+
+	// FederationType is an object where all the fields are keys
+	// that can be exposed over federation
+	FederationType interface{}
 }
 
 type concurrencyArgs struct {
@@ -362,13 +365,6 @@ type Methods map[string]*method
 type Union struct{}
 
 var unionType = reflect.TypeOf(Union{})
-
-func (s *Object) Federation(f interface{}) {
-	if s.IsFederated {
-		panic("can't federate a federated method")
-	}
-	s.FieldFunc("__federation", f)
-}
 
 func (s *Schema) FederatedObject(name string, typ interface{}) *Object {
 	if object, ok := s.objects[name]; ok {


### PR DESCRIPTION
When we create a an object that can be federated, we use to have to specify a function to expose certain fields 
```
user := s1.Object("User", User{})
user.Federation(func(u *User) *User {
        return u
})
```

but now we can pass in an option to the object to autogenerate this function in the schema

```
user := s1.Object("User", User{}, schemabuilder.RootObject)
```

We want developers to add this so we are aware of what objects are federated and what the root types are instead of making everything a federated object. 