### PR TITLE
Federation Shadow Type Validation

### DIFF
--- a/federation/executor_test.go
+++ b/federation/executor_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/graphql/schemabuilder"
 
@@ -26,6 +25,7 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 				email       string
 				phoneNumber string
 				device: Device
+				deviceWithArgs: Device
 				__federation: User
 			}
 			users: [User]
@@ -115,6 +115,12 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 		return &Device{Id: int64(1), OrgId: int64(1), IsOn: true}, nil
 	})
 
+	user.FieldFunc("deviceWithArgs", func(ctx context.Context, user *User, args struct {
+		Id int64
+	}) (*Device, error) {
+		return &Device{Id: args.Id, OrgId: user.OrgId}, nil
+	})
+
 	/*
 		Schema: s2
 		Query {
@@ -162,7 +168,6 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 				orgId: int64!
 				isAdmin: bool!
 				privelages: string!
-				batchedDevices: [Device]
 			}
 			privelagedUsers: [User]
 			Device {
@@ -170,7 +175,6 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 				orgId: int64!
 				temp: in64!
 			}
-			deviceWithArgs: [User]
 		}
 	*/
 	type UserWithAdminPrivelages struct {
@@ -196,42 +200,13 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 		return "all", nil
 	})
 
-	type DeviceWithTemperature struct {
-		Id    int64
-		OrgId int64
-		Temp  int64
-	}
-	type DeviceKeys struct {
+	type ShadowDevice struct {
 		Id    int64
 		OrgId int64
 	}
-	deviceWithTemp := s3.Object("Device", DeviceWithTemperature{}, schemabuilder.CustomShadowObject(
-		func(args struct{ Keys []DeviceKeys }) []*DeviceWithTemperature {
-			devices := make([]*DeviceWithTemperature, 0, len(args.Keys))
-			for _, key := range args.Keys {
-				devices = append(devices, &DeviceWithTemperature{Id: key.Id, OrgId: key.OrgId, Temp: int64(70)})
-			}
-			return devices
-		},
-	))
+	deviceWithTemp := s3.Object("Device", ShadowDevice{}, schemabuilder.ShadowObject)
 	deviceWithTemp.Key("id")
-
-	userWithAdminPrivelages.FieldFunc("deviceWithArgs", func(ctx context.Context, user *UserWithAdminPrivelages, args struct {
-		Id   int64
-		Temp int64
-	}) (*DeviceWithTemperature, error) {
-		return &DeviceWithTemperature{Id: args.Id, OrgId: user.OrgId, Temp: args.Temp}, nil
-	})
-
-	userWithAdminPrivelages.BatchFieldFunc("batchedDevices", func(ctx context.Context, users map[batch.Index]*UserWithAdminPrivelages) (map[batch.Index][]*DeviceWithTemperature, error) {
-		devices := make(map[batch.Index][]*DeviceWithTemperature, len(users))
-		for i, user := range users {
-			devicesForUser := make([]*DeviceWithTemperature, 0, 1)
-			devicesForUser = append(devicesForUser, &DeviceWithTemperature{Id: user.Id, OrgId: user.OrgId, Temp: int64(60)})
-			devices[i] = devicesForUser
-		}
-		return devices, nil
-	})
+	deviceWithTemp.FieldFunc("temp", func(ctx context.Context, device *ShadowDevice) int64 { return int64(70) })
 
 	// Create the executor with all the schemas
 	ctx := context.Background()
@@ -475,7 +450,7 @@ func TestExecutorQueriesWithArgs(t *testing.T) {
 						id
 						name
 						orgId
-						deviceWithArgs(id:2, temp: 80) {
+						deviceWithArgs(id:2) {
 							id
 							orgId
 							temp
@@ -493,8 +468,8 @@ func TestExecutorQueriesWithArgs(t *testing.T) {
 						"deviceWithArgs" : {
 								"__key": 2,
 								"id": 2,
-								"orgId": 0,
-								"temp":80
+								"orgId": 1,
+								"temp":70
 						}
 					}
 				]
@@ -902,4 +877,76 @@ func TestExecutorReturnsError(t *testing.T) {
 	e, err := NewExecutor(ctx, execs, &SchemaSyncerConfig{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs, nil)})
 	require.NoError(t, err)
 	runAndValidateQueryError(t, ctx, e, `{ fail }`, ``, "executing query: fail: uh oh")
+}
+
+func TestExecutorWithRootObjectUsedIncorrectly(t *testing.T) {
+	type User struct {
+		Id          int64
+		OrgId       int64
+		Name        string
+		Email       string
+		PhoneNumber string
+	}
+	s1 := schemabuilder.NewSchemaWithName("s1")
+	user := s1.Object("User", User{}, schemabuilder.RootObject)
+	user.Key("id")
+
+	s1.Query().FieldFunc("users", func(ctx context.Context) ([]*User, error) {
+		users := make([]*User, 0, 1)
+		users = append(users, &User{Id: int64(1), OrgId: int64(1), Name: "testUser", Email: "email@gmail.com", PhoneNumber: "555-5555"})
+		users = append(users, &User{Id: int64(2), OrgId: int64(2), Name: "testUser2", Email: "email@gmail.com", PhoneNumber: "555-5555"})
+		return users, nil
+	})
+
+	type UserIds struct {
+		Id    int64
+		OrgId int64
+	}
+
+	type UserWithContactInfo struct {
+		Id    int64
+		OrgId int64
+		Name  string
+	}
+
+	s2 := schemabuilder.NewSchemaWithName("s2")
+	user2 := s2.Object("User", UserWithContactInfo{}, schemabuilder.ShadowObject)
+	user2.Key("id")
+	s2.Query().FieldFunc("users", func(ctx context.Context) ([]*UserWithContactInfo, error) {
+		users := make([]*UserWithContactInfo, 0, 1)
+		users = append(users, &UserWithContactInfo{Id: int64(1), OrgId: int64(1), Name: "testUser"})
+		users = append(users, &UserWithContactInfo{Id: int64(2), OrgId: int64(2), Name: "testUser2"})
+		return users, nil
+	})
+
+	// Create the executor with all the schemas
+	ctx := context.Background()
+	execs, err := makeExecutors(map[string]*schemabuilder.Schema{
+		"s1": s1,
+		"s2": s2,
+	})
+	assert.NoError(t, err)
+
+	_, err = NewExecutor(ctx, execs, &SchemaSyncerConfig{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs, nil)})
+	assert.True(t, strings.Contains(err.Error(), "Field func users can not return shadow type User"))
+
+	// During an object migration, we may register a multiple root objects
+	// In this case, we should allow users to be registered on both servers
+	s2 = schemabuilder.NewSchemaWithName("s2")
+	user2 = s2.Object("User", UserWithContactInfo{}, schemabuilder.ShadowObject, schemabuilder.RootObject)
+	user2.Key("id")
+	s2.Query().FieldFunc("users", func(ctx context.Context) ([]*UserWithContactInfo, error) {
+		users := make([]*UserWithContactInfo, 0, 1)
+		users = append(users, &UserWithContactInfo{Id: int64(1), OrgId: int64(1), Name: "testUser"})
+		users = append(users, &UserWithContactInfo{Id: int64(2), OrgId: int64(2), Name: "testUser2"})
+		return users, nil
+	})
+
+	execs, err = makeExecutors(map[string]*schemabuilder.Schema{
+		"s1": s1,
+		"s2": s2,
+	})
+	assert.NoError(t, err)
+	_, err = NewExecutor(ctx, execs, &SchemaSyncerConfig{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs, nil)})
+	assert.NoError(t, err)
 }

--- a/federation/kitchen_sink_test.go
+++ b/federation/kitchen_sink_test.go
@@ -147,10 +147,6 @@ func buildTestSchema2() *schemabuilder.Schema {
 		}
 	})
 
-	foo.FieldFunc("s2nest", func(f *Foo) *Foo {
-		return f
-	})
-
 	schema.Object("Bar", Bar{}, schemabuilder.RootObject)
 	return schema
 }

--- a/federation/planner_test.go
+++ b/federation/planner_test.go
@@ -249,9 +249,6 @@ func TestPlanner(t *testing.T) {
 						id
 						s1baz
 					}
-					s2nest {
-						name
-					}
 					s2ok
 				}
 				s2root
@@ -302,9 +299,6 @@ func TestPlanner(t *testing.T) {
 									__federation {
 										id
 									}
-								}
-								s2nest {
-									name
 								}
 								s2ok
 							}`),

--- a/federation/schema.go
+++ b/federation/schema.go
@@ -76,6 +76,54 @@ func validateFederationKeys(serviceNames []string, serviceSchemasByName map[stri
 	return nil
 }
 
+// validateFieldsReturningFederatedObject checks that if an object is returned by a field func it can not be a shadow object type
+func validateFieldsReturningFederatedObject(serviceNames []string, serviceSchemasByName map[string]*IntrospectionQueryResult, types map[string]graphql.Type, fieldInfos map[*graphql.Field]*FieldInfo) error {
+	for service, serviceSchema := range serviceSchemasByName {
+		for _, typ := range serviceSchema.Schema.Types {
+			if typ.Kind != "OBJECT" {
+				continue
+			}
+			for _, field := range typ.Fields {
+				// Check that the field's return type is an object
+				fieldReturnType := getRootType(field.Type)
+				if fieldReturnType.Kind != "OBJECT" {
+					continue
+				}
+				// Error if it is a shadow object. To check this
+				// (1) Look through all the fields on the object to see if there is a federation field (__federation) and that
+				// the federation field is not on the current service
+				// (2) Look through all the fields on the federation object to see if it has a field for <ObjectType>-<Service>
+				returnObj, ok := types[fieldReturnType.Name].(*graphql.Object)
+				if !ok {
+					return oops.Errorf("Return type %s is not a graphql object", fieldReturnType.Name)
+				}
+				for name, f := range returnObj.Fields {
+					if name == federationField && !fieldInfos[f].Services[service] {
+						federatedFieldName := fmt.Sprintf("%s-%s", fieldReturnType, service)
+						// If the field name is <fieldType-service> on a federation object, 
+						// it is an expected function for a shadow object type
+						if field.Name == federatedFieldName {
+							continue
+						}
+						fedObj, ok := types["Federation"].(*graphql.Object)
+						// If there isn't a federation object, it isn't a shadow object
+						if !ok {
+							continue
+						}
+						for fName, _ := range fedObj.Fields {
+							if fName == federatedFieldName {
+								return oops.Errorf("Field func %s can not return shadow type %s", field.Name, returnObj.Name)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 // ConvertVersionedSchemas takes schemas for all of versions of
 // all executors services and generates a single merged schema
 // annotated with mapping from field to all services that know
@@ -184,6 +232,7 @@ func ConvertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo,
 				obj := types[typ.Name].(*graphql.Object)
 
 				for _, field := range typ.Fields {
+
 					f := obj.Fields[field.Name]
 
 					info, ok := fieldInfos[f]
@@ -197,6 +246,11 @@ func ConvertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo,
 				}
 			}
 		}
+	}
+
+	err = validateFieldsReturningFederatedObject(serviceNames, serviceSchemasByName, types, fieldInfos)
+	if err != nil {
+		return nil, oops.Wrapf(err, "Field funcs can not shadow objects")
 	}
 
 	return &SchemaWithFederationInfo{

--- a/federation/testdata/TestBuildSchemaKitchenSink.snapshots.json
+++ b/federation/testdata/TestBuildSchemaKitchenSink.snapshots.json
@@ -234,15 +234,6 @@
                 },
                 {
                   "args": [],
-                  "name": "s2nest",
-                  "type": {
-                    "kind": "OBJECT",
-                    "name": "Foo",
-                    "ofType": null
-                  }
-                },
-                {
-                  "args": [],
                   "name": "s2ok",
                   "type": {
                     "kind": "NON_NULL",


### PR DESCRIPTION
Enforces that a field can not return an object if it is a shadow type. This ensures that when a field func returns an object, we can query any field on that object and the client doesn't have to be aware of which ones are on federated servers. This also helps enforce that we can only federated field funcs, and that all queries for fields on the struct are responded to by the server with the root object. 
