### PR TITLE
go federation/normalize: clean up messed code

### DIFF
--- a/federation/normalize.go
+++ b/federation/normalize.go
@@ -155,12 +155,6 @@ func mergeSameAlias(selections []*graphql.Selection) ([]*graphql.Selection, erro
 			// Make a copy of the selection so we can modify it below
 			// or when we flatten recursively later.
 			cp := *selection
-			if selection.SelectionSet != nil {
-				// Make a new SelectionSet for the copy so we will not append to the original slice later.
-				cp.SelectionSet = &graphql.SelectionSet{}
-				cp.SelectionSet.Selections = append(cp.SelectionSet.Selections, selection.SelectionSet.Selections...)
-				cp.SelectionSet.Fragments = append(cp.SelectionSet.Fragments, selection.SelectionSet.Fragments...)
-			}
 			selection = &cp
 			newSelections = append(newSelections, selection)
 			last = selection


### PR DESCRIPTION
In https://github.com/samsarahq/thunder/pull/487/commits, I merged commit
7be9ad108fcd6097f2f0c6bde5fefd5d23910b9b accidentally.

This is to drop the bad commit.