### PR TITLE
go federation: remove unnecessary fragments from flatten

### DIFF
--- a/federation/normalize_test.go
+++ b/federation/normalize_test.go
@@ -2,7 +2,7 @@ package federation
 
 import (
 	"testing"
-
+	
 	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/graphql/schemabuilder"
 	"github.com/stretchr/testify/assert"
@@ -282,14 +282,32 @@ func TestNormalize(t *testing.T) {
 							... Bar
 						}
 					}
+					search {
+						... Zar
+					}
 				}
 
 				fragment Bar on User {
 					name
 				}
+
+				fragment Zar on House {
+					name
+					users {
+						... Bar
+					}
+				}
 			`,
 			output: `
 				{
+					search {
+						... on House {
+							name
+							users {
+								name
+							}
+						}
+					}
 					users {
 						__typename
 						friends {

--- a/federation/planner.go
+++ b/federation/planner.go
@@ -4,7 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-
+	"strings"
+	
 	"github.com/samsarahq/go/oops"
 	"github.com/samsarahq/thunder/graphql"
 )
@@ -112,7 +113,7 @@ func printPlan(rootPlan *Plan) {
 		for _, selection := range plan.SelectionSet.Selections {
 			fmt.Println("service: ", plan.Service)
 			fmt.Println(selection.Name)
-			printSelections(selection.SelectionSet)
+			printSelections(selection.SelectionSet, 0)
 
 			fmt.Println("")
 		}
@@ -122,19 +123,19 @@ func printPlan(rootPlan *Plan) {
 	}
 }
 
-func printSelections(selectionSet *graphql.SelectionSet) {
+func printSelections(selectionSet *graphql.SelectionSet, level int) {
 	if selectionSet != nil {
-		fmt.Println(" selections")
+		fmt.Println(strings.Repeat(" ", level), "selections")
 		for _, subSelection := range selectionSet.Selections {
-			fmt.Println(" ", subSelection.Name)
+			fmt.Println(strings.Repeat(" ", level), " ", subSelection.Name)
 			if subSelection.Args != nil {
-				fmt.Println("   args ", subSelection.Args)
+				fmt.Println(strings.Repeat(" ", level), "   args ", subSelection.Args)
 			}
-			printSelections(subSelection.SelectionSet)
+			printSelections(subSelection.SelectionSet, level+ 1)
 		}
-		fmt.Println(" fragments")
+		fmt.Println(strings.Repeat(" ", level), "fragments")
 		for _, subFragment := range selectionSet.Fragments {
-			printSelections(subFragment.SelectionSet)
+			printSelections(subFragment.SelectionSet, level+ 1)
 		}
 	}
 }


### PR DESCRIPTION
Currently, we are maintaining a list of all fragments that are not
applicable to the current type in flattenFragments. For each
selectionSet, we append the list of unused fragments to the selection
set's fragments. However, we never again use selectionSet.Fragments
again, even in child recursive calls, and do not need it to flatten
the rest of the selectionSet. Thus, it is safe to remove this
logic.

As a result of this logic, there was a bug: if multiple selections use the same
fragment, then we mutate the fragment's selectionSet in child recursive
calls. This results in a fragment.SelectionSet.Fragments array that
grows exponentially in size, and runtime grows exponentially as well as
we process that fragment array. Removing this logic fixes this bug.