### PR TITLE
go federation: move introspection queries to its own client

### DIFF
--- a/graphql/introspection/introspection.go
+++ b/graphql/introspection/introspection.go
@@ -444,3 +444,17 @@ func RunIntrospectionQuery(schema *graphql.Schema) ([]byte, error) {
 
 	return json.MarshalIndent(value, "", "  ")
 }
+
+func IntrospectionQueryTypeOrSelection(typeName, selectionName string) bool {
+	if selectionName == "__schema" ||
+		typeName == "__Schema" ||
+		typeName == "__Directive" ||
+		typeName == "__InputValue" ||
+		typeName == "__Type" ||
+		typeName == "__EnumValue" ||
+		typeName == "__Field" {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
This commit adds a helper func that will help the planner determine whether or not the selection is part of an introspection query. If so, this field will be routed to be resolved by the introspection client.