### PR TITLE
federation: make introspectionQueryResult public

### DIFF
--- a/federation/merge_schemas.go
+++ b/federation/merge_schemas.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-
 )
 
 // MergeMode controls how to combine two different schemas. Union is used for
@@ -95,7 +94,7 @@ type introspectionSchema struct {
 	Types []introspectionType `json:"types"`
 }
 
-type introspectionQueryResult struct {
+type IntrospectionQueryResult struct {
 	Schema introspectionSchema `json:"__schema"`
 }
 
@@ -365,7 +364,7 @@ func mergeTypes(a, b introspectionType, mode MergeMode) (*introspectionType, err
 	return &merged, nil
 }
 
-func mergeSchemas(a, b *introspectionQueryResult, mode MergeMode) (*introspectionQueryResult, error) {
+func mergeSchemas(a, b *IntrospectionQueryResult, mode MergeMode) (*IntrospectionQueryResult, error) {
 	types := make(map[string][]introspectionType)
 	for _, a := range a.Schema.Types {
 		types[a.Name] = append(types[a.Name], a)
@@ -396,14 +395,14 @@ func mergeSchemas(a, b *introspectionQueryResult, mode MergeMode) (*introspectio
 		merged = append(merged, *m)
 	}
 
-	return &introspectionQueryResult{
+	return &IntrospectionQueryResult{
 		Schema: introspectionSchema{
 			Types: merged,
 		},
 	}, nil
 }
 
-func mergeSchemaSlice(schemas []*introspectionQueryResult, mode MergeMode) (*introspectionQueryResult, error) {
+func mergeSchemaSlice(schemas []*IntrospectionQueryResult, mode MergeMode) (*IntrospectionQueryResult, error) {
 	if len(schemas) == 0 {
 		return nil, errors.New("no schemas")
 	}

--- a/federation/planner_test.go
+++ b/federation/planner_test.go
@@ -25,7 +25,7 @@ func setupExecutor(t *testing.T) (*Planner, error) {
 
 	builtSchemas := make(serviceSchemas)
 	for service, versions := range schemas {
-		builtSchemas[service] = make(map[string]*introspectionQueryResult)
+		builtSchemas[service] = make(map[string]*IntrospectionQueryResult)
 		for version, schema := range versions {
 			builtSchemas[service][version] = extractSchema(t, schema.MustBuild())
 		}

--- a/federation/schema.go
+++ b/federation/schema.go
@@ -13,7 +13,7 @@ import (
 // serviceSchemas holds all schemas for all of versions of
 // all executors services. It is a map from service name
 // and version to schema.
-type serviceSchemas map[string]map[string]*introspectionQueryResult
+type serviceSchemas map[string]map[string]*IntrospectionQueryResult
 
 // FieldInfo holds federation-specific information for
 // graphql.Fields used to plan and execute queries.
@@ -42,7 +42,7 @@ func getRootType(typ *introspectionTypeRef) *introspectionTypeRef {
 // validateFederationKeys validates that if a service is asking for a federated key, all the services
 // that have the objcet registered as a root object expose the field. This ensures that we can make
 // the hop from the root server to any of the federated servers safely before any queries are executed.
-func validateFederationKeys(serviceNames []string, serviceSchemasByName map[string]*introspectionQueryResult, obj *graphql.Object, keyField string) error {
+func validateFederationKeys(serviceNames []string, serviceSchemasByName map[string]*IntrospectionQueryResult, obj *graphql.Object, keyField string) error {
 	validFederatedKey := false
 	for _, service := range serviceNames {
 		for _, typ := range serviceSchemasByName[service].Schema.Types {
@@ -87,10 +87,10 @@ func ConvertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo,
 	}
 	sort.Strings(serviceNames)
 
-	serviceSchemasByName := make(map[string]*introspectionQueryResult)
+	serviceSchemasByName := make(map[string]*IntrospectionQueryResult)
 
 	// Finds the intersection of different version of the schemas
-	var serviceSchemas []*introspectionQueryResult
+	var serviceSchemas []*IntrospectionQueryResult
 	for _, service := range serviceNames {
 		versions := schemas[service]
 
@@ -100,7 +100,7 @@ func ConvertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo,
 		}
 		sort.Strings(versionNames)
 
-		var versionSchemas []*introspectionQueryResult
+		var versionSchemas []*IntrospectionQueryResult
 		for _, version := range versionNames {
 			versionSchemas = append(versionSchemas, versions[version])
 		}
@@ -210,10 +210,10 @@ func ConvertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo,
 
 // convertSchema annotates the schema with federation information vt
 // mapping fields to the corresponding services.
-func convertSchema(schemas map[string]*introspectionQueryResult) (*SchemaWithFederationInfo, error) {
+func convertSchema(schemas map[string]*IntrospectionQueryResult) (*SchemaWithFederationInfo, error) {
 	versionedSchemas := make(serviceSchemas)
 	for service, schema := range schemas {
-		versionedSchemas[service] = map[string]*introspectionQueryResult{
+		versionedSchemas[service] = map[string]*IntrospectionQueryResult{
 			"": schema,
 		}
 	}
@@ -303,7 +303,7 @@ func parseInputFields(source []introspectionInputField, all map[string]graphql.T
 
 // parseSchema takes the introspected schema, validates the types,
 // and maps every field to the graphql types
-func parseSchema(schema *introspectionQueryResult) (map[string]graphql.Type, error) {
+func parseSchema(schema *IntrospectionQueryResult) (map[string]graphql.Type, error) {
 	all := make(map[string]graphql.Type)
 
 	for _, typ := range schema.Schema.Types {

--- a/federation/schema_syncer.go
+++ b/federation/schema_syncer.go
@@ -28,14 +28,14 @@ func NewIntrospectionSchemaSyncer(ctx context.Context, executors map[string]Exec
 }
 
 func (s *IntrospectionSchemaSyncer) FetchPlanner(ctx context.Context) (*Planner, error) {
-	schemas := make(map[string]*introspectionQueryResult)
+	schemas := make(map[string]*IntrospectionQueryResult)
 	for server, client := range s.executors {
 		resp, err := fetchSchema(ctx, client, s.queryMetadata)
 		if err != nil {
 			return nil, oops.Wrapf(err, "fetching schema %s", server)
 		}
 		schema := resp.Result
-		var iq introspectionQueryResult
+		var iq IntrospectionQueryResult
 		if err := json.Unmarshal(schema, &iq); err != nil {
 			return nil, oops.Wrapf(err, "unmarshaling schema %s", server)
 		}
@@ -54,7 +54,7 @@ func (s *IntrospectionSchemaSyncer) FetchPlanner(ctx context.Context) (*Planner,
 		return nil, oops.Wrapf(err, "error running introspection query")
 	}
 
-	var iq introspectionQueryResult
+	var iq IntrospectionQueryResult
 	if err := json.Unmarshal(schema, &iq); err != nil {
 		return nil, oops.Wrapf(err, "unmarshaling introspection schema")
 	}

--- a/federation/schema_syncer_test.go
+++ b/federation/schema_syncer_test.go
@@ -31,13 +31,13 @@ func newFileSchemaSyncer(ctx context.Context, services []string) *FileSchemaSync
 }
 
 func (s *FileSchemaSyncer) FetchPlanner(ctx context.Context) (*Planner, error) {
-	schemas := make(map[string]*introspectionQueryResult)
+	schemas := make(map[string]*IntrospectionQueryResult)
 	for _, server := range s.services {
 		schema, err := readFile(server)
 		if err != nil {
 			return nil, oops.Wrapf(err, "error reading file for server %s", server)
 		}
-		var iq introspectionQueryResult
+		var iq IntrospectionQueryResult
 		if err := json.Unmarshal(schema, &iq); err != nil {
 			return nil, oops.Wrapf(err, "unmarshaling schema %s", server)
 		}
@@ -55,7 +55,7 @@ func (s *FileSchemaSyncer) FetchPlanner(ctx context.Context) (*Planner, error) {
 		return nil, oops.Wrapf(err, "error running introspection query")
 	}
 
-	var iq introspectionQueryResult
+	var iq IntrospectionQueryResult
 	if err := json.Unmarshal(schema, &iq); err != nil {
 		return nil, oops.Wrapf(err, "unmarshaling introspection schema")
 	}

--- a/federation/schema_test.go
+++ b/federation/schema_test.go
@@ -14,24 +14,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func extractSchema(t *testing.T, schema *graphql.Schema) *introspectionQueryResult {
+func extractSchema(t *testing.T, schema *graphql.Schema) *IntrospectionQueryResult {
 	bytes, err := introspection.RunIntrospectionQuery(introspection.BareIntrospectionSchema(schema))
 	require.NoError(t, err)
-	var iq introspectionQueryResult
+	var iq IntrospectionQueryResult
 	err = json.Unmarshal(bytes, &iq)
 	require.NoError(t, err)
 	return &iq
 }
 
-func extractSchemas(t *testing.T, schemas map[string]*schemabuilder.Schema) map[string]*introspectionQueryResult {
-	out := make(map[string]*introspectionQueryResult)
+func extractSchemas(t *testing.T, schemas map[string]*schemabuilder.Schema) map[string]*IntrospectionQueryResult {
+	out := make(map[string]*IntrospectionQueryResult)
 	for k, v := range schemas {
 		out[k] = extractSchema(t, v.MustBuild())
 	}
 	return out
 }
 
-func extractConvertedSchemas(t *testing.T, schemas map[string]*schemabuilder.Schema) *introspectionQueryResult {
+func extractConvertedSchemas(t *testing.T, schemas map[string]*schemabuilder.Schema) *IntrospectionQueryResult {
 	combined, err := convertSchema(extractSchemas(t, schemas))
 	assert.NoError(t, err)
 	return extractSchema(t, combined.Schema)
@@ -97,10 +97,10 @@ func getFieldServiceMaps(t *testing.T, s *SchemaWithFederationInfo) map[string][
 	return fieldServices
 }
 
-func extractConvertedVersionedSchemas(t *testing.T, schemas map[string]map[string]*schemabuilder.Schema) (*introspectionQueryResult, map[string][]string) {
+func extractConvertedVersionedSchemas(t *testing.T, schemas map[string]map[string]*schemabuilder.Schema) (*IntrospectionQueryResult, map[string][]string) {
 	builtSchemas := make(serviceSchemas)
 	for service, versions := range schemas {
-		builtSchemas[service] = make(map[string]*introspectionQueryResult)
+		builtSchemas[service] = make(map[string]*IntrospectionQueryResult)
 		for version, schema := range versions {
 			builtSchemas[service][version] = extractSchema(t, schema.MustBuild())
 		}
@@ -125,7 +125,7 @@ func TestBuildSchemaKitchenSink(t *testing.T) {
 	out, err := introspection.RunIntrospectionQuery(types.Schema)
 	require.NoError(t, err)
 
-	var iq introspectionQueryResult
+	var iq IntrospectionQueryResult
 	err = json.Unmarshal(out, &iq)
 	require.NoError(t, err)
 
@@ -401,7 +401,7 @@ func TestMergeEnumIntersection(t *testing.T) {
 			"zero": 0,
 			"one":  1,
 		})
-		s1.Query().FieldFunc("f", func(args struct{EnumField Enum}) Enum { return Enum(1) })
+		s1.Query().FieldFunc("f", func(args struct{ EnumField Enum }) Enum { return Enum(1) })
 	}
 
 	s2 := schemabuilder.NewSchema()
@@ -410,7 +410,7 @@ func TestMergeEnumIntersection(t *testing.T) {
 			"zero": 0,
 			"two":  2,
 		})
-		s2.Query().FieldFunc("f", func(args struct{EnumField Enum}) Enum { return Enum(1) })
+		s2.Query().FieldFunc("f", func(args struct{ EnumField Enum }) Enum { return Enum(1) })
 	}
 
 	s3 := schemabuilder.NewSchema()
@@ -418,7 +418,7 @@ func TestMergeEnumIntersection(t *testing.T) {
 		s3.Enum(Enum(0), map[string]Enum{
 			"zero": 0,
 		})
-		s3.Query().FieldFunc("f", func(args struct{EnumField Enum}) Enum { return Enum(1) })
+		s3.Query().FieldFunc("f", func(args struct{ EnumField Enum }) Enum { return Enum(1) })
 	}
 
 	assertSchemaIntersectionEq(t, s1, s2, s3)
@@ -726,7 +726,7 @@ func TestBuildSchema(t *testing.T) {
 	out, err := introspection.RunIntrospectionQuery(types.Schema)
 	require.NoError(t, err)
 
-	var iq introspectionQueryResult
+	var iq IntrospectionQueryResult
 	err = json.Unmarshal(out, &iq)
 	require.NoError(t, err)
 	fmt.Println(iq)


### PR DESCRIPTION
This makes introspectionQueryResult public so that we can unmarshal schemas without having to copy over types.