### PR TITLE
sqlgen Add batch insert API support to sqlgen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### `sqlgen`
 
 - Added `WithDynamicLimit` which is similar to `WithShardLimit` but allows for user-specified dynamic filters instead of a single static filter at registration time.
+- Added `InsertRows` which is similar to `InsertRow` but allows inserting multiple rows with those being sent over to db `chunkSize` rows at a time.
 
 ### Changed
 

--- a/sqlgen/mysql.go
+++ b/sqlgen/mysql.go
@@ -128,6 +128,48 @@ func (q *InsertQuery) ToSQL() (string, []interface{}) {
 	return buffer.String(), q.Values
 }
 
+// BatchInsertQuery represents a INSERT query with multiple rows
+type BatchInsertQuery struct {
+	Table   string
+	Columns []string
+	Values  []interface{}
+}
+
+// ToSQL builds a parameterized INSERT INTO x (a, b) VALUES (?, ?), (?, ?) ... statement
+func (q *BatchInsertQuery) ToSQL() (string, []interface{}) {
+	var buffer bytes.Buffer
+	buffer.WriteString("INSERT INTO ")
+	buffer.WriteString(q.Table)
+
+	if len(q.Columns) > 0 {
+		buffer.WriteString(" (")
+		for i, column := range q.Columns {
+			if i > 0 {
+				buffer.WriteString(", ")
+			}
+			buffer.WriteString(column)
+		}
+		buffer.WriteString(") VALUES ")
+
+		numRows := len(q.Values) / len(q.Columns)
+		for i := 0; i < numRows; i++ {
+			if i > 0 {
+				buffer.WriteString(", ")
+			}
+			buffer.WriteString("(")
+			for j := range q.Columns {
+				if j > 0 {
+					buffer.WriteString(", ")
+				}
+				buffer.WriteString("?")
+			}
+			buffer.WriteString(")")
+		}
+	}
+
+	return buffer.String(), q.Values
+}
+
 // UpsertQuery represents a INSERT ... ON DUPLICATE KEY UPDATE query
 type UpsertQuery struct {
 	Table   string

--- a/sqlgen/mysql_test.go
+++ b/sqlgen/mysql_test.go
@@ -119,6 +119,26 @@ func TestInsertQuery(t *testing.T) {
 	}, "INSERT INTO foo3", []interface{}{}, t)
 }
 
+func TestBatchInsertQuery(t *testing.T) {
+	testQuery(&BatchInsertQuery{
+		Table:   "foo",
+		Columns: []string{"bar"},
+		Values:  []interface{}{3, 4},
+	}, "INSERT INTO foo (bar) VALUES (?), (?)", []interface{}{3, 4}, t)
+
+	testQuery(&BatchInsertQuery{
+		Table:   "foo2",
+		Columns: []string{"bar", "baz"},
+		Values:  []interface{}{3, "buh"},
+	}, "INSERT INTO foo2 (bar, baz) VALUES (?, ?)", []interface{}{3, "buh"}, t)
+
+	testQuery(&BatchInsertQuery{
+		Table:   "foo2",
+		Columns: []string{"bar", "baz"},
+		Values:  []interface{}{3, "buh", 5, "test"},
+	}, "INSERT INTO foo2 (bar, baz) VALUES (?, ?), (?, ?)", []interface{}{3, "buh", 5, "test"}, t)
+}
+
 func TestUpsertQuery(t *testing.T) {
 	testQuery(&UpsertQuery{
 		Table:   "foo",

--- a/sqlgen/reflect_test.go
+++ b/sqlgen/reflect_test.go
@@ -347,6 +347,27 @@ func TestMakeInsertAutoIncrement(t *testing.T) {
 	assert.Equal(t, []interface{}{"bob", int64(20), nil, make([]byte, 16)}, query.Values)
 }
 
+func TestMakeBatchInsertAutoIncrement(t *testing.T) {
+	s := NewSchema()
+	if err := s.RegisterType("users", AutoIncrement, user{}); err != nil {
+		t.Fatal(err)
+	}
+
+	query, err := s.MakeBatchInsertRow([](interface{}){
+		&user{
+			Name: "bob",
+			Age:  20,
+		},
+		&user{
+			Name: "ben",
+			Age:  30,
+		}})
+	assert.NoError(t, err)
+	assert.Equal(t, "users", query.Table)
+	assert.Equal(t, []string{"name", "age", "optional", "uuid"}, query.Columns)
+	assert.Equal(t, []interface{}{"bob", int64(20), nil, make([]byte, 16), "ben", int64(30), nil, make([]byte, 16)}, query.Values)
+}
+
 func TestMakeUpsertAutoIncrement(t *testing.T) {
 	s := NewSchema()
 	if err := s.RegisterType("users", AutoIncrement, user{}); err != nil {


### PR DESCRIPTION
Current sqlgen API only allows inserting one row at a time which makes running large backfills very time consuming.
The intention of the batch API is to allow running backfills at a faster rate