### PR TITLE
federation: federated method name has _ instead of -

### DIFF
--- a/federation/executor.go
+++ b/federation/executor.go
@@ -149,7 +149,7 @@ func (e *Executor) runOnService(ctx context.Context, service string, typName str
 	// }
 	isRoot := keys == nil
 	if !isRoot {
-		federatedName := fmt.Sprintf("%s-%s", service, typName)
+		federatedName := fmt.Sprintf("%s_%s", service, typName)
 
 		var rootObject *graphql.Object
 		var ok bool
@@ -241,7 +241,7 @@ func (e *Executor) runOnService(ctx context.Context, service string, typName str
 		if !ok {
 			return nil, nil, oops.Errorf("executor res not a map[string]interface{}")
 		}
-		federatedName := fmt.Sprintf("%s-%s", service, typName)
+		federatedName := fmt.Sprintf("%s_%s", service, typName)
 		r, ok := result[federatedName].([]interface{})
 		if !ok {
 			return nil, nil, fmt.Errorf("root did not have a federation map, got %v", res)

--- a/federation/schema.go
+++ b/federation/schema.go
@@ -133,14 +133,14 @@ func validateFieldsReturningFederatedObject(serviceNames []string, serviceSchema
 				// Error if it is a shadow object. To check this
 				// (1) Look through all the fields on the object to see if there is a federation field (_federation) and that
 				// the federation field is not on the current service
-				// (2) Look through all the fields on the federation object to see if it has a field for <ObjectType>-<Service>
+				// (2) Look through all the fields on the federation object to see if it has a field for <Service>_<ObjectType>
 				returnObj, ok := types[fieldReturnType.Name].(*graphql.Object)
 				if !ok {
 					return oops.Errorf("Return type %s is not a graphql object", fieldReturnType.Name)
 				}
 				for name, f := range returnObj.Fields {
 					if name == federationField && !fieldInfos[f].Services[service] {
-						federatedFieldName := fmt.Sprintf("%s-%s", service, fieldReturnType)
+						federatedFieldName := fmt.Sprintf("%s_%s", service, fieldReturnType)
 						// If the field name is <fieldType-service> on a federation object,
 						// it is an expected function for a shadow object type
 						if field.Name == federatedFieldName {
@@ -228,9 +228,9 @@ func ConvertVersionedSchemas(schemas serviceSchemas) (*SchemaWithFederationInfo,
 			// on the field object.
 			if typ.Name == "Federation" {
 				for _, field := range typ.Fields {
-					// Extract the type name from the formatting <service>-<object>
+					// Extract the type name from the formatting <service>_<object>
 					// And check that the object type exists
-					names := strings.SplitN(field.Name, "-", 2)
+					names := strings.SplitN(field.Name, "_", 2)
 					if len(names) != 2 {
 						return nil, oops.Errorf("Field %s doesnt have an object name and service name", field.Name)
 					}

--- a/federation/testdata/TestBuildSchemaKitchenSink.snapshots.json
+++ b/federation/testdata/TestBuildSchemaKitchenSink.snapshots.json
@@ -125,7 +125,7 @@
                       }
                     }
                   ],
-                  "name": "schema1-Bar",
+                  "name": "schema1_Bar",
                   "type": {
                     "kind": "NON_NULL",
                     "name": "",
@@ -163,7 +163,7 @@
                       }
                     }
                   ],
-                  "name": "schema1-Foo",
+                  "name": "schema1_Foo",
                   "type": {
                     "kind": "NON_NULL",
                     "name": "",
@@ -201,7 +201,7 @@
                       }
                     }
                   ],
-                  "name": "schema2-Bar",
+                  "name": "schema2_Bar",
                   "type": {
                     "kind": "NON_NULL",
                     "name": "",
@@ -239,7 +239,7 @@
                       }
                     }
                   ],
-                  "name": "schema2-Foo",
+                  "name": "schema2_Foo",
                   "type": {
                     "kind": "NON_NULL",
                     "name": "",

--- a/graphql/schemabuilder/schema.go
+++ b/graphql/schemabuilder/schema.go
@@ -135,7 +135,7 @@ func FetchObjectFromKeys(f interface{}, options ...ObjectOption) ObjectOption {
 			fedObj.Methods = make(Methods)
 		}
 
-		federatedMethodName := fmt.Sprintf("%s-%s", obj.ServiceName, obj.Name)
+		federatedMethodName := fmt.Sprintf("%s_%s", obj.ServiceName, obj.Name)
 		if _, ok := fedObj.Methods[federatedMethodName]; ok {
 			panic("duplicate method")
 		}


### PR DESCRIPTION
Apollo ts requires field func Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/