### PR TITLE
fix import for livesql

### DIFF
--- a/livesql/binlog.go
+++ b/livesql/binlog.go
@@ -112,14 +112,15 @@ func NewBinlogWithSource(ldb *LiveDB, sourceDB *sql.DB, host string, port uint16
 		localHostName = string(runes[0:maxHostNameLength])
 	}
 
-	syncer := replication.NewBinlogSyncer(&replication.BinlogSyncerConfig{
-		ServerID: binary.LittleEndian.Uint32(slaveId),
-		Host:     host,
-		Localhost: localHostName,
-		Port:     port,
-		User:     username,
-		Password: password,
-	})
+        syncerConfig := &replication.BinlogSyncerConfig{
+                ServerID: binary.LittleEndian.Uint32(slaveId),
+                Host:     host,
+                Localhost: localHostName,
+                Port:     port,
+                User:     username,
+                Password: password,
+        }
+        syncer := replication.NewBinlogSyncer(*syncerConfig)
 
 	streamer, err := syncer.StartSync(position)
 	if err != nil {


### PR DESCRIPTION
This 'fixes' the issue described in https://github.com/samsarahq/thunder/issues/364 for versions using livesql, but breaks CI (not sure why)

For some reason, my Go wants this passed in by value, not with a  pointer, even though the vendor function here asks for a pointer:

```
vendor/github.com/siddontang/go-mysql/replication/binlogsyncer.go:

func NewBinlogSyncer(cfg *BinlogSyncerConfig) *BinlogSyncer {
```

The CI for this does not pass against Go 1.10: https://travis-ci.com/github/jrcichra/thunder/builds/188509884

But I am able to compile it fine against my fork: https://github.com/jrcichra/thunder which master has additional changes for pulling my fork version.

my program outside of this lib uses go.mod to compile, and includes:

```
github.com/jrcichra/thunder v0.5.1-0.20201007045717-c82d2fa57e8a
```

...and go build succeeds with a 1.15.x compiler importing these sections in `main` of a dependent program:

```
"github.com/jrcichra/thunder/graphql"
"github.com/jrcichra/thunder/graphql/graphiql"
"github.com/jrcichra/thunder/graphql/introspection"
"github.com/jrcichra/thunder/graphql/schemabuilder"
"github.com/jrcichra/thunder/livesql"
"github.com/jrcichra/thunder/reactive"
```