### PR TITLE
Federation: Error handling tests and bug fix

### DIFF
--- a/federation/executor_test.go
+++ b/federation/executor_test.go
@@ -3,6 +3,7 @@ package federation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -808,4 +809,98 @@ func TestExecutorWithInvalidFederationKeys(t *testing.T) {
 
 	_, err = NewExecutor(ctx, execs, &CustomExecutorArgs{})
 	assert.True(t, strings.Contains(err.Error(), "Invalid federation key unkownField"))
+}
+
+func createMutationExecutor() (map[string]ExecutorClient, error) {
+	s1 := schemabuilder.NewSchemaWithName("s1")
+	type User struct {
+		Id   int64
+		Name string
+	}
+	s1.Mutation().FieldFunc("newUser", func(ctx context.Context) (*User, error) {
+		return &User{Id: int64(123), Name: "bob"}, nil
+	})
+
+	s2 := schemabuilder.NewSchemaWithName("s2")
+	s2.Mutation().FieldFunc("newFakeUser", func(ctx context.Context) (*User, error) {
+		return &User{Id: int64(234), Name: "fake"}, nil
+	})
+	return makeExecutors(map[string]*schemabuilder.Schema{
+		"s1": s1,
+		"s2": s2,
+	})
+}
+
+func TestMutationExecutor(t *testing.T) {
+	e, err := createMutationExecutor()
+	require.NoError(t, err)
+	ctx := context.Background()
+	executor, err := NewExecutor(ctx, e, &CustomExecutorArgs{})
+	require.NoError(t, err)
+
+	testCases := []struct {
+		Name          string
+		Query         string
+		Output        string
+		Error         bool
+		ExpectedError string
+	}{
+		{
+			Name: "query fields a succesful mutation",
+			Query: `mutation NewUser {
+				newUser {
+					id
+					name
+				}
+			}`,
+			Output: `
+			{
+				"newUser":{
+					"id":123,
+					"name":"bob"
+				}
+			}`,
+			Error: false,
+		},
+		{
+			Name: "query fields multiple mutations",
+			Query: `mutation NewUser {
+				newUser {
+					id
+				}
+				newFakeUser {
+					id
+				}
+			}`,
+			Output:        "",
+			Error:         true,
+			ExpectedError: "only support 1 mutation step to maintain ordering",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			if !testCase.Error {
+				runAndValidateQueryResults(t, ctx, executor, testCase.Query, testCase.Output)
+			} else {
+				runAndValidateQueryError(t, ctx, executor, testCase.Query, testCase.Output, testCase.ExpectedError)
+			}
+		})
+	}
+}
+
+func TestExecutorReturnsError(t *testing.T) {
+	schema := schemabuilder.NewSchema()
+	schema.Query().FieldFunc("fail", func(ctx context.Context) (string, error) {
+		return "", errors.New("uh oh")
+	})
+
+	ctx := context.Background()
+	execs, err := makeExecutors(map[string]*schemabuilder.Schema{
+		"schema": schema,
+	})
+	require.NoError(t, err)
+
+	e, err := NewExecutor(ctx, execs, &CustomExecutorArgs{})
+	require.NoError(t, err)
+	runAndValidateQueryError(t, ctx, e, `{ fail }`, ``, "executing query: fail: uh oh")
 }

--- a/federation/server.go
+++ b/federation/server.go
@@ -79,7 +79,7 @@ func ExecuteRequest(ctx context.Context, req *thunderpb.ExecuteRequest, gqlSchem
 	var queryError error
 	rerunner := reactive.NewRerunner(ctx, func(ctx context.Context) (ret interface{}, err error) {
 		defer func() {
-			queryResponse = ret.(*thunderpb.ExecuteResponse)
+			queryResponse, _ = ret.(*thunderpb.ExecuteResponse)
 			queryError = err
 			close(done)
 		}()


### PR DESCRIPTION
Added tests for mutations, preventing multiple mutations, and error handling. Also fixed a bug so that the error gets propagated back to the user correctly. 