### PR TITLE
go sqlgen: Add SELECT ... FOR UPDATE support

### DIFF
--- a/sqlgen/mysql.go
+++ b/sqlgen/mysql.go
@@ -95,6 +95,10 @@ func (q *SelectQuery) ToSQL() (string, []interface{}) {
 		fmt.Fprint(&buffer, q.Options.Limit)
 	}
 
+	if q.Options.ForUpdate {
+		buffer.WriteString(" FOR UPDATE")
+	}
+
 	return buffer.String(), q.Options.Values
 }
 

--- a/sqlgen/mysql_test.go
+++ b/sqlgen/mysql_test.go
@@ -41,7 +41,7 @@ func TestSimpleWhere(t *testing.T) {
 
 func TestCountQuery(t *testing.T) {
 	testQuery(&countQuery{
-		Table:   "foo",
+		Table: "foo",
 		Where: &SimpleWhere{
 			Columns: []string{"bar"},
 			Values:  []interface{}{3},
@@ -49,7 +49,7 @@ func TestCountQuery(t *testing.T) {
 	}, "SELECT COUNT(*) FROM foo WHERE bar = ?", []interface{}{3}, t)
 
 	testQuery(&countQuery{
-		Table:   "foo2",
+		Table: "foo2",
 		Where: &SimpleWhere{
 			Columns: []string{"baz"},
 			Values:  []interface{}{"xyz"},
@@ -57,7 +57,7 @@ func TestCountQuery(t *testing.T) {
 	}, "SELECT COUNT(*) FROM foo2 WHERE baz = ?", []interface{}{"xyz"}, t)
 
 	testQuery(&countQuery{
-		Table:   "foo3",
+		Table: "foo3",
 		Where: &SimpleWhere{
 			Columns: []string{"baz", "blah"},
 			Values:  []interface{}{"xyz", nil},
@@ -83,7 +83,6 @@ func TestSelectQuery(t *testing.T) {
 			Values: []interface{}{3, nil},
 		},
 	}, "SELECT bar FROM foo WHERE bar = ? AND baz IS ?", []interface{}{3, nil}, t)
-
 
 	testQuery(&SelectQuery{
 		Table:   "foo",
@@ -120,6 +119,16 @@ func TestSelectQuery(t *testing.T) {
 			OrderBy: "bar",
 		},
 	}, "SELECT foo, bar FROM foo ORDER BY bar", nil, t)
+
+	testQuery(&SelectQuery{
+		Table:   "foo",
+		Columns: []string{"foo", "bar"},
+		Options: &SelectOptions{
+			Where:     "foo = ? AND bar = ?",
+			Values:    []interface{}{25, "xyz"},
+			ForUpdate: true,
+		},
+	}, "SELECT foo, bar FROM foo WHERE foo = ? AND bar = ? FOR UPDATE", []interface{}{25, "xyz"}, t)
 }
 
 func TestInsertQuery(t *testing.T) {

--- a/sqlgen/reflect.go
+++ b/sqlgen/reflect.go
@@ -21,8 +21,9 @@ type SelectOptions struct {
 	Where  string
 	Values []interface{}
 
-	OrderBy string
-	Limit   int
+	OrderBy   string
+	Limit     int
+	ForUpdate bool
 
 	AllowNoIndex bool
 }


### PR DESCRIPTION
Added a ForUpdate option to the SelectOptions, in order to lock rows in a transaction using the SELECT ... FOR UPDATE syntax.  The mysql documentation for locking reads can be found here: https://dev.mysql.com/doc/refman/5.6/en/innodb-locking-reads.html