### PR TITLE
graphql/batch_executor: expose IsExpensive and IsBatch workunit fields

### DIFF
--- a/graphql/batch_executor.go
+++ b/graphql/batch_executor.go
@@ -34,6 +34,14 @@ func (w *WorkUnit) Selection() *Selection {
 	return w.selection
 }
 
+func (w *WorkUnit) IsBatch() bool {
+	return w.useBatch
+}
+
+func (w *WorkUnit) IsExpensive() bool {
+	return w.field.Expensive
+}
+
 // Splits the work unit to a series of work units (one for every source/dest pair).
 func splitWorkUnit(unit *WorkUnit) []*WorkUnit {
 	workUnits := make([]*WorkUnit, 0, len(unit.sources))


### PR DESCRIPTION
In order to tag query executions as batched or not, and expensive or not, we expose methods on the work unit that provide this info.