### PR TITLE
graphql inspection: add type_as_optional directive

### DIFF
--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -123,6 +123,15 @@ var skipDirective = Directive{
 	},
 }
 
+var typeAsOptionalDirective = Directive{
+	Description: "Client-side-only directive that instructs the type generator to mark this field as optional. This is useful for making the generated types compliant with Troy persistence schema.",
+	Locations: []DirectiveLocation{
+		FIELD,
+	},
+	Name: "type_as_optional",
+	Args: []InputValue{},
+}
+
 func (s *introspection) registerType(schema *schemabuilder.Schema) {
 	object := schema.Object("__Type", Type{})
 	object.FieldFunc("kind", func(t Type) TypeKind {
@@ -349,7 +358,11 @@ func (s *introspection) registerQuery(schema *schemabuilder.Schema) {
 			Types:        types,
 			QueryType:    &Type{Inner: s.query},
 			MutationType: &Type{Inner: s.mutation},
-			Directives:   []Directive{includeDirective, skipDirective},
+			Directives: []Directive{
+				includeDirective,
+				skipDirective,
+				typeAsOptionalDirective,
+			},
 		}
 	})
 

--- a/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
+++ b/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
@@ -54,6 +54,12 @@
                 "INLINE_FRAGMENT"
               ],
               "name": "skip"
+            },
+            {
+                "args": [],
+                "description": "Client-side-only directive that instructs the type generator to mark this field as optional. This is useful for making the generated types compliant with Troy persistence schema.",
+                "locations": ["FIELD"],
+                "name": "type_as_optional"
             }
           ],
           "mutationType": {


### PR DESCRIPTION
this is a no-op directive that will be used on the client-side by our type generation system

See this PR for a deeper explanation:
https://github.com/samsara-dev/backend/pull/93693

Screenshot if it working in GraphiQL:
![image](https://user-images.githubusercontent.com/4583705/105246428-18edf700-5b28-11eb-90b3-b7de68618331.png)
