### PR TITLE
go graphql: add description to fieldfuncs

### DIFF
--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -234,9 +234,10 @@ func (s *introspection) registerType(schema *schemabuilder.Schema) {
 				sort.Slice(args, func(i, j int) bool { return args[i].Name < args[j].Name })
 
 				fields = append(fields, field{
-					Name: name,
-					Type: Type{Inner: f.Type},
-					Args: args,
+					Name:        name,
+					Description: f.Description,
+					Type:        Type{Inner: f.Type},
+					Args:        args,
 				})
 			}
 		}

--- a/graphql/introspection/introspection_test.go
+++ b/graphql/introspection/introspection_test.go
@@ -64,7 +64,7 @@ func makeSchema() *schemabuilder.Schema {
 	}, schemabuilder.Paginated)
 	query.FieldFunc("userUuid", func() (*Uuid, error) {
 		return nil, nil
-	})
+	}, schemabuilder.Description("This gets the uuid for a user"))
 	query.FieldFunc("usersUuid", func() ([]Uuid, error) {
 		return nil, nil
 	})

--- a/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
+++ b/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
@@ -56,10 +56,12 @@
               "name": "skip"
             },
             {
-                "args": [],
-                "description": "Client-side-only directive that instructs the type generator to mark this field as optional. This is useful for making the generated types compliant with Troy persistence schema.",
-                "locations": ["FIELD"],
-                "name": "type_as_optional"
+              "args": [],
+              "description": "Client-side-only directive that instructs the type generator to mark this field as optional. This is useful for making the generated types compliant with Troy persistence schema.",
+              "locations": [
+                "FIELD"
+              ],
+              "name": "type_as_optional"
             }
           ],
           "mutationType": {
@@ -452,7 +454,7 @@
                 {
                   "args": [],
                   "deprecationReason": "",
-                  "description": "",
+                  "description": "This gets the uuid for a user",
                   "isDeprecated": false,
                   "name": "userUuid",
                   "type": {

--- a/graphql/schemabuilder/output.go
+++ b/graphql/schemabuilder/output.go
@@ -125,6 +125,7 @@ func (sb *schemaBuilder) buildStruct(typ reflect.Type) error {
 				return err
 			}
 			object.Fields[name] = typedField
+			object.Fields[name].Description = method.Description
 			continue
 		}
 
@@ -133,6 +134,7 @@ func (sb *schemaBuilder) buildStruct(typ reflect.Type) error {
 			return fmt.Errorf("bad method %s on type %s: %s", name, typ, err)
 		}
 		object.Fields[name] = built
+		object.Fields[name].Description = method.Description
 	}
 
 	if objectKey != "" {

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -88,7 +88,7 @@ func BatchFilterFieldWithFallback(name string, batchFilter interface{}, filter i
 	textFilterMethod := &method{
 		Fn: batchFilter,
 		BatchArgs: batchArgs{
-			FallbackFunc:          filter,
+			FallbackFunc:       filter,
 			ShouldUseBatchFunc: flag,
 		}, Batch: true,
 		MarkedNonNullable: true}
@@ -145,7 +145,7 @@ func BatchSortFieldWithFallback(name string, batchSort interface{}, sort interfa
 	sortMethod := &method{
 		Fn: batchSort,
 		BatchArgs: batchArgs{
-			FallbackFunc:          sort,
+			FallbackFunc:       sort,
 			ShouldUseBatchFunc: flag,
 		}, Batch: true,
 		MarkedNonNullable: true}
@@ -162,6 +162,12 @@ func BatchSortFieldWithFallback(name string, batchSort interface{}, sort interfa
 		m.SortMethods[name] = sortMethod
 	}
 	return fieldFuncSortFields
+}
+
+type Description string
+
+func (s Description) apply(m *method) {
+	m.Description = string(s)
 }
 
 // FieldFunc exposes a field on an object. The function f can take a number of
@@ -225,7 +231,7 @@ func (s *Object) BatchFieldFuncWithFallback(name string, batchFunc interface{}, 
 	m := &method{
 		Fn: batchFunc,
 		BatchArgs: batchArgs{
-			FallbackFunc:          fallbackFunc,
+			FallbackFunc:       fallbackFunc,
 			ShouldUseBatchFunc: flag,
 		},
 		Batch: true,
@@ -248,7 +254,7 @@ func (s *Object) ManualPaginationWithFallback(name string, manualPaginatedFunc i
 	m := &method{
 		Fn: manualPaginatedFunc,
 		ManualPaginationArgs: manualPaginationArgs{
-			FallbackFunc:          fallbackFunc,
+			FallbackFunc:       fallbackFunc,
 			ShouldUseBatchFunc: flag,
 		},
 		Paginated: true,
@@ -308,6 +314,9 @@ type method struct {
 	// is a shadow object. A shadow object's fields are each of the
 	// field that are sent as args to a federated sunquery.
 	ShadowObjectType reflect.Type
+
+	// Human readable description of this method.
+	Description string
 }
 
 type concurrencyArgs struct {
@@ -320,17 +329,19 @@ type concurrencyArgs struct {
 // the different goroutines.
 type NumParallelInvocationsFunc func(ctx context.Context, numNodes int) int
 
-func (f NumParallelInvocationsFunc) apply(m *method) { m.ConcurrencyArgs.numParallelInvocationsFunc = f }
+func (f NumParallelInvocationsFunc) apply(m *method) {
+	m.ConcurrencyArgs.numParallelInvocationsFunc = f
+}
 
 type UseFallbackFlag func(context.Context) bool
 
 type batchArgs struct {
-	FallbackFunc          interface{}
+	FallbackFunc       interface{}
 	ShouldUseBatchFunc UseFallbackFlag
 }
 
 type manualPaginationArgs struct {
-	FallbackFunc          interface{}
+	FallbackFunc       interface{}
 	ShouldUseBatchFunc UseFallbackFlag
 }
 

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -127,6 +127,7 @@ type Field struct {
 	Resolve        Resolver
 	BatchResolver  BatchResolver
 	Type           Type
+	Description    string
 	Args           map[string]Type
 	ParseArguments func(json interface{}) (interface{}, error)
 


### PR DESCRIPTION
This fieldfunc option will allow users to set a description
value for their field. This will be most useful for people
who browse generated docs or Graphiql since they can
see an actual message instead of "".