### PR TITLE
Federation Custom Shadow Object

### DIFF
--- a/federation/kitchen_sink_test.go
+++ b/federation/kitchen_sink_test.go
@@ -86,15 +86,13 @@ func buildTestSchema1() *schemabuilder.Schema {
 	type BarKeys struct {
 		Id int64
 	}
-	schema.FederatedFieldFunc("Bar", func(args struct{ Keys []*BarKeys }) []*Bar {
+	bar := schema.Object("Bar", Bar{}, schemabuilder.CustomShadowObject(func(args struct{ Keys []*BarKeys }) []*Bar {
 		bars := make([]*Bar, 0, len(args.Keys))
 		for _, key := range args.Keys {
 			bars = append(bars, &Bar{Id: key.Id})
 		}
 		return bars
-	})
-
-	bar := schema.Object("Bar", Bar{})
+	}))
 	bar.FieldFunc("s1baz", func(b *Bar) string {
 		return fmt.Sprint(b.Id)
 	})
@@ -122,19 +120,18 @@ func buildTestSchema2() *schemabuilder.Schema {
 	type FooKeys struct {
 		Name string
 	}
-	schema.FederatedFieldFunc("Foo", func(args struct{ Keys []*FooKeys }) []*Foo {
-		foos := make([]*Foo, 0, len(args.Keys))
-		for _, key := range args.Keys {
-			foos = append(foos, &Foo{Name: key.Name})
-		}
-		return foos
-	})
 
 	schema.Query().FieldFunc("s2root", func() string {
 		return "hello"
 	})
 
-	foo := schema.Object("Foo", Foo{})
+	foo := schema.Object("Foo", Foo{}, schemabuilder.CustomShadowObject(func(args struct{ Keys []*FooKeys }) []*Foo {
+		foos := make([]*Foo, 0, len(args.Keys))
+		for _, key := range args.Keys {
+			foos = append(foos, &Foo{Name: key.Name})
+		}
+		return foos
+	}))
 
 	foo.FieldFunc("s2ok", func(ctx context.Context, in *Foo) (int, error) {
 		return len(in.Name), nil

--- a/federation/schema.go
+++ b/federation/schema.go
@@ -166,7 +166,7 @@ func ConvertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo,
 							}
 						}
 
-						// If the field is one of the input fields to the federatedfieldfunc,
+						// If the field is one of the input fields to the shadow object func,
 						// add the service name to the list of federated keys
 						for fName, f := range obj.Fields {
 							if _, ok := inputType.InputFields[fName]; !ok {

--- a/federation/schema_syncer_test.go
+++ b/federation/schema_syncer_test.go
@@ -269,10 +269,9 @@ func TestOnlyShadowServiceKnowsAboutNewField(t *testing.T) {
 	}
 
 	s2 := schemabuilder.NewSchemaWithName("schema2")
-	s2.FederatedFieldFunc("User", func(args struct{ Keys []*UserWithContactInfo }) []*UserWithContactInfo {
+	userWithContactInfo := s2.Object("User", UserWithContactInfo{}, schemabuilder.CustomShadowObject(func(args struct{ Keys []*UserWithContactInfo }) []*UserWithContactInfo {
 		return args.Keys
-	})
-	userWithContactInfo := s2.Object("User", UserWithContactInfo{})
+	}))
 	userWithContactInfo.FieldFunc("isCool", func(ctx context.Context) (bool, error) { return true, nil })
 
 	ctx := context.Background()
@@ -332,10 +331,9 @@ func TestOnlyShadowServiceKnowsAboutNewField(t *testing.T) {
 	}
 
 	s2new := schemabuilder.NewSchemaWithName("schema2")
-	s2new.FederatedFieldFunc("User", func(args struct{ Keys []*UserWithContactInfoNew }) []*UserWithContactInfoNew {
+	userWithContactInfoNew := s2new.Object("User", UserWithContactInfoNew{}, schemabuilder.CustomShadowObject(func(args struct{ Keys []*UserWithContactInfoNew }) []*UserWithContactInfoNew {
 		return args.Keys
-	})
-	userWithContactInfoNew := s2new.Object("User", UserWithContactInfoNew{})
+	}))
 	userWithContactInfoNew.FieldFunc("isCool", func(ctx context.Context) (bool, error) { return true, nil })
 
 	newExecs, err := makeExecutors(map[string]*schemabuilder.Schema{

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -2,7 +2,6 @@ package schemabuilder
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 )
 
@@ -264,36 +263,6 @@ func (s *Object) ManualPaginationWithFallback(name string, manualPaginatedFunc i
 		panic("duplicate method")
 	}
 	s.Methods[name] = m
-}
-
-type federation struct{}
-
-// FederatedFieldFunc registers the federated field func on the Federation object nested on a query object
-func (s *Schema) FederatedFieldFunc(name string, f interface{}, options ...FieldFuncOption) {
-	// Create a field func called "__federation" on the root query object
-	q := s.Query()
-	if _, ok := q.Methods[federationField]; !ok {
-		q.FieldFunc(federationField, func() federation { return federation{} })
-	}
-	obj := s.Object(federationName, federation{})
-
-	if obj.Methods == nil {
-		obj.Methods = make(Methods)
-	}
-
-	// Create a method on the "Federation" object to create the shadow object from the federated keys
-	m := &method{Fn: f}
-
-	for _, opt := range options {
-		opt.apply(m)
-	}
-
-	federatedMethodName := fmt.Sprintf("%s-%s", name, obj.ServiceName)
-	if _, ok := obj.Methods[federatedMethodName]; ok {
-		panic("duplicate method")
-	}
-
-	obj.Methods[federatedMethodName] = m
 }
 
 // Key registers the key field on an object. The field should be specified by the name of the


### PR DESCRIPTION
We initially had a function called FederatedFieldFunc to create the object, but we needed to ensure that you couldn't add that to anything. It's intended to be only used when we construct the shadow object, and that the name always matched with an object on the federated server. This felt brittlle and easy to use incorrectly, so this change allows us to combine the federated field func with the shadow object creation.

When we create a object, we can tell the schema builder it is a ShadowObject to register it in the schema, but we can also also create a custom shadow object that allows us to write a function to construct the shadow object given the keys. This means that if the key is just an id, we can make a database call to fetch the full object insteadd of passing the entire object through grpc

Here's an example of what the code would look like 
```
       type UserWithAdminPrivelages struct {
		Id    int64
		OrgId int64
	}
	type UserKeys struct {
		Id int64
	}
	s3 := schemabuilder.NewSchemaWithName("s3")
	userWithAdminPrivelages := s3.Object("User", UserWithAdminPrivelages{}, schemabuilder.CustomShadowObject(func(args struct{ Keys []UserKeys }) []*UserWithAdminPrivelages {
		users := make([]*UserWithAdminPrivelages, 0, len(args.Keys))
		for _, key := range args.Keys {
			users = append(users, &UserWithAdminPrivelages{Id: key.Id, OrgId: 0})
		}
		return users
	}))
```