### PR TITLE
Weilian/federation introspection client

### DIFF
--- a/federation/executor_test.go
+++ b/federation/executor_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/samsarahq/thunder/batch"
 	"github.com/samsarahq/thunder/graphql"
+	"github.com/samsarahq/thunder/graphql/introspection"
 	"github.com/samsarahq/thunder/graphql/schemabuilder"
 
 	"github.com/stretchr/testify/assert"
@@ -1944,6 +1945,46 @@ func TestExecutorQueriesWithDirectives(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFederatedIntrospectionQuery(t *testing.T) {
+	e, s1, s2, s3, err := createExecutorWithFederatedUser()
+	require.NoError(t, err)
+
+	// Reconstruct the expected introspection query result manually.
+	schemaVersions := make(map[string]map[string]*IntrospectionQueryResult, 3)
+	for i, s := range []*schemabuilder.Schema{s1, s2, s3} {
+		iqBytes, err := introspection.ComputeSchemaJSON(*s)
+		require.NoError(t, err)
+		var iq IntrospectionQueryResult
+		require.NoError(t, json.Unmarshal(iqBytes, &iq))
+		schemaVersions[fmt.Sprintf("%d", i)] = map[string]*IntrospectionQueryResult{
+			"": &iq,
+		}
+	}
+
+	convertedSchema, err := ConvertVersionedSchemas(schemaVersions)
+	require.NoError(t, err)
+
+	schema := introspection.BareIntrospectionSchema(convertedSchema.Schema)
+	schemaBytes, err := introspection.RunIntrospectionQuery(introspection.BareIntrospectionSchema(schema))
+	require.NoError(t, err)
+
+	var expectedIqRes IntrospectionQueryResult
+	require.NoError(t, json.Unmarshal(schemaBytes, &expectedIqRes))
+
+	// Run introspection query, expect the result to match.
+	ctx := context.Background()
+	res, _, err := e.Execute(ctx, graphql.MustParse(introspection.IntrospectionQuery, nil), nil)
+	require.NoError(t, err)
+
+	byts, err := json.Marshal(res)
+	require.NoError(t, err)
+
+	var actualIqRes IntrospectionQueryResult
+	require.NoError(t, json.Unmarshal(byts, &actualIqRes))
+
+	assert.Equal(t, expectedIqRes, actualIqRes)
 }
 
 func TestExecutorQueriesWithDirectivesWithVariables(t *testing.T) {

--- a/federation/introspection_client.go
+++ b/federation/introspection_client.go
@@ -1,0 +1,58 @@
+package federation
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/samsarahq/thunder/graphql/introspection"
+	"github.com/samsarahq/thunder/graphql/schemabuilder"
+)
+
+const IntrospectionClientName = "introspectionclient"
+
+type IntrospectionClient struct {
+	IntrospectionQueryResult []byte
+}
+
+func NewIntrospectionClient(res []byte) *IntrospectionClient {
+	return &IntrospectionClient{
+		IntrospectionQueryResult: res,
+	}
+}
+
+func (c *IntrospectionClient) Execute(ctx context.Context, request *QueryRequest) (*QueryResponse, error) {
+	return &QueryResponse{
+		Result: c.IntrospectionQueryResult,
+	}, nil
+}
+
+// AddIntrospectionQueryToSchemaVersions will take in a map of service name to schema version
+// to introspection query result, and append to it with another service called "introspectionclient"
+// that is capable of only serving introspection queries. This will allow the federation executor to
+// directly serve introspection queries via its built-in introspection client rather than relay its
+// query to a subservice.
+func AddIntrospectionQueryToSchemaVersions(schemas map[string]map[string]*IntrospectionQueryResult) (map[string]map[string]*IntrospectionQueryResult, error) {
+	schema := schemabuilder.NewSchemaWithName("introspectionclient")
+	schema.Query()
+	schema.Mutation()
+
+	gqlSchema := schema.MustBuild()
+	introspection.AddIntrospectionToSchema(gqlSchema)
+
+	res, err := introspection.RunIntrospectionQuery(introspection.BareIntrospectionSchema(gqlSchema))
+	if err != nil {
+		return nil, err
+	}
+
+	var introspectionClientSchema IntrospectionQueryResult
+	if err := json.Unmarshal(res, &introspectionClientSchema); err != nil {
+		return nil, err
+	}
+
+	schemas[IntrospectionClientName] = make(map[string]*IntrospectionQueryResult)
+	schemas[IntrospectionClientName][""] = &introspectionClientSchema
+
+	return schemas, nil
+}
+
+var _ ExecutorClient = &IntrospectionClient{}

--- a/federation/introspection_client_test.go
+++ b/federation/introspection_client_test.go
@@ -1,0 +1,56 @@
+package federation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/samsarahq/go/snapshotter"
+	"github.com/samsarahq/thunder/graphql/introspection"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddIntrospectionQueryToSchemaVersions(t *testing.T) {
+	schema1 := buildTestSchema1()
+	schema1Bytes, err := introspection.ComputeSchemaJSON(*schema1)
+	assert.Nil(t, err)
+	var iq1 IntrospectionQueryResult
+	assert.Nil(t, json.Unmarshal(schema1Bytes, &iq1))
+
+	schema2 := buildTestSchema2()
+	schema2Bytes, err := introspection.ComputeSchemaJSON(*schema2)
+	assert.Nil(t, err)
+	var iq2 IntrospectionQueryResult
+	assert.Nil(t, json.Unmarshal(schema2Bytes, &iq2))
+
+	schemaVersions := map[string]map[string]*IntrospectionQueryResult{
+		"service1": {
+			"": &iq1,
+		},
+		"service2": {
+			"": &iq2,
+		},
+	}
+
+	schemaVersionsWithIntrospection, err := AddIntrospectionQueryToSchemaVersions(schemaVersions)
+	assert.Nil(t, err)
+
+	assert.Equal(t, schemaVersions["service1"], schemaVersionsWithIntrospection["service1"])
+	assert.Equal(t, schemaVersions["service2"], schemaVersionsWithIntrospection["service2"])
+
+	introspectionSchema := schemaVersionsWithIntrospection[IntrospectionClientName][""]
+	assert.NotNil(t, introspectionSchema)
+
+	var containsSchemaField bool
+	for _, typ := range introspectionSchema.Schema.Types {
+		if typ.Name == "__Schema" {
+			containsSchemaField = true
+			break
+		}
+	}
+	assert.True(t, containsSchemaField)
+
+	snapshotter := snapshotter.New(t)
+	defer snapshotter.Verify()
+
+	snapshotter.Snapshot("schema with introspection query", introspectionSchema.Schema)
+}

--- a/federation/schema_syncer.go
+++ b/federation/schema_syncer.go
@@ -11,7 +11,7 @@ import (
 // SchemaSyncer has a function that checks if the schema has changed,
 // and if so updates the planner in the federated executor
 type SchemaSyncer interface {
-	FetchPlanner(ctx context.Context) (*Planner, error)
+	FetchPlannerAndIntrospectionQueryResult(ctx context.Context) (*Planner, []byte, error)
 }
 type IntrospectionSchemaSyncer struct {
 	executors     map[string]ExecutorClient
@@ -27,17 +27,17 @@ func NewIntrospectionSchemaSyncer(ctx context.Context, executors map[string]Exec
 	return ss
 }
 
-func (s *IntrospectionSchemaSyncer) FetchPlanner(ctx context.Context) (*Planner, error) {
+func (s *IntrospectionSchemaSyncer) FetchPlannerAndIntrospectionQueryResult(ctx context.Context) (*Planner, []byte, error) {
 	schemas := make(map[string]*IntrospectionQueryResult)
 	for server, client := range s.executors {
 		resp, err := fetchSchema(ctx, client, s.queryMetadata)
 		if err != nil {
-			return nil, oops.Wrapf(err, "fetching schema %s", server)
+			return nil, nil, oops.Wrapf(err, "fetching schema %s", server)
 		}
 		schema := resp.Result
 		var iq IntrospectionQueryResult
 		if err := json.Unmarshal(schema, &iq); err != nil {
-			return nil, oops.Wrapf(err, "unmarshaling schema %s", server)
+			return nil, nil, oops.Wrapf(err, "unmarshaling schema %s", server)
 		}
 
 		schemas[server] = &iq
@@ -45,25 +45,31 @@ func (s *IntrospectionSchemaSyncer) FetchPlanner(ctx context.Context) (*Planner,
 
 	types, err := convertSchema(schemas)
 	if err != nil {
-		return nil, oops.Wrapf(err, "converting schemas error")
+		return nil, nil, oops.Wrapf(err, "converting schemas error")
 	}
 
 	introspectionSchema := introspection.BareIntrospectionSchema(types.Schema)
 	schema, err := introspection.RunIntrospectionQuery(introspection.BareIntrospectionSchema(introspectionSchema))
 	if err != nil || schema == nil {
-		return nil, oops.Wrapf(err, "error running introspection query")
+		return nil, nil, oops.Wrapf(err, "error running introspection query")
 	}
 
 	var iq IntrospectionQueryResult
 	if err := json.Unmarshal(schema, &iq); err != nil {
-		return nil, oops.Wrapf(err, "unmarshaling introspection schema")
+		return nil, nil, oops.Wrapf(err, "unmarshaling introspection schema")
 	}
 
-	schemas["introspection"] = &iq
+	schemas[IntrospectionClientName] = &iq
+
 	types, err = convertSchema(schemas)
 	if err != nil {
-		return nil, oops.Wrapf(err, "converting schemas error")
+		return nil, nil, oops.Wrapf(err, "converting schemas error")
 	}
 
-	return NewPlanner(types, nil)
+	planner, err := NewPlanner(types, nil)
+	if err != nil {
+		return nil, nil, oops.Wrapf(err, "creating planner")
+	}
+
+	return planner, schema, nil
 }

--- a/federation/testdata/TestAddIntrospectionQueryToSchemaVersions.snapshots.json
+++ b/federation/testdata/TestAddIntrospectionQueryToSchemaVersions.snapshots.json
@@ -1,0 +1,821 @@
+[
+  {
+    "Name": "schema with introspection query",
+    "Values": [
+      {
+        "directives": [
+          {
+            "args": [
+              {
+                "defaultValue": null,
+                "description": "Included when true.",
+                "name": "if",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "bool",
+                    "ofType": null
+                  }
+                }
+              }
+            ],
+            "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+            "locations": [
+              "FIELD",
+              "FRAGMENT_SPREAD",
+              "INLINE_FRAGMENT"
+            ],
+            "name": "include"
+          },
+          {
+            "args": [
+              {
+                "defaultValue": null,
+                "description": "Skipped when true.",
+                "name": "if",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "bool",
+                    "ofType": null
+                  }
+                }
+              }
+            ],
+            "description": "Directs the executor to skip this field or fragment only when the `if` argument is true.",
+            "locations": [
+              "FIELD",
+              "FRAGMENT_SPREAD",
+              "INLINE_FRAGMENT"
+            ],
+            "name": "skip"
+          },
+          {
+            "args": [],
+            "description": "Client-side-only directive that instructs the type generator to mark this field as optional. This is useful for making the generated types compliant with Troy persistence schema.",
+            "locations": [
+              "FIELD"
+            ],
+            "name": "type_as_optional"
+          }
+        ],
+        "mutationType": {
+          "description": "",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "",
+          "name": "Mutation",
+          "possibleTypes": null
+        },
+        "queryType": {
+          "description": "",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "",
+          "name": "Query",
+          "possibleTypes": null
+        },
+        "types": [
+          {
+            "description": "",
+            "enumValues": [],
+            "fields": [],
+            "inputFields": [],
+            "interfaces": [],
+            "kind": "OBJECT",
+            "name": "Mutation",
+            "possibleTypes": []
+          },
+          {
+            "description": "",
+            "enumValues": [],
+            "fields": [
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "__schema",
+                "type": {
+                  "kind": "OBJECT",
+                  "name": "__Schema",
+                  "ofType": null
+                }
+              },
+              {
+                "args": [
+                  {
+                    "name": "name",
+                    "type": {
+                      "kind": "NON_NULL",
+                      "name": "",
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "string",
+                        "ofType": null
+                      }
+                    }
+                  }
+                ],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "__type",
+                "type": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              }
+            ],
+            "inputFields": [],
+            "interfaces": [],
+            "kind": "OBJECT",
+            "name": "Query",
+            "possibleTypes": []
+          },
+          {
+            "description": "",
+            "enumValues": [],
+            "fields": [
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": "",
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": "",
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "__InputValue",
+                        "ofType": null
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "description",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "locations",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": "",
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": "",
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "string",
+                        "ofType": null
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "name",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                }
+              }
+            ],
+            "inputFields": [],
+            "interfaces": [],
+            "kind": "OBJECT",
+            "name": "__Directive",
+            "possibleTypes": []
+          },
+          {
+            "description": "",
+            "enumValues": [],
+            "fields": [
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "deprecationReason",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "description",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "isDeprecated",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "bool",
+                    "ofType": null
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "name",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                }
+              }
+            ],
+            "inputFields": [],
+            "interfaces": [],
+            "kind": "OBJECT",
+            "name": "__EnumValue",
+            "possibleTypes": []
+          },
+          {
+            "description": "",
+            "enumValues": [],
+            "fields": [
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "args",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": "",
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": "",
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "__InputValue",
+                        "ofType": null
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "deprecationReason",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "description",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "isDeprecated",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "bool",
+                    "ofType": null
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "name",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "type",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              }
+            ],
+            "inputFields": [],
+            "interfaces": [],
+            "kind": "OBJECT",
+            "name": "__Field",
+            "possibleTypes": []
+          },
+          {
+            "description": "",
+            "enumValues": [],
+            "fields": [
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "defaultValue",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "string",
+                  "ofType": null
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "description",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "name",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "type",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              }
+            ],
+            "inputFields": [],
+            "interfaces": [],
+            "kind": "OBJECT",
+            "name": "__InputValue",
+            "possibleTypes": []
+          },
+          {
+            "description": "",
+            "enumValues": [],
+            "fields": [
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "directives",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": "",
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": "",
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "__Directive",
+                        "ofType": null
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "mutationType",
+                "type": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "queryType",
+                "type": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "subscriptionType",
+                "type": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "types",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": "",
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": "",
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "__Type",
+                        "ofType": null
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "inputFields": [],
+            "interfaces": [],
+            "kind": "OBJECT",
+            "name": "__Schema",
+            "possibleTypes": []
+          },
+          {
+            "description": "",
+            "enumValues": [],
+            "fields": [
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "description",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                }
+              },
+              {
+                "args": [
+                  {
+                    "name": "includeDeprecated",
+                    "type": {
+                      "kind": "SCALAR",
+                      "name": "bool",
+                      "ofType": null
+                    }
+                  }
+                ],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "enumValues",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": "",
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": "",
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "__EnumValue",
+                        "ofType": null
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "args": [
+                  {
+                    "name": "includeDeprecated",
+                    "type": {
+                      "kind": "SCALAR",
+                      "name": "bool",
+                      "ofType": null
+                    }
+                  }
+                ],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "fields",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": "",
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": "",
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "__Field",
+                        "ofType": null
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "inputFields",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": "",
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": "",
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "__InputValue",
+                        "ofType": null
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "interfaces",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": "",
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": "",
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "__Type",
+                        "ofType": null
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "kind",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "string",
+                    "ofType": null
+                  }
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "name",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "string",
+                  "ofType": null
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "ofType",
+                "type": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              {
+                "args": [],
+                "deprecationReason": "",
+                "description": "",
+                "isDeprecated": false,
+                "name": "possibleTypes",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": "",
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": "",
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": "",
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "__Type",
+                        "ofType": null
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "inputFields": [],
+            "interfaces": [],
+            "kind": "OBJECT",
+            "name": "__Type",
+            "possibleTypes": []
+          },
+          {
+            "description": "",
+            "enumValues": [],
+            "fields": [],
+            "inputFields": [],
+            "interfaces": [],
+            "kind": "SCALAR",
+            "name": "bool",
+            "possibleTypes": []
+          },
+          {
+            "description": "",
+            "enumValues": [],
+            "fields": [],
+            "inputFields": [],
+            "interfaces": [],
+            "kind": "SCALAR",
+            "name": "string",
+            "possibleTypes": []
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR adds an introspection client to the federation executor. This introspection client runs at the gateway executor and will serve all introspection queries. 

After collecting all the schemas, the SchemaSyncer will combine all federated schemas, and run an introspection query on it, populating the result to the introspection client. This allows an introspection query to be served as if only one graphql schema is running.