### PR TITLE
go schemabuilder: apply object options even if object is already regi…

### DIFF
--- a/graphql/schemabuilder/schema.go
+++ b/graphql/schemabuilder/schema.go
@@ -56,19 +56,21 @@ func NewSchemaWithName(name string) *Schema {
 // the corresponding map of the enums.
 //
 // For example a enum could be declared as follows:
-//   type enumType int32
-//   const (
-//	  one   enumType = 1
-//	  two   enumType = 2
-//	  three enumType = 3
-//   )
+//
+//	  type enumType int32
+//	  const (
+//		  one   enumType = 1
+//		  two   enumType = 2
+//		  three enumType = 3
+//	  )
 //
 // Then the Enum can be registered as:
-//   s.Enum(enumType(1), map[string]interface{}{
-//     "one":   enumType(1),
-//     "two":   enumType(2),
-//     "three": enumType(3),
-//   })
+//
+//	s.Enum(enumType(1), map[string]interface{}{
+//	  "one":   enumType(1),
+//	  "two":   enumType(2),
+//	  "three": enumType(3),
+//	})
 func (s *Schema) Enum(val interface{}, enumMap interface{}) {
 	typ := reflect.TypeOf(val)
 	if s.enumTypes == nil {
@@ -169,6 +171,10 @@ func (s *Schema) Object(name string, typ interface{}, options ...ObjectOption) *
 		if reflect.TypeOf(object.Type) != reflect.TypeOf(typ) {
 			panic("re-registered object with different type")
 		}
+		for _, opt := range options {
+			opt.apply(s, object)
+		}
+
 		return object
 	}
 	object := &Object{


### PR DESCRIPTION
Currently, when we define an object more than once within a single gql schema, we will ignore any options defined after the first registration (which is pseudo-randomly determined when the schema is built). We want to be able to apply options for every time we register an object, so we can have some regulations on object option code.

Currently, the only use for object options are for federation, where we use it to define a FetchObjectFromKeys method. Ignoring options on repeat registrations means a lot of code gets dropped. We want to ensure that FetchObjectFromKeys only gets defined once per gql server.