### PR TITLE
federation/planner: remove check for requiring federated keys

### DIFF
--- a/federation/planner.go
+++ b/federation/planner.go
@@ -165,9 +165,6 @@ func (e *Planner) selectService(
 		}
 		return "", oops.Errorf("Field is not on multiple services")
 	}
-	if len(field.FederatedKey) > 0 {
-		return "", oops.Errorf("It is not allowed to select service for non field func %s for type %s", selection.Name, typeName)
-	}
 	if _, ok := fieldInfo.Services[customService]; !ok {
 		return "", oops.Errorf("no service %s", customService)
 	}


### PR DESCRIPTION
For fields on a federated object, it uses the service selector to know which service to run it on, and needs to be able to select a fields. It can have federated keys and have a customer service, so we want to remove the error check