### PR TITLE
batch index: implement MarshalText and UnmarshalText

### DIFF
--- a/batch/index.go
+++ b/batch/index.go
@@ -1,5 +1,7 @@
 package batch
 
+import "encoding/json"
+
 // Index is a "key" mapper for batch requests.  Its key is not special and
 // should be treated the same as an index in a slice.
 type Index struct {
@@ -12,4 +14,16 @@ type Index struct {
 func NewIndex(key int) Index {
 	// TODO generate a hash to really mess with people trying to recreate batches?
 	return Index{key: key}
+}
+
+// Create another type for Index so that MarshalText and UnmarshalText
+// don't run into recursion issues.
+type index Index
+
+func (i Index) MarshalText() (text []byte, err error) {
+	return json.Marshal(index(i))
+}
+
+func (i *Index) UnmarshalText(text []byte) error {
+	return json.Unmarshal(text, (*index)(i))
 }


### PR DESCRIPTION
currently, json.Marshal on batch.Index throws an error `json: unsupported type: map[batch.Index]bool` when attempting to run. This change fixes that issue by implementing MarshalText and UnmarshalText on batch.Index