### PR TITLE
graphql/schemabuilder: rename to ShouldUseBatchFunc

### DIFF
--- a/graphql/schemabuilder/batch.go
+++ b/graphql/schemabuilder/batch.go
@@ -50,11 +50,11 @@ func (sb *schemaBuilder) buildBatchFunctionWithFallback(typ reflect.Type, m *met
 		}
 	}
 
-	if m.BatchArgs.ShouldUseFallbackFunc == nil {
+	if m.BatchArgs.ShouldUseBatchFunc == nil {
 		return nil, fmt.Errorf("batch function requires fallback check function (got nil)")
 	}
 
-	batchField.UseBatchFunc = m.BatchArgs.ShouldUseFallbackFunc
+	batchField.UseBatchFunc = m.BatchArgs.ShouldUseBatchFunc
 	batchField.Resolve = fallbackField.Resolve
 	return batchField, nil
 }

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -873,7 +873,7 @@ func (c *connectionContext) consumeSorts(sb *schemaBuilder, m *method, typ refle
 
 		// Build a GraphQL field for the function.
 		var field *graphql.Field
-		if sortMethod.Batch && sortMethod.BatchArgs.FallbackFunc != nil && sortMethod.BatchArgs.ShouldUseFallbackFunc != nil {
+		if sortMethod.Batch && sortMethod.BatchArgs.FallbackFunc != nil && sortMethod.BatchArgs.ShouldUseBatchFunc != nil {
 			field, err = sb.buildBatchFunctionWithFallback(typ, sortMethod)
 		} else if sortMethod.Batch {
 			field, err = sb.buildBatchFunction(typ, sortMethod)
@@ -926,7 +926,7 @@ func (c *connectionContext) consumeTextFilters(sb *schemaBuilder, m *method, typ
 		}
 
 		var field *graphql.Field
-		if filterMethod.Batch && filterMethod.BatchArgs.FallbackFunc != nil && filterMethod.BatchArgs.ShouldUseFallbackFunc != nil {
+		if filterMethod.Batch && filterMethod.BatchArgs.FallbackFunc != nil && filterMethod.BatchArgs.ShouldUseBatchFunc != nil {
 			field, err = sb.buildBatchFunctionWithFallback(typ, filterMethod)
 		} else if filterMethod.Batch {
 			field, err = sb.buildBatchFunction(typ, filterMethod)
@@ -1088,7 +1088,7 @@ func (sb *schemaBuilder) buildPaginatedFieldWithFallback(typ reflect.Type, m *me
 	field := &graphql.Field{
 		Resolve: func(ctx context.Context, source, args interface{}, selectionSet *graphql.SelectionSet) (i interface{}, e error) {
 			dualArgs := args.(dualArgResponses)
-			if m.ManualPaginationArgs.ShouldUseFallbackFunc(ctx) {
+			if m.ManualPaginationArgs.ShouldUseBatchFunc(ctx) {
 				return fallbackField.Resolve(ctx, source, dualArgs.fallbackArgValue, selectionSet)
 			}
 			return manualPaginationField.Resolve(ctx, source, dualArgs.argValue, selectionSet)

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -89,7 +89,7 @@ func BatchFilterFieldWithFallback(name string, batchFilter interface{}, filter i
 		Fn: batchFilter,
 		BatchArgs: batchArgs{
 			FallbackFunc:          filter,
-			ShouldUseFallbackFunc: flag,
+			ShouldUseBatchFunc: flag,
 		}, Batch: true,
 		MarkedNonNullable: true}
 	for _, opt := range options {
@@ -146,7 +146,7 @@ func BatchSortFieldWithFallback(name string, batchSort interface{}, sort interfa
 		Fn: batchSort,
 		BatchArgs: batchArgs{
 			FallbackFunc:          sort,
-			ShouldUseFallbackFunc: flag,
+			ShouldUseBatchFunc: flag,
 		}, Batch: true,
 		MarkedNonNullable: true}
 	for _, opt := range options {
@@ -226,7 +226,7 @@ func (s *Object) BatchFieldFuncWithFallback(name string, batchFunc interface{}, 
 		Fn: batchFunc,
 		BatchArgs: batchArgs{
 			FallbackFunc:          fallbackFunc,
-			ShouldUseFallbackFunc: flag,
+			ShouldUseBatchFunc: flag,
 		},
 		Batch: true,
 	}
@@ -249,7 +249,7 @@ func (s *Object) ManualPaginationWithFallback(name string, manualPaginatedFunc i
 		Fn: manualPaginatedFunc,
 		ManualPaginationArgs: manualPaginationArgs{
 			FallbackFunc:          fallbackFunc,
-			ShouldUseFallbackFunc: flag,
+			ShouldUseBatchFunc: flag,
 		},
 		Paginated: true,
 	}
@@ -326,12 +326,12 @@ type UseFallbackFlag func(context.Context) bool
 
 type batchArgs struct {
 	FallbackFunc          interface{}
-	ShouldUseFallbackFunc UseFallbackFlag
+	ShouldUseBatchFunc UseFallbackFlag
 }
 
 type manualPaginationArgs struct {
 	FallbackFunc          interface{}
-	ShouldUseFallbackFunc UseFallbackFlag
+	ShouldUseBatchFunc UseFallbackFlag
 }
 
 // A Methods map represents the set of methods exposed on a Object.


### PR DESCRIPTION
We use to call it ShouldUseFallbackFunc, but if its true we use the batch func and if its false we use the
fallback func. This is a bit misleading, but since its an internlly used structure, we can rename it without
causing any regressions