### PR TITLE
Federation Unmarshalling Bug

### DIFF
--- a/federation/executor.go
+++ b/federation/executor.go
@@ -1,6 +1,7 @@
 package federation
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -228,9 +229,19 @@ func (e *Executor) runOnService(ctx context.Context, service string, typName str
 	}
 	// Unmarshal json from results
 	var res interface{}
-	if err := json.Unmarshal(response.Result, &res); err != nil {
+	// if err := json.Unmarshal(response.Result, &res); err != nil {
+	// 	return nil, nil, oops.Wrapf(err, "unmarshal res")
+	// }
+
+	d := json.NewDecoder(bytes.NewReader(response.Result))
+	d.UseNumber()
+	if err := d.Decode(&res); err != nil {
 		return nil, nil, oops.Wrapf(err, "unmarshal res")
 	}
+
+
+	// if err := json.Unmarshal([]byte(result.Output), &output); err != nil {
+
 
 	if !isRoot {
 		result, ok := res.(map[string]interface{})

--- a/federation/server.go
+++ b/federation/server.go
@@ -1,6 +1,7 @@
 package federation
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -172,9 +173,18 @@ func unmarshalPbSelectionSet(selectionSet *thunderpb.SelectionSet) (*graphql.Sel
 
 		var args map[string]interface{}
 		if len(selection.Arguments) != 0 {
-			if err := json.Unmarshal(selection.Arguments, &args); err != nil {
+			// if err := json.Unmarshal(selection.Arguments, &args); err != nil {
+			// 	return nil, oops.Wrapf(err, "unmarshaling selection arguments")
+			// }
+
+			d := json.NewDecoder(bytes.NewReader(selection.Arguments))
+			d.UseNumber()
+			if err := d.Decode(&args); err != nil {
 				return nil, oops.Wrapf(err, "unmarshaling selection arguments")
 			}
+
+			
+
 		}
 
 		selections = append(selections, &graphql.Selection{


### PR DESCRIPTION
There's a bug where unmarshaling graphql response strings into
interfaces was turning MaxInt64's into 9223372036854776000 which
overflows int64. We discovered this because we were getting errors
when trying to unmarshal json into a go struct int64 field.

This happens because json.Unmarshal treats numbers as float64s, and
to preserve the int64 value we have to use a json decoder and UseNumber
instead.

See go playground snippet for an example of this behavior:
https://play.golang.org/p/gL8f4BsJ0M-

See stackoverflow for fix:
https://stackoverflow.com/questions/16946306/preserve-int64-values-when-parsing-json-in-go

