### PR TITLE
federation/schema: FetchObjectFromKeys is expensive

### DIFF
--- a/graphql/schemabuilder/schema.go
+++ b/graphql/schemabuilder/schema.go
@@ -121,7 +121,7 @@ type federation struct{}
 
 func FetchObjectFromKeys(f interface{}, options ...ObjectOption) ObjectOption {
 	// Create a method on the "Federation" object to create the shadow object from the federated keys
-	m := &method{Fn: f}
+	m := &method{Fn: f, Expensive: true}
 
 	var FetchObjectFromKeysField objectOptionFunc = func(s *Schema, obj *Object) {
 		q := s.Query()


### PR DESCRIPTION
This field func often requires db queries or expensive fetching, and should have the expensive tag. This allows it to be called in a seperate goroutine, although it only has to be callled once