### PR TITLE
Federation Bug Missing Selections

### DIFF
--- a/federation/executor_test.go
+++ b/federation/executor_test.go
@@ -694,6 +694,83 @@ func TestExecutorQueriesWithFragments(t *testing.T) {
 				]
 			}`,
 		},
+		{
+			Name: "query fields with repeated fields and fragments",
+			Query: `
+			query Foo {
+				users {
+					...Bar
+				}
+				users2: users {
+					...Bar
+				}
+			}
+			fragment Bar on User {
+				id
+				name
+				email
+				device {
+					...DeviceInfo
+				}
+			}
+			fragment DeviceInfo on Device {
+				id
+				temp
+			}
+			
+			`,
+			Output: `
+			{
+				"users":[
+					{
+						"__key":1,
+						"id":1,
+						"name":"testUser",
+						"email":"email@gmail.com",
+						"device":{
+							"__key":1,
+							"id":1,
+							"temp":70
+						}
+					},
+					{
+						"__key":2,
+						"id":2,
+						"name":"testUser2",
+						"email":"email@gmail.com",
+						"device":{
+							"__key":1,
+							"id":1,
+							"temp":70
+						}
+					}
+				],
+				"users2":[
+					{
+						"__key":1,
+						"id":1,
+						"name":"testUser",
+						"email":"email@gmail.com",
+						"device":{
+							"__key":1,
+							"id":1,
+							"temp":70
+						}
+					},
+					{
+						"__key":2,
+						"id":2,
+						"name":"testUser2",
+						"email":"email@gmail.com",
+						"device":{
+							"__key":1,
+							"id":1,
+							"temp":70
+						}
+					}
+				]
+			}`,
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {

--- a/federation/normalize.go
+++ b/federation/normalize.go
@@ -231,8 +231,9 @@ func (f *flattener) flatten(selectionSet *graphql.SelectionSet, typ graphql.Type
 		if err != nil {
 			return nil, err
 		}
-		selectionSet.Fragments = fragments
-
+		if len(fragments) > 0 {
+			selectionSet.Fragments = append(selectionSet.Fragments, fragments...)
+		}
 		// Recursively flatten.
 		for _, selection := range selections {
 			// Get the type of the field.


### PR DESCRIPTION
Fixed a federation bug where for nested fragments we weren't setting the selection set to equal the flattened selections. I also added a test that would catch this scenario