### PR TITLE
Federation: Testing adding and deleting keys

### DIFF
--- a/graphql/schemabuilder/input.go
+++ b/graphql/schemabuilder/input.go
@@ -98,11 +98,6 @@ func (sb *schemaBuilder) makeStructParser(typ reflect.Type) (*argParser, graphql
 					return fmt.Errorf("%s: %s", name, err)
 				}
 			}
-			for name := range asMap {
-				if _, ok := fields[name]; !ok {
-					return fmt.Errorf("unknown arg %s", name)
-				}
-			}
 
 			return nil
 		},


### PR DESCRIPTION
Tests adding and deleting a federated key, and all the states in between that process. This included places where the server has an updated version, but the gateway hasn't updated yet. We do have to make sure that when deleting a field, all the shadow objects stop asking for it. Similarly, we have to make sure that when adding a field, the root object knows about it before the shadow objects know about it. 
