### PR TITLE
internal/fields: Use sql.NullTime instead of mysql.NullTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 #### `sqlgen`
 - Implemented a basic `(*sqlgen.DB).Count` receiver that wraps `SELECT COUNT(*)` functionality in SQL databases. ([#230](https://github.com/samsarahq/thunder/pull/230))
-
+- Use go standard library implementation of sql.NullTime over mysql.NullTime
 
 ## [0.5.0] 2019-01-10
 

--- a/internal/fields/sql.go
+++ b/internal/fields/sql.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/go-sql-driver/mysql"
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -228,7 +228,7 @@ func (s *Scanner) Scan(src interface{}) error {
 			return nil
 		}
 	case *time.Time:
-		t := mysql.NullTime{}
+		t := sql.NullTime{}
 		if err := t.Scan(src); err != nil {
 			return err
 		}


### PR DESCRIPTION
In go1.13, the standard library added sql.NullTime. We're switching to
the new implementation to keep the library up to date and prevent
potential deprecation of NullTime in the go-sql-driver package. It's
worth noting that go-sql-driver1.6 already deprecates mysql.NullTime and
is using sql.NullTime under the hood.