### PR TITLE
go executor: move append inside mutex

### DIFF
--- a/federation/executor.go
+++ b/federation/executor.go
@@ -370,15 +370,16 @@ func (e *Executor) execute(ctx context.Context, isRootPlan bool, p *Plan, keys [
 			if err != nil {
 				return oops.Wrapf(err, "executing sub plan: %v", err)
 			}
+			
+			// Acquire mutex lock before modifying results
+			resMu.Lock()
+			defer resMu.Unlock()
 			optionalRespMetadata = append(optionalRespMetadata, subQueryRespMetadata...)
 
 			if len(executionResults) != len(subPlanMetaData.results) {
 				return fmt.Errorf("got %d results for %d targets", len(executionResults), len(subPlanMetaData.results))
 			}
 
-			// Acquire mutex lock before modifying results
-			resMu.Lock()
-			defer resMu.Unlock()
 			for i, result := range subPlanMetaData.results {
 				executionResult, ok := executionResults[i].(map[string]interface{})
 				if !ok {


### PR DESCRIPTION
go append is not thread safe, so we should put it inside the mutex