### PR TITLE
Weilian/introspection client schema

### DIFF
--- a/federation/executor_test.go
+++ b/federation/executor_test.go
@@ -1963,11 +1963,14 @@ func TestFederatedIntrospectionQuery(t *testing.T) {
 		}
 	}
 
+	schemaVersions, err = AddIntrospectionQueryToSchemaVersions(schemaVersions)
+	require.NoError(t, err)
+
 	convertedSchema, err := ConvertVersionedSchemas(schemaVersions)
 	require.NoError(t, err)
 
 	schema := introspection.BareIntrospectionSchema(convertedSchema.Schema)
-	schemaBytes, err := introspection.RunIntrospectionQuery(introspection.BareIntrospectionSchema(schema))
+	schemaBytes, err := introspection.RunIntrospectionQuery(schema)
 	require.NoError(t, err)
 
 	var expectedIqRes IntrospectionQueryResult

--- a/federation/schema_syncer_test.go
+++ b/federation/schema_syncer_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/samsarahq/go/oops"
+	"github.com/samsarahq/thunder/graphql"
 	"github.com/samsarahq/thunder/graphql/introspection"
 	"github.com/samsarahq/thunder/graphql/schemabuilder"
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,7 @@ func newFileSchemaSyncer(ctx context.Context, services []string) *FileSchemaSync
 	return ss
 }
 
-func (s *FileSchemaSyncer) FetchPlannerAndIntrospectionQueryResult(ctx context.Context) (*Planner, []byte, error) {
+func (s *FileSchemaSyncer) FetchPlannerAndSchema(ctx context.Context) (*Planner, *graphql.Schema, error) {
 	schemas := make(map[string]*IntrospectionQueryResult)
 	for _, server := range s.services {
 		schema, err := readFile(server)
@@ -71,7 +72,7 @@ func (s *FileSchemaSyncer) FetchPlannerAndIntrospectionQueryResult(ctx context.C
 		return nil, nil, oops.Wrapf(err, "error ")
 	}
 
-	return planner, schema, nil
+	return planner, introspection.BareIntrospectionSchema(types.Schema), nil
 }
 
 // WriteToFile will print any string of text to a file safely by


### PR DESCRIPTION
This commit will supply the introspection client with the full introspection schema rather than justthe introspection query result.
This will allow the introspection schema to also serve custom queries with the introspective fields.