### PR TITLE
Lowercase sort of pagination

### DIFF
--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"sort"
 	"sync"
+	"strings"
 
 	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/graphql"
@@ -812,9 +813,9 @@ var sorts = map[reflect.Kind]func([]sortReference, SortOrder){
 			a := slice[i].value
 			b := slice[j].value
 			if order == SortOrder_Ascending {
-				return a.String() < b.String()
+				return strings.ToLower(a.String()) < strings.ToLower(b.String())
 			} else {
-				return a.String() > b.String()
+				return strings.ToLower(a.String()) > strings.ToLower(b.String())
 			}
 		})
 	},


### PR DESCRIPTION
We want to allow pagination to compare strings after lowercasing them since it makes the sort more intuitive in some cases. There is now a custom sort order called `asc_lower` and `desc_lower` to support this without changing the default sorting. 