### PR TITLE
Federation API 

### DIFF
--- a/federation/customexecutor_test.go
+++ b/federation/customexecutor_test.go
@@ -88,7 +88,9 @@ func createFederatedSchema(t *testing.T) *schemabuilder.Schema {
 		Name  string
 	}
 	s1 := schemabuilder.NewSchema()
-	user := s1.Object("User", User{}, schemabuilder.RootObject)
+	user := s1.Object("User", User{}, schemabuilder.FetchObjectFromKeys(func(args struct{ Keys []*User }) []*User {
+		return args.Keys
+	}))
 	user.Key("id")
 	s1.Query().FieldFunc("users", func(ctx context.Context) ([]*User, error) {
 		value, ok := ctx.Value("authtoken").(string)

--- a/federation/kitchen_sink_test.go
+++ b/federation/kitchen_sink_test.go
@@ -68,7 +68,9 @@ func buildTestSchema1() *schemabuilder.Schema {
 		}
 	})
 
-	foo := schema.Object("Foo", Foo{}, schemabuilder.RootObject)
+	foo := schema.Object("Foo", Foo{}, schemabuilder.FetchObjectFromKeys(func(args struct{ Keys []*Foo }) []*Foo {
+		return args.Keys
+	}))
 	foo.BatchFieldFunc("s1hmm", func(ctx context.Context, in map[batch.Index]*Foo) (map[batch.Index]string, error) {
 		out := make(map[batch.Index]string)
 		for i, foo := range in {
@@ -86,7 +88,7 @@ func buildTestSchema1() *schemabuilder.Schema {
 	type BarKeys struct {
 		Id int64
 	}
-	bar := schema.Object("Bar", Bar{}, schemabuilder.CustomShadowObject(func(args struct{ Keys []*BarKeys }) []*Bar {
+	bar := schema.Object("Bar", Bar{}, schemabuilder.FetchObjectFromKeys(func(args struct{ Keys []*BarKeys }) []*Bar {
 		bars := make([]*Bar, 0, len(args.Keys))
 		for _, key := range args.Keys {
 			bars = append(bars, &Bar{Id: key.Id})
@@ -125,7 +127,7 @@ func buildTestSchema2() *schemabuilder.Schema {
 		return "hello"
 	})
 
-	foo := schema.Object("Foo", Foo{}, schemabuilder.CustomShadowObject(func(args struct{ Keys []*FooKeys }) []*Foo {
+	foo := schema.Object("Foo", Foo{}, schemabuilder.FetchObjectFromKeys(func(args struct{ Keys []*FooKeys }) []*Foo {
 		foos := make([]*Foo, 0, len(args.Keys))
 		for _, key := range args.Keys {
 			foos = append(foos, &Foo{Name: key.Name})
@@ -147,6 +149,8 @@ func buildTestSchema2() *schemabuilder.Schema {
 		}
 	})
 
-	schema.Object("Bar", Bar{}, schemabuilder.RootObject)
+	schema.Object("Bar", Bar{}, schemabuilder.FetchObjectFromKeys(func(args struct{ Keys []*Bar }) []*Bar {
+		return args.Keys
+	}))
 	return schema
 }

--- a/federation/testdata/TestBuildSchemaKitchenSink.snapshots.json
+++ b/federation/testdata/TestBuildSchemaKitchenSink.snapshots.json
@@ -71,6 +71,27 @@
               "possibleTypes": []
             },
             {
+              "enumValues": [],
+              "fields": [],
+              "inputFields": [
+                {
+                  "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "int64",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "kind": "INPUT_OBJECT",
+              "name": "Bar_InputObject",
+              "possibleTypes": []
+            },
+            {
               "enumValues": [
                 {
                   "name": "one"
@@ -117,6 +138,82 @@
                         "ofType": {
                           "kind": "OBJECT",
                           "name": "Bar",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "args": [
+                    {
+                      "name": "keys",
+                      "type": {
+                        "kind": "NON_NULL",
+                        "name": "",
+                        "ofType": {
+                          "kind": "LIST",
+                          "name": "",
+                          "ofType": {
+                            "kind": "INPUT_OBJECT",
+                            "name": "Bar_InputObject",
+                            "ofType": null
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "name": "Bar-schema2",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": "",
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": "",
+                        "ofType": {
+                          "kind": "OBJECT",
+                          "name": "Bar",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "args": [
+                    {
+                      "name": "keys",
+                      "type": {
+                        "kind": "NON_NULL",
+                        "name": "",
+                        "ofType": {
+                          "kind": "LIST",
+                          "name": "",
+                          "ofType": {
+                            "kind": "INPUT_OBJECT",
+                            "name": "Foo_InputObject",
+                            "ofType": null
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "name": "Foo-schema1",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": "",
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": "",
+                        "ofType": {
+                          "kind": "OBJECT",
+                          "name": "Foo",
                           "ofType": null
                         }
                       }
@@ -303,6 +400,27 @@
                   "ofType": null
                 }
               ]
+            },
+            {
+              "enumValues": [],
+              "fields": [],
+              "inputFields": [
+                {
+                  "name": "name",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "string",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "kind": "INPUT_OBJECT",
+              "name": "Foo_InputObject",
+              "possibleTypes": []
             },
             {
               "enumValues": [],

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -14,8 +14,6 @@ type Object struct {
 	Methods     Methods // Deprecated, use FieldFunc instead.
 	key         string
 	ServiceName string
-	IsRoot      bool
-	IsShadow    bool
 }
 
 type paginationObject struct {


### PR DESCRIPTION
* Removes shadow and root objects. We moved the generation of these functions elsewhere. The motivation for this is that we want the objects on two different servers to always be the same to allow us to hop from any server to another server. Either the keys or entire object can be sent over grpc. 
* Creates an option called `FetchObjectFromKeys` that generates the "__federation" field on an object, and takes in a function as an arg that use used for the shadow function to fetch the object from the keys
* Adds validation that if an object is federated on one server, it is federated on all the other servers with that object

https://paper.dropbox.com/doc/Federation-API-Updated--A4uTEGk52asO9hNzGXB3ZiztAg-f3mzf2dC0zjl60U7ReHAj
