### PR TITLE
Amyliu/federation directives

### DIFF
--- a/federation/executor_test.go
+++ b/federation/executor_test.go
@@ -950,3 +950,389 @@ func TestExecutorWithRootObjectUsedIncorrectly(t *testing.T) {
 	_, err = NewExecutor(ctx, execs, &SchemaSyncerConfig{SchemaSyncer: NewIntrospectionSchemaSyncer(ctx, execs, nil)})
 	assert.NoError(t, err)
 }
+
+func TestExecutorQueriesWithDirectives(t *testing.T) {
+	e, _, _, _, err := createExecutorWithFederatedUser()
+	require.NoError(t, err)
+	testCases := []struct {
+		Name          string
+		Query         string
+		Output        string
+		Error         bool
+		ExpectedError string
+	}{
+		{
+			Name: "query fields with nested objects on multiple schemas with directives",
+			Query: `
+				query Foo {
+					users {
+						id
+						device @include (if: true) {
+							id @skip(if: false)
+							isOn @skip(if: true)
+							temp @include(if: true)
+						}
+					}
+				}`,
+			Output: `
+				{
+					"users":[
+						{
+							"__key":1,
+							"id":1,
+							"device":{
+								"__key":1,
+								"id":1,
+								"temp":70
+							}
+						},
+						{
+							"__key":2,
+							"id":2,
+							"device":{
+								"__key":1,
+								"id":1,
+								"temp":70
+							}
+						}
+					]
+				}`,
+		},
+		{
+			Name: "directive top level selection true",
+			Query: `
+				query Foo {
+					users @skip(if: true) {
+						id
+					}
+					usersWithArgs(name: "foo") @include(if: true) {
+						name
+					}
+				}`,
+			Output: `
+			{
+				"usersWithArgs":[
+					{
+						"__key":1,
+						"name":"foo"
+					}
+				]
+			}`,
+			Error: false,
+		},
+		{
+			Name: "directive top level selection false",
+			Query: `
+				query Foo {
+					users @include(if: false) {
+						id
+					}
+					usersWithArgs(name: "foo") @skip(if: false) {
+						id
+						name
+					}
+				}`,
+			Output: `
+			{
+				"usersWithArgs":[
+					{
+						"__key":1,
+						"id":1,
+						"name":"foo"
+					}
+				]
+			}`,
+			Error: false,
+		},
+		{
+			Name: "directive nested selections",
+			Query: `
+				query Foo {
+					users {
+						id @skip(if: true)
+						device @include(if: true){
+							id
+							isOn @skip(if: false)
+							temp @include(if: false)
+						}
+					}
+				}`,
+			Output: `
+			{
+				"users":[
+					{
+						"__key":1,
+						"device":{
+							"__key":1,
+							"id":1,
+							"isOn":true
+						}
+					},
+					{
+						"__key":2,
+						"device":{
+							"__key":1,
+							"id":1,
+							"isOn":true
+						}
+					}
+				]
+			}`,
+			Error: false,
+		},
+		{
+			Name: "directive with fragments inline and repeated",
+			Query: `
+				query Foo {
+					users {
+						... on User @skip(if: true){
+							name
+							isAdmin
+						}
+						... on User @include(if: true){
+							id
+							email
+						}
+						...Bar @include(if: false)
+						...Baz @skip(if: false)
+					}
+				}
+				fragment Bar on User {
+					orgId
+				}
+				fragment Baz on User {
+					phoneNumber
+				}`,
+			Output: `
+			{
+				"users":[
+					{
+						"__key":1,
+						"id":1,
+						"email":"email@gmail.com",
+						"phoneNumber": "555-5555"
+					},
+					{
+						"__key":2,
+						"id":2,
+						"email":"email@gmail.com",
+						"phoneNumber": "555-5555"
+					}
+				]
+			}`,
+			Error: false,
+		},
+		{
+			Name: "directive with top level fragments",
+			Query: `
+				query Foo {
+					...Bar @skip(if: true)
+					...Baz @include(if: true)
+				}
+				fragment Bar on Query {
+					users {
+						id
+					}
+				}
+				fragment Baz on Query {
+					users {
+						name
+					}
+				}`,
+			Output: `
+			{
+				"users":[
+					{
+						"__key":1,
+						"name":"testUser"
+					},
+					{
+						"__key":2,
+						"name":"testUser2"
+					}
+				]
+			}`,
+			Error: false,
+		},
+		{
+			Name: "directive on both fragment and fragment selection",
+			Query: `
+				query Foo {
+					users {
+						...Bar @include(if: true)
+					}
+				}
+				fragment Bar on User {
+					id @include(if: true)
+					phoneNumber @skip(if: true)
+				}`,
+			Output: `
+			{
+				"users":[
+					{
+						"__key":1,
+						"id": 1
+					},
+					{
+						"__key":2,
+						"id": 2
+					}
+				]
+			}`,
+			Error: false,
+		},
+		{
+			Name: "directive on query fields with union type",
+			Query: `
+			query Foo {
+				everyone {
+					... on Admin @skip(if: false) {
+						id @skip(if: true)
+						superPower
+					}
+					... on User {
+						id
+						email
+						device @include(if: false) {
+							id
+						}
+					}
+				}
+			}`,
+			Output: `
+			{
+				"everyone":[
+					{
+						"__key":1,
+						"__typename":"Admin",
+						"superPower":"flying"
+					},
+					{
+						"__key":2,
+						"__typename":"User",
+						"id":2,
+						"email":"email@gmail.com"
+					}
+				]
+			}`,
+		},
+		{
+			Name: "directive missing argument",
+			Query: `
+				query Foo {
+					users {
+						...Bar @include(notif: true)
+					}
+				}
+				fragment Bar on User {
+					id
+				}`,
+			Output:        "",
+			Error:         true,
+			ExpectedError: "required argument in directive not provided: if",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			ctx := context.Background()
+			if !testCase.Error {
+				// Validates that we were able to execute the query on multiple
+				// schemas and correctly stitch the results back together
+				runAndValidateQueryResults(t, ctx, e, testCase.Query, testCase.Output)
+			} else {
+				runAndValidateQueryError(t, ctx, e, testCase.Query, testCase.Output, testCase.ExpectedError)
+			}
+		})
+	}
+}
+
+func TestExecutorQueriesWithDirectivesWithVariables(t *testing.T) {
+	e, _, _, _, err := createExecutorWithFederatedUser()
+	require.NoError(t, err)
+	testCases := []struct {
+		Name          string
+		Query         string
+		Variables     map[string]interface{}
+		Output        string
+		Error         bool
+		ExpectedError string
+	}{
+		{
+			Name: "directive with skip variable true",
+			Query: `
+				query Foo {
+					...Bar @skip(if: $something)
+				}
+				fragment Bar on Query {
+					users {
+						name
+					}
+				}`,
+			Output: `
+			{}`,
+			Variables: map[string]interface{}{"something": true},
+			Error:     false,
+		},
+		{
+			Name: "directive with both variables false",
+			Query: `
+				query Foo {
+					...Bar @skip(if: $something)
+				}
+				fragment Bar on Query {
+					users {
+						name
+						id @include(if: $somethingElse)
+					}
+				}`,
+			Output: `
+			{
+				"users":[
+					{
+						"__key":1,
+						"name":"testUser"
+					},
+					{
+						"__key":2,
+						"name":"testUser2"
+					}
+				]
+			}`,
+			Variables: map[string]interface{}{"something": false, "somethingElse": false},
+			Error:     false,
+		},
+		{
+			Name: "directive with both variables false",
+			Query: `
+				query Foo {
+					...Bar @skip(if: $something)
+				}
+				fragment Bar on Query {
+					users {
+						name
+					}
+				}`,
+			Output:        "",
+			Variables:     map[string]interface{}{"something": "wrong type"},
+			Error:         true,
+			ExpectedError: "expected type boolean, found type string in \"if\" argument",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			ctx := context.Background()
+			if !testCase.Error {
+				res, _, err := e.Execute(ctx, graphql.MustParse(testCase.Query, testCase.Variables), nil)
+				require.NoError(t, err)
+				var expected interface{}
+				err = json.Unmarshal([]byte(testCase.Output), &expected)
+				require.NoError(t, err)
+				assert.Equal(t, expected, res)
+			} else {
+				_, _, err := e.Execute(ctx, graphql.MustParse(testCase.Query, testCase.Variables), nil)
+				assert.True(t, strings.Contains(err.Error(), testCase.ExpectedError))
+			}
+
+		})
+	}
+}

--- a/federation/normalize.go
+++ b/federation/normalize.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"sort"
 
+	"github.com/samsarahq/go/oops"
 	"github.com/samsarahq/thunder/graphql"
 )
 
@@ -115,7 +116,14 @@ func (f *flattener) flattenFragments(selectionSet *graphql.SelectionSet, typ *gr
 
 	// Descend into fragments matching the current type.
 	for _, fragment := range selectionSet.Fragments {
-		ok, err := f.applies(typ, fragment)
+		ok, err := graphql.ShouldIncludeNode(fragment.Directives)
+		if err != nil {
+			return oops.Wrapf(err, "applying directive for fragment on %s", fragment.On)
+		}
+		if !ok {
+			continue
+		}
+		ok, err = f.applies(typ, fragment)
 		if err != nil {
 			return err
 		}

--- a/federation/planner.go
+++ b/federation/planner.go
@@ -192,6 +192,14 @@ func (e *Planner) planObject(typ *graphql.Object, selectionSet *graphql.Selectio
 	}
 
 	for _, selection := range selectionSet.Selections {
+		ok, err := graphql.ShouldIncludeNode(selection.Directives)
+		if err != nil {
+			return nil, oops.Wrapf(err, "applying directive")
+
+		}
+		if !ok {
+			continue
+		}
 		if selection.Name == "__typename" {
 			localSelections = append(localSelections, selection)
 			continue

--- a/graphql/batch_executor.go
+++ b/graphql/batch_executor.go
@@ -124,7 +124,7 @@ func (e *Executor) Execute(ctx context.Context, typ Type, source interface{}, qu
 	initialSelectionWorkUnits := make([]*WorkUnit, 0, len(topLevelSelections))
 	writers := make(map[string]*outputNode)
 	for _, selection := range topLevelSelections {
-		ok, err := shouldIncludeNode(selection.Directives)
+		ok, err := ShouldIncludeNode(selection.Directives)
 		if err != nil {
 			return nil, err
 		}
@@ -469,7 +469,7 @@ func resolveObjectBatch(ctx context.Context, sources []interface{}, typ *Object,
 			continue
 		}
 
-		if ok, err := shouldIncludeNode(selection.Directives); err != nil {
+		if ok, err := ShouldIncludeNode(selection.Directives); err != nil {
 			return nil, nestPathError(selection.Alias, err)
 		} else if !ok {
 			continue

--- a/graphql/directive.go
+++ b/graphql/directive.go
@@ -10,8 +10,8 @@ const (
 	IF      = "if"
 )
 
-// shouldIncludeNode validates and checks the value of a skip or include directive
-func shouldIncludeNode(directives []*Directive) (bool, error) {
+// ShouldIncludeNode validates and checks the value of a skip or include directive
+func ShouldIncludeNode(directives []*Directive) (bool, error) {
 	skipDirective := findDirectiveWithName(directives, SKIP)
 	if skipDirective != nil {
 		b, err := parseIf(skipDirective)

--- a/graphql/parser.go
+++ b/graphql/parser.go
@@ -496,7 +496,7 @@ func Flatten(selectionSet *SelectionSet) ([]*Selection, error) {
 		}
 
 		for _, fragment := range selectionSet.Fragments {
-			ok, err := shouldIncludeNode(fragment.Directives)
+			ok, err := ShouldIncludeNode(fragment.Directives)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR adds directive support (`@skip` and `@include`) for federated queries 

[Jira ticket](https://samsaradev.atlassian.net/jira/software/projects/CLOUD/boards/437?selectedIssue=CLOUD-283)

Because the ShouldIncludeNode fxn is called in the planning/flattening step, I found that I didn't have to marshal Directives into thunderpb since at that point the directives had already been applied. I actually made the proto changes and added it to the marshaling/unmarshaling of the DirectExecutorClient queries, but realized that everything works without needing to do that. Lmk if this seems wrong though.

References:
- original directive support [PR](https://github.com/samsarahq/thunder/pull/353)
- directive support bugfix [PR](https://github.com/samsarahq/thunder/pull/361)