### PR TITLE
go sqlgen: add an API to batch upsert rows in sqlgen

### DIFF
--- a/sqlgen/db.go
+++ b/sqlgen/db.go
@@ -526,6 +526,68 @@ func (db *DB) InsertRows(ctx context.Context, rows interface{}, chunkSize int) e
 	return nil
 }
 
+// UpsertRows upserts multiple rows into the database, chunksize rows at a time.
+// Most SQL db enforce a limit on max size of packet, which is why we need to break
+// the rows into chunks.
+//
+// rows should be an array of pointers to a struct, for example:
+//
+//   user1 := &User{Name: "foo"}
+//   user2 := &User{Name: "fan"}
+//   if err := db.UpsertRows(ctx, [](*User){user1, user2}, 100); err != nil {
+//
+func (db *DB) UpsertRows(ctx context.Context, rows interface{}, chunkSize int) error {
+	val := reflect.ValueOf(rows)
+	kind := val.Kind()
+	if kind != reflect.Slice && kind != reflect.Array {
+		return fmt.Errorf("expect array/slice got %s", val.Kind().String())
+	}
+
+	rowsData := make([]interface{}, val.Len())
+	for i := 0; i < val.Len(); i++ {
+		rowsData[i] = val.Index(i).Interface()
+	}
+
+	var tx *sql.Tx
+	if !db.HasTx(ctx) {
+		var err error
+		ctx, tx, err = db.WithTx(ctx)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+	}
+
+	for j := 0; j < len(rowsData); j += chunkSize {
+		sliceLength := chunkSize
+		if len(rowsData) < j+sliceLength {
+			sliceLength = len(rowsData) - j
+		}
+		slice := rowsData[j : j+sliceLength]
+
+		query, err := db.Schema.MakeBatchUpsertRow(slice)
+		if err != nil {
+			return err
+		}
+
+		numColumns := len(query.Columns)
+		for i := 0; i < len(slice); i++ {
+			if err := db.checkColumnValuesAgainstLimits(ctx, query, query.Columns, query.Values[i*numColumns:(i+1)*numColumns], query.Table); err != nil {
+				return err
+			}
+		}
+		_, err = db.execWithTrace(ctx, query, "UpsertRows")
+		if err != nil {
+			return err
+		}
+	}
+
+	if tx != nil {
+		return tx.Commit()
+	}
+	return nil
+}
+
 // UpsertRow inserts a single row into the database
 //
 // row should be a pointer to a struct, for example:

--- a/sqlgen/mysql_test.go
+++ b/sqlgen/mysql_test.go
@@ -153,6 +153,26 @@ func TestUpsertQuery(t *testing.T) {
 	}, "INSERT INTO foo (bar, baz) VALUES (?, ?) ON DUPLICATE KEY UPDATE bar=VALUES(bar), baz=VALUES(baz)", []interface{}{10, "buh"}, t)
 }
 
+func TestBatchUpsertQuery(t *testing.T) {
+	testQuery(&BatchUpsertQuery{
+		Table:   "foo",
+		Columns: []string{"bar"},
+		Values:  []interface{}{3, 4},
+	}, "INSERT INTO foo (bar) VALUES (?), (?) ON DUPLICATE KEY UPDATE bar=VALUES(bar)", []interface{}{3, 4}, t)
+
+	testQuery(&BatchUpsertQuery{
+		Table:   "foo2",
+		Columns: []string{"bar", "baz"},
+		Values:  []interface{}{3, "buh"},
+	}, "INSERT INTO foo2 (bar, baz) VALUES (?, ?) ON DUPLICATE KEY UPDATE bar=VALUES(bar), baz=VALUES(baz)", []interface{}{3, "buh"}, t)
+
+	testQuery(&BatchUpsertQuery{
+		Table:   "foo2",
+		Columns: []string{"bar", "baz"},
+		Values:  []interface{}{3, "buh", 5, "test"},
+	}, "INSERT INTO foo2 (bar, baz) VALUES (?, ?), (?, ?) ON DUPLICATE KEY UPDATE bar=VALUES(bar), baz=VALUES(baz)", []interface{}{3, "buh", 5, "test"}, t)
+}
+
 func TestUpdateQuery(t *testing.T) {
 	testQuery(&UpdateQuery{
 		Table:   "foo",


### PR DESCRIPTION
The sqlgen API currently only supports upserting a single row at a time. In order to allow for more performant batch upserts, this change adds support for a batch upsert API.