### PR TITLE
batch: fix panic when context missing WithBatching

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -127,8 +127,8 @@ func safeInvoke(
 // Invoke arranges for the Func's Many to be called with arg as one of its
 // arguments, and returns the corresponding result.
 func (f *Func) Invoke(ctx context.Context, arg interface{}) (interface{}, error) {
-	bctx := ctx.Value(batchContextKey{}).(*batchContext)
-	if bctx == nil {
+	bctx, ok := ctx.Value(batchContextKey{}).(*batchContext)
+	if !ok {
 		panic("WithBatching must be called on the context before using Func")
 	}
 

--- a/batch/batch_test.go
+++ b/batch/batch_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/samsarahq/thunder/batch"
+	"github.com/stretchr/testify/assert"
+
 )
 
 // TestBasic tests that batch.Func with default options batches calls.
@@ -299,4 +301,17 @@ func TestError(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+func TestNoWithBatching(t *testing.T) {
+	ctx := context.Background()
+	f := func() {
+		(&batch.Func{
+			Many: func(ctx context.Context, args []interface{}) ([]interface{}, error) {
+				return nil, nil
+			},
+		}).Invoke(ctx, 0)
+	}
+
+	assert.PanicsWithValue(t, "WithBatching must be called on the context before using Func", f)
 }


### PR DESCRIPTION
Previously line 130 panicked with the error "interface{} is nil, not *batch.batchContext" if `Invoke` was called without calling `WithBatching` on `ctx`, so the intended error message was not printed. This change ensures the correct panic message is printed, for easier debugging.