### PR TITLE
reactive/rerunner: add dependencySetForSelection

### DIFF
--- a/reactive/rerunner.go
+++ b/reactive/rerunner.go
@@ -176,6 +176,21 @@ func (ds *dependencySet) get() []Dependency {
 	return ds.dependencies
 }
 
+type dependencySetForSelectionKey struct{}
+
+func WithDependencySetForSelection(ctx context.Context) context.Context {
+	return context.WithValue(ctx, dependencySetForSelectionKey{}, &dependencySet{})
+}
+
+func DependenciesForSelection(ctx context.Context) []Dependency {
+	depSet := ctx.Value(dependencySetForSelectionKey{}).(*dependencySet)
+	if depSet == nil {
+		return nil
+	}
+
+	return depSet.get()
+}
+
 type Dependency interface{}
 
 type DependencyCallbackFunc func(context.Context, Dependency)
@@ -195,6 +210,10 @@ func AddDependency(ctx context.Context, r *Resource, dep Dependency) {
 		depSet, ok := ctx.Value(dependencySetKey{}).(*dependencySet)
 		if ok && depSet != nil {
 			depSet.add(dep)
+		}
+		depSetForSelection, ok := ctx.Value(dependencySetForSelectionKey{}).(*dependencySet)
+		if ok && depSetForSelection != nil {
+			depSetForSelection.add(dep)
 		}
 		if callback, ok := ctx.Value(dependencyCallbackKey{}).(DependencyCallbackFunc); ok && callback != nil {
 			callback(ctx, dep)


### PR DESCRIPTION
In addition to tracking the dependencies for a query, we will also provide tooling for a WorkScheduler to track the dependencies for a single selection.

For example, one could change the implementation of the WorkScheduler [defined here](https://github.com/samsarahq/thunder/blob/master/graphql/batch_scheduler.go) like so:

Before:
```
func (r *immediateGoroutineSchedulerRunner) runEnqueue(resolver UnitResolver, units ...*WorkUnit) {
	for _, unit := range units {
		r.wg.Add(1)
		go func(u *WorkUnit) {
			defer r.wg.Done()
			units := resolver(u)
			r.runEnqueue(resolver, units...)
		}(unit)
	}
}
```

After:
```
func (r *immediateGoroutineSchedulerRunner) runEnqueue(resolver UnitResolver, units ...*WorkUnit) {
	for _, unit := range units {
		r.wg.Add(1)
		go func(u *WorkUnit) {
			defer r.wg.Done()

                         u.Ctx = reactive.WithDependencySetForSelection(u.Ctx)
			units := resolver(u)

                         depsForSelection := reactive.DependenciesForSelection(u.Ctx)
                         // Do something with the newly added dependencies

			r.runEnqueue(resolver, units...)
		}(unit)
	}
}
```

I opted not to make the above change in this commit since it doesn't seem useful for all users. 