### PR TITLE
Shadow FieldFunc

### DIFF
--- a/federation/executor_test.go
+++ b/federation/executor_test.go
@@ -321,6 +321,7 @@ func TestExecutorQueriesBasic(t *testing.T) {
 							email
 							phoneNumber
 							isAdmin
+							secret
 						}
 					}`,
 			Output: `
@@ -331,13 +332,15 @@ func TestExecutorQueriesBasic(t *testing.T) {
 								"id":1,
 								"email": "email@gmail.com",
 								"phoneNumber": "555-5555",
-								"isAdmin":true
+								"isAdmin":true,
+								"secret": "shhhhh"
 							},{
 								"__key":2,
 								"id":2,
 								"email": "email@gmail.com",
 								"phoneNumber": "555-5555",
-								"isAdmin":true
+								"isAdmin":true,
+								"secret": "shhhhh"
 							}
 						]
 					}`,

--- a/graphql/schemabuilder/function.go
+++ b/graphql/schemabuilder/function.go
@@ -171,8 +171,9 @@ func (sb *schemaBuilder) buildShadowObjectFederationFunction(typ reflect.Type, m
 	rType := &graphql.NonNull{Type: &graphql.List{Type: returnType}}
 	field := &graphql.Field{
 		Resolve: func(ctx context.Context, source, funcRawArgs interface{}, selectionSet *graphql.SelectionSet) (interface{}, error) {
-			args := funcRawArgs.(map[string]graphql.Type)
-			return args["keys"], nil
+			args := reflect.ValueOf(funcRawArgs)
+			keys := reflect.Indirect(args).FieldByName("Keys")
+			return keys.Interface(), nil
 		},
 		Args:                       args,
 		Type:                       rType,


### PR DESCRIPTION
In federation, we want to support shadow field funcs. This autogenerates a field to construct the shadow object from the args such that we can run a subquery. We had a bug in which it wasn't correctly reading the args, which gets fixed and tested here.