### PR TITLE
Rename "__federation" to "_federation"

### DIFF
--- a/federation/executor.go
+++ b/federation/executor.go
@@ -141,7 +141,7 @@ func (e *Executor) runOnService(ctx context.Context, service string, typName str
 	// and pass the keys in to find the object that the subquery is nested on
 	// Pass all federated keys for that service as arguments
 	// {
-	//   __federation {
+	//   _federation {
 	//     [ObjectName]-[Service] (keys: Keys) {
 	//       subQuery
 	//     }
@@ -275,7 +275,7 @@ func (pathTargets *pathSubqueryMetadata) extractKeys(node interface{}, path []Pa
 		// Add a pointer to the object for where the results from
 		// the subquery will be added into the final result
 		pathTargets.results = append(pathTargets.results, obj)
-		// Keys from the "__federation" field func are passed to
+		// Keys from the "_federation" field func are passed to
 		// the subquery
 		pathTargets.keys = append(pathTargets.keys, key)
 		return nil

--- a/federation/executor.go
+++ b/federation/executor.go
@@ -16,7 +16,7 @@ import (
 )
 
 const keyField = "__key"
-const federationField = "__federation"
+const federationField = "_federation"
 const typeNameField = "__typeName"
 const minSchemaSyncIntervalSeconds = 30
 
@@ -270,7 +270,7 @@ func (pathTargets *pathSubqueryMetadata) extractKeys(node interface{}, path []Pa
 		}
 		key, ok := obj[federationField]
 		if !ok {
-			return fmt.Errorf("missing __federation: %v", obj)
+			return fmt.Errorf("missing _federation: %v", obj)
 		}
 		// Add a pointer to the object for where the results from
 		// the subquery will be added into the final result

--- a/federation/executor_test.go
+++ b/federation/executor_test.go
@@ -27,7 +27,7 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 				phoneNumber string
 				device: Device
 				deviceWithArgs: Device
-				__federation: User
+				_federation: User
 			}
 			users: [User]
 			usersWithArgs: [User]
@@ -36,7 +36,7 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 				orgId: int64!
 				superPower: string!
 				hiding: bool
-				__federation: Admin
+				_federation: Admin
 			}
 			admins: [Admin]
 			everyone: [Admin || User]
@@ -44,7 +44,7 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 				id: int64!
 				orgId: int64!
 				isOn: bool
-				__federation: Device
+				_federation: Device
 			}
 		}
 	*/
@@ -172,7 +172,7 @@ func createExecutorWithFederatedUser() (*Executor, *schemabuilder.Schema, *schem
 				User(keys: [UserKeys!]): [UserWithAdminPrivelages]
 			}
 			User {
-				__federation: User
+				_federation: User
 				id: int64!
 				orgId: int64!
 				isAdmin: bool!

--- a/federation/planner.go
+++ b/federation/planner.go
@@ -86,7 +86,7 @@ func NewPlanner(types *SchemaWithFederationInfo, optionalServiceSelector Service
 // Executing a subquery
 //
 // When a subquery is run on a seperate graphql server, we want the subquery to be nested
-// on the "__federation" type so that the graphQL server
+// on the "_federation" type so that the graphQL server
 // For example, if our query like the example below where "allFoos" is a field on service1
 // and "name" is a field on service2.
 // {
@@ -96,14 +96,14 @@ func NewPlanner(types *SchemaWithFederationInfo, optionalServiceSelector Service
 // }
 // When we send the subquery to service2 it should look like the example below
 // {
-// 	__federation {
+// 	_federation {
 // 	  Foo(id: $id) {
 //      __typename
 // 		  name
 // 		}
 // 	  }
 // }
-// "__federation" becomes the root query that the subquery is nested under,
+// "_federation" becomes the root query that the subquery is nested under,
 // "Foo" is the federated object type that we need to refetch,
 // and "__typename" lets gateway know what type the object is.
 
@@ -286,20 +286,20 @@ func (e *Planner) planObject(typ *graphql.Object, selectionSet *graphql.Selectio
 	}
 
 	// knows how to resolve it, and we can take the results from that subquery and stitch it into the final response
-	// "__federation" indicates a seperate subplan that will be dispatched to a graphql server
+	// "_federation" indicates a seperate subplan that will be dispatched to a graphql server
 	if needKey {
 		hasKey := false
 		for _, selection := range p.SelectionSet.Selections {
 			if selection.Name == federationField && selection.Alias == federationField {
 				hasKey = true
 			} else if selection.Name == federationField || selection.Alias == federationField {
-				return nil, fmt.Errorf("Both the selection name and alias have to be __federation")
+				return nil, fmt.Errorf("Both the selection name and alias have to be _federation")
 			}
 		}
 		if !hasKey {
 			// Parse all the fields and if it is a federated key for that service
 			// add it to the planner to fetch that field such that the subquery looks like
-			// __federation {
+			// _federation {
 			//	 id (federatedKey)
 			// }
 			selections := make([]*graphql.Selection, 0, len(typ.Fields))

--- a/federation/planner_test.go
+++ b/federation/planner_test.go
@@ -86,7 +86,7 @@ func TestPlanner(t *testing.T) {
 					SelectionSet: mustParse(`{
 						s1fff {
 							name
-							__federation {
+							_federation {
 								name
 							}
 						}
@@ -123,7 +123,7 @@ func TestPlanner(t *testing.T) {
 					Kind:    "query",
 					SelectionSet: mustParse(`{
 						s1fff {
-							__federation {
+							_federation {
 								name
 							}
 						}
@@ -138,7 +138,7 @@ func TestPlanner(t *testing.T) {
 							Service: "schema2",
 							SelectionSet: mustParse(`{
 								s2bar {
-									__federation {
+									_federation {
 										id
 									}
 								}
@@ -193,10 +193,10 @@ func TestPlanner(t *testing.T) {
 							}
 							... on Foo {
 								__typename
-								a: s1nest { b: s1nest { c: s1nest { __federation { name } } } }
+								a: s1nest { b: s1nest { c: s1nest { _federation { name } } } }
 								name
 								s1hmm
-								__federation {
+								_federation {
 									name
 								}
 							}
@@ -261,12 +261,12 @@ func TestPlanner(t *testing.T) {
 					SelectionSet: mustParse(`{
 						s1echo(foo: "foo", pair: {a: 1, b: 3})
 						s1fff {
-							a: s1nest { b: s1nest { c: s1nest { __federation { name } } } }
+							a: s1nest { b: s1nest { c: s1nest { _federation { name } } } }
 							s1hmm
 							s1nest {
 								name
 							}
-							__federation {
+							_federation {
 								name
 							}
 						}
@@ -296,7 +296,7 @@ func TestPlanner(t *testing.T) {
 							SelectionSet: mustParse(`{
 								s2bar {
 									id
-									__federation {
+									_federation {
 										id
 									}
 								}

--- a/federation/schema.go
+++ b/federation/schema.go
@@ -48,7 +48,7 @@ func validateFederationKeys(serviceNames []string, serviceSchemasByName map[stri
 			validFederatedKey := false
 			if typ.Name == obj.Name {
 				// Check that it is a root object by checking if it has a field func called
-				// "__federation" on the object
+				// "_federation" on the object
 				isRootObject := false
 				for _, introspectedField := range typ.Fields {
 					if introspectedField.Name == federationField {
@@ -78,7 +78,7 @@ func validateFederationKeys(serviceNames []string, serviceSchemasByName map[stri
 // validateFederatedObjects validates that if a object is federated, it is federated on all the schemas
 func validateFederatedObjects(serviceNames []string, serviceSchemasByName map[string]*IntrospectionQueryResult, objName string) error {
 	// Check if it is federated on one service. It is federated if there is a field
-	//	called "__federation" on that object on any of the services it is on
+	//	called "_federation" on that object on any of the services it is on
 	federatedOnOneService := false
 	for _, service := range serviceNames {
 		for _, typ := range serviceSchemasByName[service].Schema.Types {
@@ -131,7 +131,7 @@ func validateFieldsReturningFederatedObject(serviceNames []string, serviceSchema
 					continue
 				}
 				// Error if it is a shadow object. To check this
-				// (1) Look through all the fields on the object to see if there is a federation field (__federation) and that
+				// (1) Look through all the fields on the object to see if there is a federation field (_federation) and that
 				// the federation field is not on the current service
 				// (2) Look through all the fields on the federation object to see if it has a field for <ObjectType>-<Service>
 				returnObj, ok := types[fieldReturnType.Name].(*graphql.Object)

--- a/federation/testdata/TestBuildSchemaKitchenSink.snapshots.json
+++ b/federation/testdata/TestBuildSchemaKitchenSink.snapshots.json
@@ -10,7 +10,7 @@
               "fields": [
                 {
                   "args": [],
-                  "name": "__federation",
+                  "name": "_federation",
                   "type": {
                     "kind": "OBJECT",
                     "name": "Bar",
@@ -269,7 +269,7 @@
               "fields": [
                 {
                   "args": [],
-                  "name": "__federation",
+                  "name": "_federation",
                   "type": {
                     "kind": "OBJECT",
                     "name": "Foo",
@@ -491,7 +491,7 @@
               "fields": [
                 {
                   "args": [],
-                  "name": "__federation",
+                  "name": "_federation",
                   "type": {
                     "kind": "NON_NULL",
                     "name": "",

--- a/graphql/schemabuilder/function.go
+++ b/graphql/schemabuilder/function.go
@@ -103,7 +103,7 @@ func (sb *schemaBuilder) buildFunctionAndFuncCtx(typ reflect.Type, m *method) (*
 // This allows them to be sent to any other server as federated keys.
 //
 // It generates a field func on the federated object that looks like the example below
-// rootObjectType.fieldfunc("__federation", func(root *rootObjectType) (*rootObjectType) { return root })
+// rootObjectType.fieldfunc("_federation", func(root *rootObjectType) (*rootObjectType) { return root })
 // This function allows us to fetch all the fields on the root object that can be sent to another server
 // as args to a shadow field func.
 func (sb *schemaBuilder) buildFederatedFunction(typ reflect.Type, m *method) (*graphql.Field, error) {
@@ -130,7 +130,7 @@ func (sb *schemaBuilder) buildFederatedFunction(typ reflect.Type, m *method) (*g
 // buildShadowObjectFederationFunction builds a federation object and a field func that takes the
 // federation keys as args and constructs the shadow object. This is used for federated subqueries.
 // {
-//   __federation {
+//   _federation {
 //     [ObjectName]-[Service] (keys: Keys) {
 //       subQuery
 //     }

--- a/graphql/schemabuilder/schema.go
+++ b/graphql/schemabuilder/schema.go
@@ -7,7 +7,7 @@ import (
 	"github.com/samsarahq/thunder/graphql"
 )
 
-const federationField = "__federation"
+const federationField = "_federation"
 const federationName = "Federation"
 
 // Schema is a struct that can be used to build out a GraphQL schema.  Functions


### PR DESCRIPTION
We use this to identify subqueries and refetch the objects, but due to apollo ts compatibility we need to rename it with a single underscore. The doubel underscore is reserved for introspection queries