### PR TITLE
go batch: marshaling index as a number

### DIFF
--- a/batch/index.go
+++ b/batch/index.go
@@ -16,14 +16,10 @@ func NewIndex(key int) Index {
 	return Index{key: key}
 }
 
-// Create another type for Index so that MarshalText and UnmarshalText
-// don't run into recursion issues.
-type index Index
-
 func (i Index) MarshalText() (text []byte, err error) {
-	return json.Marshal(index(i))
+	return json.Marshal(i.key)
 }
 
 func (i *Index) UnmarshalText(text []byte) error {
-	return json.Unmarshal(text, (*index)(i))
+	return json.Unmarshal(text, &i.key)
 }


### PR DESCRIPTION
The index struct is currently marshaling to/from "{}", which makes it hard to add diagnostic logging to code that uses it.

This change marshals the index using its internal key; for example:
```
index1 := batch.NewIndex(1)
index2 := batch.NewIndex(2)
data := map[batch.Index]string {
  index1: "foo",
  index2: "bar",
}

json, _ := json.Marshal(data)

// json before change
{
  "{}": "foo",
  "{}": "bar"
}

// json after change
{
  1: "foo",
  2: "bar"
}
```