### PR TITLE
normalize: fix a bug in mergeSameAlias

### DIFF
--- a/federation/normalize.go
+++ b/federation/normalize.go
@@ -177,18 +177,18 @@ func mergeSameAlias(selections []*graphql.Selection) ([]*graphql.Selection, erro
 				return nil, fmt.Errorf("one selection with alias %s has subselections and one does not",
 					selection.Alias)
 			}
-			seenSelections := make(map[string]bool, len(last.SelectionSet.Selections))
+			seenSelections := make(map[string]struct{}, len(selection.SelectionSet.Selections))
 			for _, s := range selection.SelectionSet.Selections {
-				if !seenSelections[s.Alias] {
-					seenSelections[s.Alias] = true
+				if _, ok := seenSelections[s.Alias]; !ok {
+					seenSelections[s.Alias] = struct{}{}
 					last.SelectionSet.Selections = append(last.SelectionSet.Selections, s)
 				}
 
 			}
-			seenFragments := make(map[*graphql.Fragment]bool, len(last.SelectionSet.Selections))
+			seenFragments := make(map[*graphql.Fragment]struct{}, len(selection.SelectionSet.Fragments))
 			for _, f := range selection.SelectionSet.Fragments {
-				if !seenFragments[f] {
-					seenFragments[f] = true
+				if _, ok := seenFragments[f]; !ok {
+					seenFragments[f] = struct{}{}
 					last.SelectionSet.Fragments = append(last.SelectionSet.Fragments, f)
 				}
 			}

--- a/federation/normalize.go
+++ b/federation/normalize.go
@@ -150,8 +150,14 @@ func mergeSameAlias(selections []*graphql.Selection) ([]*graphql.Selection, erro
 		if last == nil || selection.Alias != last.Alias {
 			// Make a copy of the selection so we can modify it below
 			// or when we flatten recursively later.
-			copy := *selection
-			selection = &copy
+			cp := *selection
+			if selection.SelectionSet != nil {
+				// Make a new SelectionSet for the copy so we will not append to the original slice later.
+				cp.SelectionSet = &graphql.SelectionSet{}
+				cp.SelectionSet.Selections = append(cp.SelectionSet.Selections, selection.SelectionSet.Selections...)
+				cp.SelectionSet.Fragments = append(cp.SelectionSet.Fragments, selection.SelectionSet.Fragments...)
+			}
+			selection = &cp
 			newSelections = append(newSelections, selection)
 			last = selection
 			continue

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -173,6 +173,20 @@ type SelectionSet struct {
 	Fragments  []*Fragment
 }
 
+// ShallowCopy returns a shallow copy of SelectionSet.
+func (s *SelectionSet) ShallowCopy() *SelectionSet {
+	cp := &SelectionSet{}
+	if s.Selections != nil {
+		cp.Selections = make([]*Selection, len(s.Selections))
+		copy(cp.Selections, s.Selections)
+	}
+	if s.Fragments != nil {
+		cp.Fragments = make([]*Fragment, len(s.Fragments))
+		copy(cp.Fragments, s.Fragments)
+	}
+	return cp
+}
+
 // A selection represents a part of a GraphQL query
 //
 // The selection

--- a/graphql/types_test.go
+++ b/graphql/types_test.go
@@ -1,0 +1,38 @@
+package graphql_test
+
+import (
+	"github.com/samsarahq/thunder/graphql"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSelectionSetShallowCopy(t *testing.T) {
+	testCases := []*graphql.SelectionSet{
+		{},
+		{Selections: []*graphql.Selection{{Name: "test"}}, Fragments: []*graphql.Fragment{{On: "test"}}},
+		{Selections: []*graphql.Selection{{Name: "test"}}},
+		{Fragments: []*graphql.Fragment{{On: "test"}}},
+	}
+
+	for _, tc := range testCases {
+		r := tc.ShallowCopy()
+		if tc.Fragments == nil {
+			require.Nil(t, r.Fragments)
+		} else {
+			require.True(t, &tc.Fragments != &r.Fragments)
+			require.True(t, len(tc.Fragments) == len(r.Fragments))
+			for i, f := range r.Fragments {
+				require.Equal(t, f, tc.Fragments[i])
+			}
+		}
+		if tc.Selections == nil {
+			require.Nil(t, r.Selections)
+		} else {
+			require.True(t, &tc.Selections != &r.Selections)
+			require.True(t, len(tc.Selections) == len(r.Selections))
+			for i, f := range r.Selections {
+				require.Equal(t, f, tc.Selections[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
In mergeSameAlias, we make a shadow copy of each selection and then append
to copy.selectionSet.selections later.
Since append in GO does not always create a new slice, there is chance we
are appending to the original selectionSet.selections slice. This could cause
the recursively flatten function to run into an infinite loop in some cases.

This commit make a new selectionSet for each copy so we will not append to the
original selections later in the function.

This change does not increase the runtime too much. 
```
Current
BenchmarkNormalize2-8   	    5182	    193595 ns/op	  101487 B/op	    2131 allocs/op

New
BenchmarkNormalize2-16    	    5040	    248245 ns/op	  105241 B/op	    2232 allocs/op
```