### PR TITLE
Tonia/pass custom filterfunc

### DIFF
--- a/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
+++ b/graphql/introspection/testdata/TestComputeSchemaJSON.snapshots.json
@@ -56,10 +56,12 @@
               "name": "skip"
             },
             {
-                "args": [],
-                "description": "Client-side-only directive that instructs the type generator to mark this field as optional. This is useful for making the generated types compliant with Troy persistence schema.",
-                "locations": ["FIELD"],
-                "name": "type_as_optional"
+              "args": [],
+              "description": "Client-side-only directive that instructs the type generator to mark this field as optional. This is useful for making the generated types compliant with Troy persistence schema.",
+              "locations": [
+                "FIELD"
+              ],
+              "name": "type_as_optional"
             }
           ],
           "mutationType": {
@@ -514,6 +516,16 @@
                     {
                       "defaultValue": null,
                       "description": "",
+                      "name": "filterType",
+                      "type": {
+                        "kind": "SCALAR",
+                        "name": "string",
+                        "ofType": null
+                      }
+                    },
+                    {
+                      "defaultValue": null,
+                      "description": "",
                       "name": "first",
                       "type": {
                         "kind": "SCALAR",
@@ -614,6 +626,16 @@
                             "ofType": null
                           }
                         }
+                      }
+                    },
+                    {
+                      "defaultValue": null,
+                      "description": "",
+                      "name": "filterType",
+                      "type": {
+                        "kind": "SCALAR",
+                        "name": "string",
+                        "ofType": null
                       }
                     },
                     {

--- a/graphql/schemabuilder/pagination.go
+++ b/graphql/schemabuilder/pagination.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"sync"
 	"strings"
+	"sync"
 
 	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/graphql"
@@ -113,6 +113,9 @@ type ConnectionArgs struct {
 	SortBy *string
 	// sortOrder: "asc" | "desc"
 	SortOrder *SortOrder
+	// filterType: "customFilterType"
+	// Note: FilterType is not part of the Relay Spec for Connection types
+	FilterType *string
 }
 
 // PaginationArgs are used in externally set connections by embedding them in an args struct. They
@@ -127,6 +130,7 @@ type PaginationArgs struct {
 	FilterTextFields *[]string
 	SortBy           *string
 	SortOrder        *SortOrder
+	FilterType       *string
 }
 
 func (p PaginationArgs) limit() int {
@@ -194,6 +198,10 @@ type connectionContext struct {
 	SortFields map[string]*graphql.Field
 	// The slice sorting function for each GraphQL field.
 	SortFunctions map[string]func([]sortReference, SortOrder)
+	// The custom filter functions available.
+	FilterFunctions map[string]func(string, []string) bool
+	// The custom search tokenization functions available.
+	TokenizeSearchFunctions map[string]func(string) []string
 }
 
 // embedsPaginationArgs returns true if PaginationArgs were embedded.
@@ -415,7 +423,7 @@ type SafeBatchNodesToKeep struct {
 	mux         sync.Mutex
 }
 
-func (c *connectionContext) applyBatchTextFilter(ctx context.Context, nodes []interface{}, matchStrings []string, batchedFields map[string]*graphql.Field, nodesToKeep []bool) error {
+func (c *connectionContext) applyBatchTextFilter(ctx context.Context, nodes []interface{}, searchTokens []string, filterType *string, batchedFields map[string]*graphql.Field, nodesToKeep []bool) error {
 	g, ctx := errgroup.WithContext(ctx)
 	m := &sync.Mutex{}
 	for unscopeName, unscopedFilterField := range batchedFields {
@@ -430,7 +438,15 @@ func (c *connectionContext) applyBatchTextFilter(ctx context.Context, nodes []in
 				if !ok {
 					return fmt.Errorf("filter %s returned %T, must be a string", name, text)
 				}
-				if filter.MatchText(textString, matchStrings) {
+
+				shouldKeep := false
+				if filterType == nil {
+					shouldKeep = filter.DefaultFilterFunc(textString, searchTokens)
+				} else if filterFunc, ok := c.FilterFunctions[*filterType]; ok {
+					shouldKeep = filterFunc(textString, searchTokens)
+				}
+
+				if shouldKeep {
 					m.Lock()
 					nodesToKeep[i] = true
 					m.Unlock()
@@ -446,7 +462,7 @@ func (c *connectionContext) applyBatchTextFilter(ctx context.Context, nodes []in
 	return nil
 }
 
-func (c *connectionContext) checkFilters(ctx context.Context, node interface{}, matchStrings []string, filterFields map[string]*graphql.Field) (bool, error) {
+func (c *connectionContext) checkFilters(ctx context.Context, node interface{}, searchTokens []string, filterFields map[string]*graphql.Field, filterType *string) (bool, error) {
 	keep := false
 	for name, filterField := range filterFields {
 		// Resolve the graphql.Field made for sorting.
@@ -459,9 +475,17 @@ func (c *connectionContext) checkFilters(ctx context.Context, node interface{}, 
 		if !ok {
 			return keep, fmt.Errorf("filter %s returned %T, must be a string", name, text)
 		}
-		if filter.MatchText(textString, matchStrings) {
-			keep = true
-			break
+
+		if filterType == nil {
+			if filter.DefaultFilterFunc(textString, searchTokens) {
+				keep = true
+				break
+			}
+		} else if filterFunc, ok := c.FilterFunctions[*filterType]; ok {
+			if filterFunc(textString, searchTokens) {
+				keep = true
+				break
+			}
 		}
 	}
 	return keep, nil
@@ -470,12 +494,12 @@ func (c *connectionContext) checkFilters(ctx context.Context, node interface{}, 
 // We found that parallelizing non-expensive fields was slower due to the overhead of
 // spawning goroutines, so we execute non-expensive fields serially. We're also concerned
 // about the memory overhead of spawning many goroutines
-func (c *connectionContext) applyTextFilterNotBatchedExpensive(ctx context.Context, nodes []interface{}, matchStrings []string, filterFields map[string]*graphql.Field, nodesToKeep []bool) error {
+func (c *connectionContext) applyTextFilterNotBatchedExpensive(ctx context.Context, nodes []interface{}, searchTokens []string, filterType *string, filterFields map[string]*graphql.Field, nodesToKeep []bool) error {
 	g, ctx := errgroup.WithContext(ctx)
 	for unscopedI, unscopedNode := range nodes {
 		i, node := unscopedI, unscopedNode
 		g.Go(func() error {
-			keep, err := c.checkFilters(ctx, node, matchStrings, filterFields)
+			keep, err := c.checkFilters(ctx, node, searchTokens, filterFields, filterType)
 			nodesToKeep[i] = keep
 			return err
 		})
@@ -486,10 +510,10 @@ func (c *connectionContext) applyTextFilterNotBatchedExpensive(ctx context.Conte
 	return nil
 }
 
-func (c *connectionContext) applyTextFilterNotBatched(ctx context.Context, nodes []interface{}, matchStrings []string, filterFields map[string]*graphql.Field, nodesToKeep []bool) error {
+func (c *connectionContext) applyTextFilterNotBatched(ctx context.Context, nodes []interface{}, searchTokens []string, filterType *string, filterFields map[string]*graphql.Field, nodesToKeep []bool) error {
 	for unscopedI, unscopedNode := range nodes {
 		i, node := unscopedI, unscopedNode
-		keep, err := c.checkFilters(ctx, node, matchStrings, filterFields)
+		keep, err := c.checkFilters(ctx, node, searchTokens, filterFields, filterType)
 		if err != nil {
 			return err
 		}
@@ -533,24 +557,32 @@ func (c *connectionContext) applyTextFilter(ctx context.Context, nodes []interfa
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
-	matchStrings := filter.GetMatchStrings(*args.FilterText)
+
+	// Get search tokens from search query
+	var searchTokens []string
+	if args.FilterType == nil {
+		searchTokens = filter.GetDefaultSearchTokens(*args.FilterText)
+	} else if tokenizeSearchFunc, ok := c.TokenizeSearchFunctions[*args.FilterType]; ok {
+		searchTokens = tokenizeSearchFunc(*args.FilterText)
+	}
+
 	nodesToKeep := make([]bool, len(nodes))
 	expensiveNodesToKeep := make([]bool, len(nodes))
 	batchedNodesToKeep := make([]bool, len(nodes))
 
 	if len(filterTextFieldsNotBatched) > 0 {
 		g.Go(func() error {
-			return c.applyTextFilterNotBatched(ctx, nodes, matchStrings, filterTextFieldsNotBatched, nodesToKeep)
+			return c.applyTextFilterNotBatched(ctx, nodes, searchTokens, args.FilterType, filterTextFieldsNotBatched, nodesToKeep)
 		})
 	}
 	if len(filterTextFieldsNotBatchedExpensive) > 0 {
 		g.Go(func() error {
-			return c.applyTextFilterNotBatchedExpensive(ctx, nodes, matchStrings, filterTextFieldsNotBatchedExpensive, expensiveNodesToKeep)
+			return c.applyTextFilterNotBatchedExpensive(ctx, nodes, searchTokens, args.FilterType, filterTextFieldsNotBatchedExpensive, expensiveNodesToKeep)
 		})
 	}
 	if len(filterTextFieldsBatched) > 0 {
 		g.Go(func() error {
-			return c.applyBatchTextFilter(ctx, nodes, matchStrings, filterTextFieldsBatched, batchedNodesToKeep)
+			return c.applyBatchTextFilter(ctx, nodes, searchTokens, args.FilterType, filterTextFieldsBatched, batchedNodesToKeep)
 		})
 	}
 	if err := g.Wait(); err != nil {
@@ -916,6 +948,18 @@ func (c *connectionContext) checkFilterTextFunctionTypes(name string, filterMeth
 }
 
 func (c *connectionContext) consumeTextFilters(sb *schemaBuilder, m *method, typ reflect.Type) error {
+	// Store custom filter functions
+	c.FilterFunctions = make(map[string]func(string, []string) bool)
+	for name, filterMethod := range m.FilterMethods {
+		c.FilterFunctions[name] = filterMethod
+	}
+
+	// Store custom tokenize search functions
+	c.TokenizeSearchFunctions = make(map[string]func(string) []string)
+	for name, tokenizeSearchMethod := range m.TokenizeFilterTextMethods {
+		c.TokenizeSearchFunctions[name] = tokenizeSearchMethod
+	}
+
 	c.FilterTextFields = make(map[string]*graphql.Field)
 
 	for name, filterMethod := range m.TextFilterMethods {
@@ -1227,6 +1271,7 @@ func (c *connectionContext) extractReturnAndErr(ctx context.Context, out []refle
 			FilterTextFields: connectionArgs.FilterTextFields,
 			SortBy:           connectionArgs.SortBy,
 			SortOrder:        connectionArgs.SortOrder,
+			FilterType:       connectionArgs.FilterType,
 		}
 	} else {
 		paginationArgs = reflect.ValueOf(args).Field(c.PaginationArgsIndex).Interface().(PaginationArgs)

--- a/graphql/schemabuilder/types.go
+++ b/graphql/schemabuilder/types.go
@@ -50,6 +50,52 @@ var Expensive fieldFuncOptionFunc = func(m *method) {
 	m.Expensive = true
 }
 
+// FilterFunc is an option that can be passed to a FieldFunc to specify
+// custom string matching algorithms for filtering FieldFunc results.
+//
+// It accepts 3 parameters:
+// 1. name
+// This should describe the filter behaviour (e.g. "fuzzySearch").
+// This parameter corresponds with the PaginationArg prop FilterType.
+// Specifying filterType on a GraphQL query will indicate which tokenization
+// and matching algorithms (see below) are used to filter results.
+//
+// 2. tokenizeFilterText
+// This argument should be an algorithm that determines how the search query string
+// is broken up into search tokens. It expects to receive a search string and return
+// a list of search token strings which will be used to compare against
+// the field string for a match in 'filterFunc' (see below).
+//
+// 3. filterFunc
+// This argument should be an algorithm that determines whether there is a match
+// between the field string and the search tokens. It expects to receive the field string
+// and the list of search tokens (generated from 'tokenizeFilterText') and return a boolean
+// which signals whether there is a match that should be included in the returned results.
+func FilterFunc(name string, tokenizeFilterText func(string) []string, filterFunc func(string, []string) bool) FieldFuncOption {
+	var fieldFuncFilterMethods fieldFuncOptionFunc = func(m *method) {
+		// Store custom filter functions
+		if m.FilterMethods == nil {
+			m.FilterMethods = map[string]func(string, []string) bool{}
+		}
+
+		if _, ok := m.FilterMethods[name]; ok {
+			panic("Field Filter Functions have the same name: " + name)
+		}
+		m.FilterMethods[name] = filterFunc
+
+		// Store custom filer text tokenization functions
+		if m.TokenizeFilterTextMethods == nil {
+			m.TokenizeFilterTextMethods = map[string]func(string) []string{}
+		}
+
+		if _, ok := m.TokenizeFilterTextMethods[name]; ok {
+			panic("Tokenize Filter Text Functions have the same name: " + name)
+		}
+		m.TokenizeFilterTextMethods[name] = tokenizeFilterText
+	}
+	return fieldFuncFilterMethods
+}
+
 func FilterField(name string, filter interface{}, options ...FieldFuncOption) FieldFuncOption {
 	textFilterMethod := &method{Fn: filter, Batch: false, MarkedNonNullable: true}
 	for _, opt := range options {
@@ -88,7 +134,7 @@ func BatchFilterFieldWithFallback(name string, batchFilter interface{}, filter i
 	textFilterMethod := &method{
 		Fn: batchFilter,
 		BatchArgs: batchArgs{
-			FallbackFunc:          filter,
+			FallbackFunc:       filter,
 			ShouldUseBatchFunc: flag,
 		}, Batch: true,
 		MarkedNonNullable: true}
@@ -145,7 +191,7 @@ func BatchSortFieldWithFallback(name string, batchSort interface{}, sort interfa
 	sortMethod := &method{
 		Fn: batchSort,
 		BatchArgs: batchArgs{
-			FallbackFunc:          sort,
+			FallbackFunc:       sort,
 			ShouldUseBatchFunc: flag,
 		}, Batch: true,
 		MarkedNonNullable: true}
@@ -225,7 +271,7 @@ func (s *Object) BatchFieldFuncWithFallback(name string, batchFunc interface{}, 
 	m := &method{
 		Fn: batchFunc,
 		BatchArgs: batchArgs{
-			FallbackFunc:          fallbackFunc,
+			FallbackFunc:       fallbackFunc,
 			ShouldUseBatchFunc: flag,
 		},
 		Batch: true,
@@ -248,7 +294,7 @@ func (s *Object) ManualPaginationWithFallback(name string, manualPaginatedFunc i
 	m := &method{
 		Fn: manualPaginatedFunc,
 		ManualPaginationArgs: manualPaginationArgs{
-			FallbackFunc:          fallbackFunc,
+			FallbackFunc:       fallbackFunc,
 			ShouldUseBatchFunc: flag,
 		},
 		Paginated: true,
@@ -285,6 +331,12 @@ type method struct {
 	// Whether or not the FieldFunc has been marked as expensive.
 	Expensive bool
 
+	// Custom filter methods for determining whether a field matches a search query.
+	FilterMethods map[string]func(string, []string) bool
+
+	// Custom methods for generating search tokens from a search query.
+	TokenizeFilterTextMethods map[string]func(string) []string
+
 	// Text filter methods
 	TextFilterMethods map[string]*method
 
@@ -320,17 +372,19 @@ type concurrencyArgs struct {
 // the different goroutines.
 type NumParallelInvocationsFunc func(ctx context.Context, numNodes int) int
 
-func (f NumParallelInvocationsFunc) apply(m *method) { m.ConcurrencyArgs.numParallelInvocationsFunc = f }
+func (f NumParallelInvocationsFunc) apply(m *method) {
+	m.ConcurrencyArgs.numParallelInvocationsFunc = f
+}
 
 type UseFallbackFlag func(context.Context) bool
 
 type batchArgs struct {
-	FallbackFunc          interface{}
+	FallbackFunc       interface{}
 	ShouldUseBatchFunc UseFallbackFlag
 }
 
 type manualPaginationArgs struct {
-	FallbackFunc          interface{}
+	FallbackFunc       interface{}
 	ShouldUseBatchFunc UseFallbackFlag
 }
 

--- a/graphql/testdata/TestConnection.snapshots.json
+++ b/graphql/testdata/TestConnection.snapshots.json
@@ -265,6 +265,55 @@
               "startCursor": "MQ=="
             },
             "totalCount": 3
+          },
+          "filterByCanAndCustomFilter": {
+            "edges": [
+              {
+                "cursor": "MQ==",
+                "node": {
+                  "__key": 1,
+                  "filterText": "can",
+                  "id": 1
+                }
+              },
+              {
+                "cursor": "Mw==",
+                "node": {
+                  "__key": 3,
+                  "filterText": "cannot",
+                  "id": 3
+                }
+              },
+              {
+                "cursor": "Ng==",
+                "node": {
+                  "__key": 6,
+                  "filterText": "crane",
+                  "id": 6
+                }
+              }
+            ],
+            "pageInfo": {
+              "endCursor": "Ng==",
+              "hasNextPage": false,
+              "hasPrevPage": false,
+              "pages": [
+                ""
+              ],
+              "startCursor": "MQ=="
+            },
+            "totalCount": 3
+          },
+          "filterByCanAndNonExistentFilterFunc": {
+            "edges": [],
+            "pageInfo": {
+              "endCursor": "",
+              "hasNextPage": false,
+              "hasPrevPage": false,
+              "pages": [],
+              "startCursor": ""
+            },
+            "totalCount": 0
           }
         }
       }

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -7,16 +7,16 @@ import (
 
 var matchGroups = regexp.MustCompile(`(?:([^\s"]+)|"([^"]*)"?)+`)
 
-func GetMatchStrings(query string) []string {
+func GetDefaultSearchTokens(query string) []string {
 	if query == "" {
 		return nil
 	}
 	matches := matchGroups.FindAllStringSubmatch(query, -1)
-	matchStrings := make([]string, 0, len(matches))
+	searchTokens := make([]string, 0, len(matches))
 	for _, match := range matches {
 		// Empty quotes can count as a match, ignore them.
 		if match[1] == "" && match[2] == "" {
-			matchStrings = append(matchStrings, "")
+			searchTokens = append(searchTokens, "")
 			continue
 		}
 		// Get relevant match (one of these has to be a non-empty string, otherwise this wouldn't be a match).
@@ -24,17 +24,17 @@ func GetMatchStrings(query string) []string {
 		if matchString == "" {
 			matchString = match[2]
 		}
-		// matchStrings[i] = matchString
-		matchStrings = append(matchStrings, matchString)
+		// searchTokens[i] = matchString
+		searchTokens = append(searchTokens, matchString)
 	}
-	return matchStrings
+	return searchTokens
 }
 
-func MatchText(str string, matchStrings []string) bool {
-	if len(matchStrings) == 0 {
+func DefaultFilterFunc(str string, searchTokens []string) bool {
+	if len(searchTokens) == 0 {
 		return true
 	}
-	for _, matchString := range matchStrings {
+	for _, matchString := range searchTokens {
 		if strings.Contains(strings.ToLower(str), strings.ToLower(matchString)) && matchString != "" {
 			return true
 		}

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMatch(t *testing.T) {
+func TestDefaultMatchText(t *testing.T) {
 	testcases := []struct {
 		String  string
 		Query   string
@@ -24,10 +24,10 @@ func TestMatch(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		matchStrings := filter.GetMatchStrings(tc.Query)
+		searchTokens := filter.GetDefaultSearchTokens(tc.Query)
 		assert.Equal(t,
 			tc.Matches,
-			filter.MatchText(tc.String, matchStrings),
+			filter.DefaultFilterFunc(tc.String, searchTokens),
 			"expected Match(`%s`, `%s`) to be %v", tc.String, tc.Query, tc.Matches,
 		)
 	}


### PR DESCRIPTION
**Problem**
The default algorithm we use for filtering/search do not work for all situations.

Right now, we tokenize the searchQuery (FilterText) by splitting the searchQuery by spaces.
Our search algorithm compares each search token to the item string (FilterTextField) and identifies a match it the search token is a substring of the item string.

This may work in some situations, but is not ideal for every situation.

For example, when searching for a list of names, the search query "Bob B" will return not only users with the first name "Bob", but everyone that has "B" in their name which makes the return result incredibly broad.


**Solution**
There will never be a universally best search algorithm -- it depends on the situation.

For that reason, it would be best to give users of Thunder control over which search tokenization and filter algorithm they would like to use for their FieldFunc.

This change introduces a new FieldFuncOption: `FilterFunc` which accepts:
* a name
* a search algorithm
*  search tokenization algorithm.

It also introduces a new PaginationArg: `FilterType`
This will allow developers to specify a "filterType" in their GraphQL query which will correspond to the "name" passed to the FieldFuncOption `FilterFunc`
