### PR TITLE
Federation Unmarshalling Errors

### DIFF
--- a/federation/customexecutor_test.go
+++ b/federation/customexecutor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"bytes"
 
 	"github.com/samsarahq/go/oops"
 	"github.com/samsarahq/thunder/graphql"
@@ -123,7 +124,9 @@ func executeSuccesfulQuery(t *testing.T, ctx context.Context, e *Executor, extra
 	 		]
 	 	}`
 	var expected interface{}
-	err = json.Unmarshal([]byte(output), &expected)
+	d := json.NewDecoder(bytes.NewReader([]byte(output)))
+	d.UseNumber()
+	err = d.Decode(&expected)
 	require.NoError(t, err)
 	assert.Equal(t, expected, res)
 	expectedoptionalRespMetadata := make([]interface{}, 1)

--- a/federation/executor.go
+++ b/federation/executor.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sync"
 	"time"
+	"bytes"
 
 	"github.com/samsarahq/go/oops"
 	"golang.org/x/sync/errgroup"
@@ -228,7 +229,9 @@ func (e *Executor) runOnService(ctx context.Context, service string, typName str
 	}
 	// Unmarshal json from results
 	var res interface{}
-	if err := json.Unmarshal(response.Result, &res); err != nil {
+	d := json.NewDecoder(bytes.NewReader(response.Result))
+	d.UseNumber()
+	if err := d.Decode(&res); err != nil {
 		return nil, nil, oops.Wrapf(err, "unmarshal res")
 	}
 

--- a/federation/executor_test.go
+++ b/federation/executor_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"bytes"
 
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/graphql/schemabuilder"
@@ -242,7 +243,9 @@ func runAndValidateQueryResults(t *testing.T, ctx context.Context, e *Executor, 
 	res, _, err := e.Execute(ctx, graphql.MustParse(query, map[string]interface{}{}), nil)
 	require.NoError(t, err)
 	var expected interface{}
-	err = json.Unmarshal([]byte(out), &expected)
+	d := json.NewDecoder(bytes.NewReader([]byte(out)))
+	d.UseNumber()
+	err = d.Decode(&expected)
 	require.NoError(t, err)
 	assert.Equal(t, expected, res)
 }
@@ -1418,7 +1421,9 @@ func TestExecutorQueriesWithDirectivesWithVariables(t *testing.T) {
 				res, _, err := e.Execute(ctx, graphql.MustParse(testCase.Query, testCase.Variables), nil)
 				require.NoError(t, err)
 				var expected interface{}
-				err = json.Unmarshal([]byte(testCase.Output), &expected)
+				d := json.NewDecoder(bytes.NewReader([]byte(testCase.Output)))
+				d.UseNumber()
+				err = d.Decode(&expected)
 				require.NoError(t, err)
 				assert.Equal(t, expected, res)
 			} else {
@@ -1571,7 +1576,10 @@ func TestBasicFederatedObjectFetchAllFields(t *testing.T) {
 				res, _, err := e.Execute(ctx, graphql.MustParse(testCase.Query, testCase.Variables), nil)
 				require.NoError(t, err)
 				var expected interface{}
-				err = json.Unmarshal([]byte(testCase.Output), &expected)
+				d := json.NewDecoder(bytes.NewReader([]byte(testCase.Output)))
+				d.UseNumber()
+				err = d.Decode(&expected)
+
 				require.NoError(t, err)
 				fmt.Println(expected)
 				assert.Equal(t, expected, res)


### PR DESCRIPTION
There's a bug where unmarshaling graphql response strings into
interfaces was turning MaxInt64's into 9223372036854776000 which
overflows int64. We discovered this because we were getting errors
when trying to unmarshal json into a go struct int64 field.

This happens because json.Unmarshal treats numbers as float64s, and
to preserve the int64 value we have to use a json decoder and UseNumber
instead.

See go playground snippet for an example of this behavior:
https://play.golang.org/p/gL8f4BsJ0M-

See stackoverflow for fix:
https://stackoverflow.com/questions/16946306/preserve-int64-values-when-parsing-json-in-go