### PR TITLE
IntrospectionSchemaSyncer: add a queryMetadata field to the syncer

### DIFF
--- a/federation/customexecutor_test.go
+++ b/federation/customexecutor_test.go
@@ -136,7 +136,7 @@ func TestCustomExecutor(t *testing.T) {
 	srv, err := NewCustomExecutorServer(schema.MustBuild())
 	require.NoError(t, err)
 	execs["s1"] = &SpecialExecutorClient{Client: srv}
-	e, err := NewExecutor(ctx, execs, &CustomExecutorArgs{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs)})
+	e, err := NewExecutor(ctx, execs, &CustomExecutorArgs{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs, nil)})
 	require.NoError(t, err)
 	executeSuccesfulQuery(t, ctx, e, &Token{token: "testToken"})
 }

--- a/federation/executor_test.go
+++ b/federation/executor_test.go
@@ -250,7 +250,7 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 		return nil, nil, nil, nil, err
 	}
 
-	e, err := NewExecutor(ctx, execs, &CustomExecutorArgs{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs)})
+	e, err := NewExecutor(ctx, execs, &CustomExecutorArgs{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs, nil)})
 	return e, s1, s2, s3, err
 }
 
@@ -808,7 +808,7 @@ func TestExecutorWithInvalidFederationKeys(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	_, err = NewExecutor(ctx, execs, &CustomExecutorArgs{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs)})
+	_, err = NewExecutor(ctx, execs, &CustomExecutorArgs{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs, nil)})
 	assert.True(t, strings.Contains(err.Error(), "Invalid federation key unkownField"))
 }
 
@@ -837,7 +837,7 @@ func TestMutationExecutor(t *testing.T) {
 	e, err := createMutationExecutor()
 	require.NoError(t, err)
 	ctx := context.Background()
-	executor, err := NewExecutor(ctx, e, &CustomExecutorArgs{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, e)})
+	executor, err := NewExecutor(ctx, e, &CustomExecutorArgs{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, e, nil)})
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -902,7 +902,7 @@ func TestExecutorReturnsError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	e, err := NewExecutor(ctx, execs, &CustomExecutorArgs{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs)})
+	e, err := NewExecutor(ctx, execs, &CustomExecutorArgs{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs, nil)})
 	require.NoError(t, err)
 	runAndValidateQueryError(t, ctx, e, `{ fail }`, ``, "executing query: fail: uh oh")
 }

--- a/federation/metadataexecutor_test.go
+++ b/federation/metadataexecutor_test.go
@@ -68,7 +68,7 @@ func TestCustomMetadataExecutor(t *testing.T) {
 	srv, err := NewCustomMetadataServer(schema.MustBuild())
 	require.NoError(t, err)
 	execs["s1"] = &SpecialMetadataExecutorClient{Client: srv}
-	e, err := NewExecutor(ctx, execs, &CustomExecutorArgs{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs)})
+	e, err := NewExecutor(ctx, execs, &CustomExecutorArgs{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs, nil)})
 	require.NoError(t, err)
 	md := metadata.Pairs("authtoken", "testToken")
 	ctx = metadata.NewOutgoingContext(context.Background(), md)

--- a/federation/schema_syncer.go
+++ b/federation/schema_syncer.go
@@ -14,13 +14,15 @@ type SchemaSyncer interface {
 	FetchPlanner(ctx context.Context) (*Planner, error)
 }
 type IntrospectionSchemaSyncer struct {
-	executors map[string]ExecutorClient
+	executors     map[string]ExecutorClient
+	queryMetadata interface{}
 }
 
 // Creates a schema syncer that periodically runs an introspection query agaisnt all the federated servers to check for updates.
-func NewIntrospectionSchemaSyncer(ctx context.Context, executors map[string]ExecutorClient) *IntrospectionSchemaSyncer {
+func NewIntrospectionSchemaSyncer(ctx context.Context, executors map[string]ExecutorClient, queryMetadata interface{}) *IntrospectionSchemaSyncer {
 	ss := &IntrospectionSchemaSyncer{
-		executors: executors,
+		executors:     executors,
+		queryMetadata: queryMetadata,
 	}
 	return ss
 }
@@ -28,7 +30,7 @@ func NewIntrospectionSchemaSyncer(ctx context.Context, executors map[string]Exec
 func (s *IntrospectionSchemaSyncer) FetchPlanner(ctx context.Context) (*Planner, error) {
 	schemas := make(map[string]*introspectionQueryResult)
 	for server, client := range s.executors {
-		resp, err := fetchSchema(ctx, client, nil)
+		resp, err := fetchSchema(ctx, client, s.queryMetadata)
 		if err != nil {
 			return nil, oops.Wrapf(err, "fetching schema %s", server)
 		}


### PR DESCRIPTION
So that we can pass metadata to the introspection query.