### PR TITLE
graphql/schemabuilder/schema: enforce unique type names

### DIFF
--- a/graphql/schemabuilder/reflect_test.go
+++ b/graphql/schemabuilder/reflect_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/graphql"
-	"github.com/samsarahq/thunder/graphql/schemabuilder/testpackage"
 	"github.com/samsarahq/thunder/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -681,19 +680,6 @@ func TestBadArguments(t *testing.T) {
 	if _, err := schema.Build(); err.Error() != "bad method aField on type schemabuilder.query: attempted to parse int64 as arguments struct, but failed: expected struct but received type int64" {
 		t.Errorf("expected non-struct args argument to fail, but received %s", err.Error())
 	}
-}
-
-func TestTypeNamesMustBeUnique(t *testing.T) {
-	type Object struct {
-		Something string
-	}
-	builder := NewSchema()
-	builder.Query().FieldFunc("object1", func(ctx context.Context) *Object { return nil })
-	// Put other Object type in a separate package to induce name collision.
-	builder.Query().FieldFunc("object2", func(ctx context.Context) *testpackage.Object { return nil })
-	_, err := builder.Build()
-	assert.Error(t, err, "cannot have duplicate object names")
-	assert.Contains(t, err.Error(), "duplicate name")
 }
 
 func TestObjectKeyMustBeScalar(t *testing.T) {

--- a/graphql/schemabuilder/schema_test.go
+++ b/graphql/schemabuilder/schema_test.go
@@ -1,0 +1,274 @@
+package schemabuilder_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samsarahq/thunder/batch"
+	"github.com/samsarahq/thunder/graphql/schemabuilder"
+	"github.com/samsarahq/thunder/graphql/schemabuilder/testdata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuplicateEnumNamesFailSchema(t *testing.T) {
+	schema := schemabuilder.NewSchema()
+
+	type DupedEnumType int32
+	var dupeEnum1 DupedEnumType
+	schema.Enum(dupeEnum1, map[string]DupedEnumType{
+		"three": DupedEnumType(3),
+		"two":   DupedEnumType(2),
+		"one":   DupedEnumType(1),
+	})
+
+	var dupeEnum2 testdata.DupedEnumType
+	schema.Enum(dupeEnum2, map[string]testdata.DupedEnumType{
+		"four": testdata.DupedEnumType(4),
+		"five": testdata.DupedEnumType(5),
+		"six":  testdata.DupedEnumType(6),
+	})
+
+	_, err := schema.Build()
+	require.Error(t, err)
+
+	errStr := err.Error()
+	require.Contains(t, errStr, "type name is duplicated")
+	require.Contains(t, errStr, "DupedEnumType")
+	require.Contains(t, errStr, "github.com/samsarahq/thunder/graphql/schemabuilder_test")
+	require.Contains(t, errStr, "github.com/samsarahq/thunder/graphql/schemabuilder/testdata")
+}
+
+type User struct {
+	Id int
+}
+
+func TestDuplicateScalarTypeNames(t *testing.T) {
+	type DupedScalarType string
+	type Wrapper struct {
+		Val DupedScalarType
+	}
+
+	{
+		dupedSchema := schemabuilder.NewSchema()
+		query := dupedSchema.Query()
+		query.FieldFunc("getScalar", func() DupedScalarType { return "" })
+		query.FieldFunc("getOtherScalar", func() []*testdata.DupedScalarType { return nil })
+
+		// Duplicate scalar type alias names are ok because
+		// they are converted to their underlying scalar type.
+		dupedSchema.MustBuild()
+	}
+
+	{
+		dupedStructFieldSchema := schemabuilder.NewSchema()
+		query := dupedStructFieldSchema.Query()
+
+		query.FieldFunc("getScalarFieldWithScalarFieldArg",
+			func(ctx context.Context, arg struct {
+				Scalars []testdata.DupedScalarType
+			}) Wrapper {
+				return Wrapper{}
+			})
+
+		// Duplicate scalar type alias names in struct fields are ok because
+		// they are converted to their underlying scalar type.
+		dupedStructFieldSchema.MustBuild()
+	}
+
+	{
+		dupedBatchSchema := schemabuilder.NewSchema()
+		dupedBatchSchema.Query().FieldFunc("rootUser", func() User {
+			return User{}
+		})
+
+		user := dupedBatchSchema.Object("user", User{})
+		user.BatchFieldFunc("getDupedScalarBatch",
+			func(ctx context.Context, batch map[batch.Index]User) map[batch.Index]DupedScalarType {
+				return nil
+			})
+		user.BatchFieldFunc("getOtherDupedScalarBatch",
+			func(ctx context.Context, batch map[batch.Index]User) map[batch.Index]testdata.DupedScalarType {
+				return nil
+			})
+
+		// Duplicate scalar type alias names in batch return types are ok because
+		// they are converted to their underlying scalar type.
+		dupedBatchSchema.MustBuild()
+	}
+}
+
+func TestDuplicateStructTypeNamesFailSchema(t *testing.T) {
+	type DupedStructType struct {
+		OtherField string
+	}
+	type Wrapper struct {
+		Val DupedStructType
+	}
+
+	{
+		dupedSchema := schemabuilder.NewSchema()
+		query := dupedSchema.Query()
+		query.FieldFunc("popularity", func(arg DupedStructType) []*testdata.DupedStructType { return nil })
+
+		_, err := dupedSchema.Build()
+		require.Error(t, err)
+
+		errStr := err.Error()
+		assert.Contains(t, errStr, "type name is duplicated")
+		assert.Contains(t, errStr, "DupedStructType")
+		assert.Contains(t, errStr, "github.com/samsarahq/thunder/graphql/schemabuilder_test")
+		assert.Contains(t, errStr, "github.com/samsarahq/thunder/graphql/schemabuilder/testdata")
+	}
+
+	{
+		dupedStructFieldSchema := schemabuilder.NewSchema()
+		query := dupedStructFieldSchema.Query()
+		query.FieldFunc("getDataWithArgs", func(ctx context.Context, arg struct {
+			Struct []*testdata.DupedStructType
+		}) Wrapper {
+			return Wrapper{}
+		})
+
+		_, err := dupedStructFieldSchema.Build()
+		require.Error(t, err)
+
+		errStr := err.Error()
+		assert.Contains(t, errStr, "type name is duplicated")
+		assert.Contains(t, errStr, "DupedStructType")
+		assert.Contains(t, errStr, "github.com/samsarahq/thunder/graphql/schemabuilder_test")
+		assert.Contains(t, errStr, "github.com/samsarahq/thunder/graphql/schemabuilder/testdata")
+	}
+
+	{
+		dupedBatchReturnSchema := schemabuilder.NewSchema()
+		dupedBatchReturnSchema.Query().FieldFunc("rootUser", func() User { return User{} })
+
+		user := dupedBatchReturnSchema.Object("user", User{})
+		user.BatchFieldFunc("getDupedStructBatch",
+			func(ctx context.Context, batch map[batch.Index]User) map[batch.Index]DupedStructType {
+				return nil
+			})
+		user.BatchFieldFunc("getOtherDupedStructBatch",
+			func(ctx context.Context, batch map[batch.Index]User) map[batch.Index]*testdata.DupedStructType {
+				return nil
+			})
+
+		_, err := dupedBatchReturnSchema.Build()
+		require.Error(t, err)
+
+		errStr := err.Error()
+		assert.Contains(t, errStr, "type name is duplicated")
+		assert.Contains(t, errStr, "DupedStructType")
+		assert.Contains(t, errStr, "github.com/samsarahq/thunder/graphql/schemabuilder_test")
+		assert.Contains(t, errStr, "github.com/samsarahq/thunder/graphql/schemabuilder/testdata")
+	}
+
+	{
+		dupedBatchArgSchema := schemabuilder.NewSchema()
+		dupedBatchArgSchema.Query().FieldFunc("rootStruct", func() DupedStructType {
+			return DupedStructType{}
+		})
+		dupedBatchArgSchema.Query().FieldFunc("rootOtherStruct", func() testdata.DupedStructType {
+			return testdata.DupedStructType{}
+		})
+
+		structType := dupedBatchArgSchema.Object("structType", DupedStructType{})
+		structType.BatchFieldFunc("processDupedStructBatch",
+			func(ctx context.Context, batch map[batch.Index]DupedStructType) map[batch.Index]int {
+				return nil
+			})
+
+		otherStructType := dupedBatchArgSchema.Object("otherStructType", testdata.DupedStructType{})
+		otherStructType.BatchFieldFunc("processOtherDupedStructBatch",
+			func(ctx context.Context, batch map[batch.Index]*testdata.DupedStructType) map[batch.Index]int {
+				return nil
+			})
+
+		_, err := dupedBatchArgSchema.Build()
+		require.Error(t, err)
+
+		errStr := err.Error()
+		assert.Contains(t, errStr, "type name is duplicated")
+		assert.Contains(t, errStr, "DupedStructType")
+		assert.Contains(t, errStr, "github.com/samsarahq/thunder/graphql/schemabuilder_test")
+		assert.Contains(t, errStr, "github.com/samsarahq/thunder/graphql/schemabuilder/testdata")
+	}
+}
+
+func TestDuplicateTypeNamesOfDifferentKinds(t *testing.T) {
+	{
+		dupedStructAndEnumSchema := schemabuilder.NewSchema()
+
+		type Foo int32
+		var foo Foo
+		dupedStructAndEnumSchema.Enum(foo, map[string]Foo{
+			"three": Foo(3),
+			"two":   Foo(2),
+			"one":   Foo(1),
+		})
+
+		query := dupedStructAndEnumSchema.Query()
+		query.FieldFunc("foo", func(arg struct{ Foo []*testdata.Foo }) Foo { return 1 })
+
+		_, err := dupedStructAndEnumSchema.Build()
+		require.Error(t, err)
+
+		errStr := err.Error()
+		assert.Contains(t, errStr, "type name is duplicated")
+		assert.Contains(t, errStr, "Foo")
+		assert.Contains(t, errStr, "github.com/samsarahq/thunder/graphql/schemabuilder_test")
+		assert.Contains(t, errStr, "github.com/samsarahq/thunder/graphql/schemabuilder/testdata")
+	}
+
+	{
+		dupedEnumAndScalarSchema := schemabuilder.NewSchema()
+
+		type Bar int32
+		var bar Bar
+		dupedEnumAndScalarSchema.Enum(bar, map[string]Bar{
+			"three": Bar(3),
+			"two":   Bar(2),
+			"one":   Bar(1),
+		})
+
+		query := dupedEnumAndScalarSchema.Query()
+		query.FieldFunc("bar", func(arg struct {
+			bar Bar
+		}) []*testdata.Bar {
+			return nil
+		})
+
+		// int32 Bar type is converted to int32 so there is no conflict with enum type Bar.
+		_, err := dupedEnumAndScalarSchema.Build()
+		require.NoError(t, err)
+	}
+
+	{
+		dupedStructAndScalarSchema := schemabuilder.NewSchema()
+
+		type Foo int32
+
+		query := dupedStructAndScalarSchema.Query()
+		query.FieldFunc("foo", func(arg struct{ Foo []*testdata.Foo }) Foo { return 1 })
+
+		// int32 Foo type is converted to int32 so there is no conflict with struct type Foo.
+		_, err := dupedStructAndScalarSchema.Build()
+		require.NoError(t, err)
+	}
+}
+
+func TestRecursiveType(t *testing.T) {
+	schema := schemabuilder.NewSchema()
+
+	type Tree struct {
+		Name     string
+		Children []*Tree
+	}
+
+	schema.Query().FieldFunc("tree", func(ctx context.Context, tree Tree) int {
+		return 0
+	})
+
+	schema.MustBuild()
+}

--- a/graphql/schemabuilder/testdata/duplicatetypes.go
+++ b/graphql/schemabuilder/testdata/duplicatetypes.go
@@ -1,0 +1,12 @@
+package testdata
+
+type DupedEnumType int32
+
+type DupedScalarType int32
+
+type DupedStructType struct {
+	OtherField int64
+}
+
+type Foo struct{}
+type Bar string

--- a/graphql/schemabuilder/testpackage/types.go
+++ b/graphql/schemabuilder/testpackage/types.go
@@ -1,5 +1,0 @@
-package testpackage
-
-type Object struct {
-	SomethingElse string
-}


### PR DESCRIPTION
Introspection assumes that each type in the schema is unique.
Note that package names are not considered when comparing type names.
In other words, foo_package.SomeType and bar_package.SomeType
are considered to have the same name.

This causes issues with the type resolution as only one type
of each name can exist in the schema. For example, one might
define 2 fieldfuncs, one returning foo_package.SomeType and
another returning bar_package.SomeType. The introspection
query will incorrectly declare that both fieldfuncs return
the same type: one of foo_package.SomeType or bar_package.SomeType.

In order to avoid type collisions, we will fail to build the
schema if we detect duplicate types in the GraphQL schema.

We iterate over every object's registered fieldfuncs,
recursing through each fieldfunc's argument and return types to
collect a set of types. Then, we compare these types to the
set of enum types.

Note that there is an existing type name uniqueness check in
getType. However, this only checks return types and does not
correctly compare slice or pointer types. For example,
registering both foo_package.SomeType and []*bar_package.SomeType
will not throw an error. The test for the existing check has been
removed in favor of the new tests introduced in this commit.