### PR TITLE
Federation Name Convention

### DIFF
--- a/federation/executor.go
+++ b/federation/executor.go
@@ -149,7 +149,7 @@ func (e *Executor) runOnService(ctx context.Context, service string, typName str
 	// }
 	isRoot := keys == nil
 	if !isRoot {
-		federatedName := fmt.Sprintf("%s-%s", typName, service)
+		federatedName := fmt.Sprintf("%s-%s", service, typName)
 
 		var rootObject *graphql.Object
 		var ok bool
@@ -241,7 +241,7 @@ func (e *Executor) runOnService(ctx context.Context, service string, typName str
 		if !ok {
 			return nil, nil, oops.Errorf("executor res not a map[string]interface{}")
 		}
-		federatedName := fmt.Sprintf("%s-%s", typName, service)
+		federatedName := fmt.Sprintf("%s-%s", service, typName)
 		r, ok := result[federatedName].([]interface{})
 		if !ok {
 			return nil, nil, fmt.Errorf("root did not have a federation map, got %v", res)

--- a/federation/schema.go
+++ b/federation/schema.go
@@ -140,7 +140,7 @@ func validateFieldsReturningFederatedObject(serviceNames []string, serviceSchema
 				}
 				for name, f := range returnObj.Fields {
 					if name == federationField && !fieldInfos[f].Services[service] {
-						federatedFieldName := fmt.Sprintf("%s-%s", fieldReturnType, service)
+						federatedFieldName := fmt.Sprintf("%s-%s", service, fieldReturnType)
 						// If the field name is <fieldType-service> on a federation object,
 						// it is an expected function for a shadow object type
 						if field.Name == federatedFieldName {
@@ -228,13 +228,13 @@ func ConvertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo,
 			// on the field object.
 			if typ.Name == "Federation" {
 				for _, field := range typ.Fields {
-					// Extract the type name from the formatting <object>-<service>
+					// Extract the type name from the formatting <service>-<object>
 					// And check that the object type exists
 					names := strings.SplitN(field.Name, "-", 2)
 					if len(names) != 2 {
 						return nil, oops.Errorf("Field %s doesnt have an object name and service name", field.Name)
 					}
-					objName := names[0]
+					objName := names[1]
 					obj, ok := types[objName].(*graphql.Object)
 					if !ok {
 						return nil, oops.Errorf("Expected objectName %s on merged schema", objName)

--- a/federation/testdata/TestBuildSchemaKitchenSink.snapshots.json
+++ b/federation/testdata/TestBuildSchemaKitchenSink.snapshots.json
@@ -125,45 +125,7 @@
                       }
                     }
                   ],
-                  "name": "Bar-schema1",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": "",
-                    "ofType": {
-                      "kind": "LIST",
-                      "name": "",
-                      "ofType": {
-                        "kind": "NON_NULL",
-                        "name": "",
-                        "ofType": {
-                          "kind": "OBJECT",
-                          "name": "Bar",
-                          "ofType": null
-                        }
-                      }
-                    }
-                  }
-                },
-                {
-                  "args": [
-                    {
-                      "name": "keys",
-                      "type": {
-                        "kind": "NON_NULL",
-                        "name": "",
-                        "ofType": {
-                          "kind": "LIST",
-                          "name": "",
-                          "ofType": {
-                            "kind": "INPUT_OBJECT",
-                            "name": "Bar_InputObject",
-                            "ofType": null
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "name": "Bar-schema2",
+                  "name": "schema1-Bar",
                   "type": {
                     "kind": "NON_NULL",
                     "name": "",
@@ -201,7 +163,7 @@
                       }
                     }
                   ],
-                  "name": "Foo-schema1",
+                  "name": "schema1-Foo",
                   "type": {
                     "kind": "NON_NULL",
                     "name": "",
@@ -232,6 +194,44 @@
                           "name": "",
                           "ofType": {
                             "kind": "INPUT_OBJECT",
+                            "name": "Bar_InputObject",
+                            "ofType": null
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "name": "schema2-Bar",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "",
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": "",
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": "",
+                        "ofType": {
+                          "kind": "OBJECT",
+                          "name": "Bar",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "args": [
+                    {
+                      "name": "keys",
+                      "type": {
+                        "kind": "NON_NULL",
+                        "name": "",
+                        "ofType": {
+                          "kind": "LIST",
+                          "name": "",
+                          "ofType": {
+                            "kind": "INPUT_OBJECT",
                             "name": "FooKeys_InputObject",
                             "ofType": null
                           }
@@ -239,7 +239,7 @@
                       }
                     }
                   ],
-                  "name": "Foo-schema2",
+                  "name": "schema2-Foo",
                   "type": {
                     "kind": "NON_NULL",
                     "name": "",

--- a/graphql/schemabuilder/schema.go
+++ b/graphql/schemabuilder/schema.go
@@ -3,6 +3,7 @@ package schemabuilder
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/samsarahq/thunder/graphql"
 )
@@ -37,7 +38,7 @@ func NewSchema() *Schema {
 // NewSchema creates a new schema with a schema name
 func NewSchemaWithName(name string) *Schema {
 	schema := &Schema{
-		Name:    name,
+		Name:    strings.ToLower(name),
 		objects: make(map[string]*Object),
 	}
 
@@ -134,7 +135,7 @@ func FetchObjectFromKeys(f interface{}, options ...ObjectOption) ObjectOption {
 			fedObj.Methods = make(Methods)
 		}
 
-		federatedMethodName := fmt.Sprintf("%s-%s", obj.Name, obj.ServiceName)
+		federatedMethodName := fmt.Sprintf("%s-%s", obj.ServiceName, obj.Name)
 		if _, ok := fedObj.Methods[federatedMethodName]; ok {
 			panic("duplicate method")
 		}


### PR DESCRIPTION
For apollo ts convention, field funcs need to start with a lowercase letter. We can't force the object name to be lowercase, but we can force the service name, so I switched the ordering.