### PR TITLE
go sql: add option to panic on non-indexed queries

### DIFF
--- a/sqlgen/reflect.go
+++ b/sqlgen/reflect.go
@@ -23,6 +23,8 @@ type SelectOptions struct {
 
 	OrderBy string
 	Limit   int
+
+	AllowNoIndex bool
 }
 
 func (s *SelectOptions) IncludeFilter(table *Table, filter Filter) error {
@@ -381,8 +383,8 @@ func (b *baseCountQuery) makeCountQuery() (*countQuery, error) {
 	}
 
 	return &countQuery{
-		Table:   b.Table.Name,
-		Where:   where,
+		Table: b.Table.Name,
+		Where: where,
 	}, nil
 }
 


### PR DESCRIPTION
In this commit we add the ability to instrument a connection
with a boolean that, when enabled, will have a query panic
when no index is present in a sql explain for that query.

We also add the ability to bypass this check on any given query
in SelectOptions. Additionally we add some thin wrappers to our
query functions to set this option.

This will permit us to enable this check in
tests and have people explicitly make full table scan queries
when they fully intend to.

Implementation detail:
We check both key and possible keys since there are times where key
will be non-null (eg PRIMARY) while possible keys is null, and also
times when key is null, but possible keys is not null (eg when
mysql chooses a full scan despite the presence of an index due to small
table size)